### PR TITLE
[FEAT] Kind 멀티노드 클러스터 및 ArgoCD/Istio infrastructure Helm 설정 (#2, #3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Goti 티켓팅 서비스의 Kubernetes GitOps 레포지토리.
 
 ## 전제조건
 
-- [Kind](https://kind.sigs.k8s.io/) v0.20+
-- [kubectl](https://kubernetes.io/docs/tasks/tools/) v1.28+
-- [Helm](https://helm.sh/) v3.12+
+- [Kind](https://kind.sigs.k8s.io/) v0.31+
+- [kubectl](https://kubernetes.io/docs/tasks/tools/) v1.33+
+- [Helm](https://helm.sh/) v3.14+
 - Docker Desktop 또는 Docker Engine
 
 ## 빠른 시작
@@ -29,7 +29,7 @@ make down
 
 | 서비스 | URL | 비고 |
 |--------|-----|------|
-| ArgoCD | https://localhost:30080 | admin / (초기 비밀번호) |
+| ArgoCD | http://localhost:30080 | admin / (초기 비밀번호) |
 | Grafana | http://localhost:3000 | admin / admin |
 | Prometheus | http://localhost:9090 | - |
 | goti-server | http://localhost:8080 | port-forward 필요 |

--- a/README.md
+++ b/README.md
@@ -1,1 +1,121 @@
 # Goti-k8s
+
+Goti 티켓팅 서비스의 Kubernetes GitOps 레포지토리.
+
+## 전제조건
+
+- [Kind](https://kind.sigs.k8s.io/) v0.20+
+- [kubectl](https://kubernetes.io/docs/tasks/tools/) v1.28+
+- [Helm](https://helm.sh/) v3.12+
+- Docker Desktop 또는 Docker Engine
+
+## 빠른 시작
+
+```bash
+# 1. 클러스터 생성 + 전체 스택 설치 (원커맨드)
+make up
+
+# 2. 포트포워딩 (Grafana, Prometheus, goti-server)
+make port-forward
+
+# 3. 상태 확인
+make status
+
+# 4. 클러스터 삭제
+make down
+```
+
+## 접속 정보 (dev-kind)
+
+| 서비스 | URL | 비고 |
+|--------|-----|------|
+| ArgoCD | https://localhost:30080 | admin / (초기 비밀번호) |
+| Grafana | http://localhost:3000 | admin / admin |
+| Prometheus | http://localhost:9090 | - |
+| goti-server | http://localhost:8080 | port-forward 필요 |
+| Istio Gateway | http://localhost:31080 | - |
+
+## 디렉토리 구조
+
+```
+Goti-k8s/
+├── .github/                    # 이슈/PR 템플릿
+├── kind/                       # Kind 클러스터 설정
+│   └── cluster-config.yaml
+├── infrastructure/             # 인프라 Helm 래퍼
+│   ├── argocd/
+│   └── istio/                  # Istio 서비스 메시
+│       ├── base/               # CRDs
+│       ├── istiod/             # Control Plane
+│       └── gateway/            # Ingress Gateway
+├── charts/                     # Helm Charts
+│   ├── goti-common/            # Library Chart (공통 템플릿)
+│   └── goti-server/            # Application Chart
+├── environments/               # 환경별 values
+│   └── dev/
+│       ├── goti-server/
+│       └── monitoring/
+├── gitops/                     # ArgoCD 리소스
+│   ├── projects/               # AppProject
+│   └── applicationsets/        # ApplicationSet
+├── clusters/                   # 클러스터별 부트스트랩
+│   └── dev/bootstrap/
+├── scripts/                    # 자동화 스크립트
+├── Makefile
+└── README.md
+```
+
+## 아키텍처
+
+- **GitOps**: ArgoCD ApplicationSet (하이브리드 패턴)
+- **서비스 메시**: Istio (sidecar injection + mTLS)
+- **모니터링**: Prometheus + Grafana + Loki + Tempo + Alloy
+- **Helm 패턴**: Library Chart (goti-common) + Application Chart
+
+## Helm Commands
+
+```bash
+# Lint
+make lint
+
+# Template 렌더링 + dry-run 검증
+make validate
+
+# 캐시 정리
+make clean
+```
+
+## 트러블슈팅
+
+### ArgoCD 초기 비밀번호
+```bash
+kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d
+```
+
+### Pod 상태 확인
+```bash
+kubectl get pods -A
+kubectl describe pod <pod-name> -n <namespace>
+kubectl logs <pod-name> -n <namespace>
+```
+
+### Istio sidecar 상태 확인
+```bash
+istioctl analyze -n goti
+kubectl get pods -n goti -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.containers[*].name}{"\n"}{end}'
+```
+
+### ArgoCD Application 동기화
+```bash
+# 개별 앱 동기화
+kubectl -n argocd patch application <app-name> --type merge -p '{"operation":{"initiatedBy":{"username":"admin"},"sync":{}}}'
+
+# 또는 ArgoCD CLI
+argocd app sync <app-name>
+```
+
+## 컨벤션
+
+- Commit: `[TYPE] 설명 (#이슈번호)` (FEAT, BUG, REFACTOR, TEST, DOCS, CHORE)
+- Branch: `feature/*`, `chore/*`, `hotfix/*`
+- PR 템플릿: `.github/PULL_REQUEST_TEMPLATE.md` 참고

--- a/infrastructure/argocd/Chart.yaml
+++ b/infrastructure/argocd/Chart.yaml
@@ -4,5 +4,5 @@ description: ArgoCD Helm wrapper for Goti GitOps
 version: 0.1.0
 dependencies:
   - name: argo-cd
-    version: "7.8.13"
+    version: "9.4.6"
     repository: "https://argoproj.github.io/argo-helm"

--- a/infrastructure/argocd/Chart.yaml
+++ b/infrastructure/argocd/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: argocd
+description: ArgoCD Helm wrapper for Goti GitOps
+version: 0.1.0
+dependencies:
+  - name: argo-cd
+    version: "7.8.13"
+    repository: "https://argoproj.github.io/argo-helm"

--- a/infrastructure/argocd/values-dev.yaml
+++ b/infrastructure/argocd/values-dev.yaml
@@ -33,3 +33,5 @@ argo-cd:
   configs:
     params:
       server.insecure: true
+      # chart 9.x에서 기본값 제거됨 — ApplicationSet 자동 sync 필요 시 명시
+      applicationsetcontroller.policy: sync

--- a/infrastructure/argocd/values-dev.yaml
+++ b/infrastructure/argocd/values-dev.yaml
@@ -1,0 +1,35 @@
+# ArgoCD Kind 개발 환경 최적화 설정
+argo-cd:
+  global:
+    # 리비전 히스토리 최소화 (리소스 절약)
+    revisionHistoryLimit: 1
+
+  # 컨트롤러: 단일 레플리카
+  controller:
+    replicas: 1
+
+  # 서버: 단일 레플리카 + NodePort
+  server:
+    replicas: 1
+    service:
+      type: NodePort
+      nodePortHttp: 30080
+
+  # Repo 서버: 단일 레플리카
+  repoServer:
+    replicas: 1
+
+  # 내장 Redis 사용
+  redis:
+    enabled: true
+
+  # 불필요한 컴포넌트 비활성화 (개발 환경)
+  dex:
+    enabled: false
+  notifications:
+    enabled: false
+
+  # 개발 환경에서는 insecure 모드 허용
+  configs:
+    params:
+      server.insecure: true

--- a/infrastructure/argocd/values.yaml
+++ b/infrastructure/argocd/values.yaml
@@ -1,0 +1,18 @@
+# ArgoCD 공통 설정
+argo-cd:
+  # 리소스 이름을 argocd로 통일 (subchart 접두사 방지)
+  fullnameOverride: argocd
+
+  # 서버 설정
+  server:
+    service:
+      type: ClusterIP
+
+  # ArgoCD 설정
+  configs:
+    cm:
+      # 리소스 동기화 주기 (3분)
+      timeout.reconciliation: "180s"
+    params:
+      # HTTPS 사용 여부 (기본값: 비활성화하지 않음)
+      server.insecure: false

--- a/infrastructure/istio/base/Chart.yaml
+++ b/infrastructure/istio/base/Chart.yaml
@@ -4,5 +4,5 @@ description: Istio base (CRDs) Helm wrapper
 version: 0.1.0
 dependencies:
   - name: base
-    version: "1.25.2"
+    version: "1.29.0"
     repository: "https://istio-release.storage.googleapis.com/charts"

--- a/infrastructure/istio/base/Chart.yaml
+++ b/infrastructure/istio/base/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: istio-base
+description: Istio base (CRDs) Helm wrapper
+version: 0.1.0
+dependencies:
+  - name: base
+    version: "1.25.2"
+    repository: "https://istio-release.storage.googleapis.com/charts"

--- a/infrastructure/istio/base/values.yaml
+++ b/infrastructure/istio/base/values.yaml
@@ -1,0 +1,3 @@
+# Istio Base (CRDs) 설정
+base:
+  defaultRevision: default

--- a/infrastructure/istio/gateway/Chart.yaml
+++ b/infrastructure/istio/gateway/Chart.yaml
@@ -4,5 +4,5 @@ description: Istio Ingress Gateway Helm wrapper
 version: 0.1.0
 dependencies:
   - name: gateway
-    version: "1.25.2"
+    version: "1.29.0"
     repository: "https://istio-release.storage.googleapis.com/charts"

--- a/infrastructure/istio/gateway/Chart.yaml
+++ b/infrastructure/istio/gateway/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: istio-gateway
+description: Istio Ingress Gateway Helm wrapper
+version: 0.1.0
+dependencies:
+  - name: gateway
+    version: "1.25.2"
+    repository: "https://istio-release.storage.googleapis.com/charts"

--- a/infrastructure/istio/gateway/values-dev.yaml
+++ b/infrastructure/istio/gateway/values-dev.yaml
@@ -1,0 +1,23 @@
+# Istio Ingress Gateway dev-kind 최적화
+gateway:
+  replicaCount: 1
+  service:
+    type: NodePort
+    ports:
+      - name: http2
+        port: 80
+        targetPort: 80
+        nodePort: 31080
+        protocol: TCP
+      - name: https
+        port: 443
+        targetPort: 443
+        nodePort: 31443
+        protocol: TCP
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 256Mi

--- a/infrastructure/istio/gateway/values.yaml
+++ b/infrastructure/istio/gateway/values.yaml
@@ -1,0 +1,14 @@
+# Istio Ingress Gateway 공통 values
+gateway:
+  replicaCount: 1
+  service:
+    type: LoadBalancer
+    ports:
+      - name: http2
+        port: 80
+        targetPort: 80
+        protocol: TCP
+      - name: https
+        port: 443
+        targetPort: 443
+        protocol: TCP

--- a/infrastructure/istio/gateway/values.yaml
+++ b/infrastructure/istio/gateway/values.yaml
@@ -1,6 +1,6 @@
 # Istio Ingress Gateway 공통 values
 gateway:
-  replicaCount: 1
+  replicaCount: 2
   service:
     type: LoadBalancer
     ports:

--- a/infrastructure/istio/istiod/Chart.yaml
+++ b/infrastructure/istio/istiod/Chart.yaml
@@ -4,5 +4,5 @@ description: Istio control plane Helm wrapper
 version: 0.1.0
 dependencies:
   - name: istiod
-    version: "1.25.2"
+    version: "1.29.0"
     repository: "https://istio-release.storage.googleapis.com/charts"

--- a/infrastructure/istio/istiod/Chart.yaml
+++ b/infrastructure/istio/istiod/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: istiod
+description: Istio control plane Helm wrapper
+version: 0.1.0
+dependencies:
+  - name: istiod
+    version: "1.25.2"
+    repository: "https://istio-release.storage.googleapis.com/charts"

--- a/infrastructure/istio/istiod/values-dev.yaml
+++ b/infrastructure/istio/istiod/values-dev.yaml
@@ -1,0 +1,31 @@
+# Istiod Kind 개발 환경 최적화 설정
+istiod:
+  pilot:
+    # 단일 레플리카 (개발 환경)
+    replicaCount: 1
+    autoscaleEnabled: false
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+
+  # 메시 전역 설정
+  meshConfig:
+    # 접근 로그 활성화 (디버깅용)
+    accessLogFile: "/dev/stdout"
+    # 분산 트레이싱 활성화
+    enableTracing: true
+    defaultConfig:
+      tracing:
+        zipkin:
+          # Alloy(OpenTelemetry Collector) 엔드포인트
+          address: "alloy.monitoring.svc:9411"
+    # OTLP 트레이싱 프로바이더 (Alloy 연동)
+    extensionProviders:
+      - name: otel-tracing
+        opentelemetry:
+          service: alloy.monitoring.svc.cluster.local
+          port: 4317

--- a/infrastructure/istio/istiod/values-dev.yaml
+++ b/infrastructure/istio/istiod/values-dev.yaml
@@ -18,11 +18,6 @@ istiod:
     accessLogFile: "/dev/stdout"
     # 분산 트레이싱 활성화
     enableTracing: true
-    defaultConfig:
-      tracing:
-        zipkin:
-          # Alloy(OpenTelemetry Collector) 엔드포인트
-          address: "alloy.monitoring.svc:9411"
     # OTLP 트레이싱 프로바이더 (Alloy 연동)
     extensionProviders:
       - name: otel-tracing

--- a/infrastructure/istio/istiod/values-dev.yaml
+++ b/infrastructure/istio/istiod/values-dev.yaml
@@ -1,16 +1,16 @@
 # Istiod Kind 개발 환경 최적화 설정
+# NOTE: Istio 1.24부터 pilot: 네스팅 제거됨 — flat 구조 사용
 istiod:
-  pilot:
-    # 단일 레플리카 (개발 환경)
-    replicaCount: 1
-    autoscaleEnabled: false
-    resources:
-      requests:
-        cpu: 100m
-        memory: 256Mi
-      limits:
-        cpu: 500m
-        memory: 512Mi
+  # 단일 레플리카 (개발 환경)
+  replicaCount: 1
+  autoscaleEnabled: false
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
 
   # 메시 전역 설정
   meshConfig:

--- a/infrastructure/istio/istiod/values.yaml
+++ b/infrastructure/istio/istiod/values.yaml
@@ -1,7 +1,7 @@
 # Istiod (컨트롤 플레인) 공통 설정
+# NOTE: Istio 1.24부터 pilot: 네스팅 제거됨 — flat 구조 사용
 istiod:
-  pilot:
-    autoscaleEnabled: true
-    autoscaleMin: 1
-    autoscaleMax: 3
-    replicaCount: 1
+  autoscaleEnabled: true
+  autoscaleMin: 1
+  autoscaleMax: 3
+  replicaCount: 1

--- a/infrastructure/istio/istiod/values.yaml
+++ b/infrastructure/istio/istiod/values.yaml
@@ -1,5 +1,7 @@
 # Istiod (컨트롤 플레인) 공통 설정
 istiod:
-  # 기본 설정 유지 - 환경별 values 파일에서 오버라이드
   pilot:
     autoscaleEnabled: true
+    autoscaleMin: 1
+    autoscaleMax: 3
+    replicaCount: 1

--- a/infrastructure/istio/istiod/values.yaml
+++ b/infrastructure/istio/istiod/values.yaml
@@ -1,0 +1,5 @@
+# Istiod (컨트롤 플레인) 공통 설정
+istiod:
+  # 기본 설정 유지 - 환경별 values 파일에서 오버라이드
+  pilot:
+    autoscaleEnabled: true

--- a/kind/cluster-config.yaml
+++ b/kind/cluster-config.yaml
@@ -1,0 +1,37 @@
+# Goti 로컬 개발 환경 Kind 클러스터 설정
+# control-plane 1개 + worker 2개 구성
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: goti-dev
+nodes:
+  - role: control-plane
+    kubeadmConfigPatches:
+      - |
+        kind: InitConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "ingress-ready=true"
+    extraPortMappings:
+      # HTTP/HTTPS (Ingress)
+      - containerPort: 80
+        hostPort: 80
+        protocol: TCP
+      - containerPort: 443
+        hostPort: 443
+        protocol: TCP
+      # ArgoCD NodePort
+      - containerPort: 30080
+        hostPort: 30080
+        protocol: TCP
+      - containerPort: 30443
+        hostPort: 30443
+        protocol: TCP
+      # Istio Gateway NodePort
+      - containerPort: 31080
+        hostPort: 31080
+        protocol: TCP
+      - containerPort: 31443
+        hostPort: 31443
+        protocol: TCP
+  - role: worker
+  - role: worker

--- a/kind/cluster-config.yaml
+++ b/kind/cluster-config.yaml
@@ -1,10 +1,12 @@
 # Goti 로컬 개발 환경 Kind 클러스터 설정
 # control-plane 1개 + worker 2개 구성
+# K8s 1.34 고정 — ArgoCD v3.3이 1.35 미지원 (protobuf 이슈 #25767)
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 name: goti-dev
 nodes:
   - role: control-plane
+    image: kindest/node:v1.34.3
     kubeadmConfigPatches:
       - |
         kind: InitConfiguration
@@ -31,4 +33,6 @@ nodes:
         hostPort: 31443
         protocol: TCP
   - role: worker
+    image: kindest/node:v1.34.3
   - role: worker
+    image: kindest/node:v1.34.3

--- a/kind/cluster-config.yaml
+++ b/kind/cluster-config.yaml
@@ -19,12 +19,9 @@ nodes:
       - containerPort: 443
         hostPort: 443
         protocol: TCP
-      # ArgoCD NodePort
+      # ArgoCD NodePort (HTTP only, insecure mode in dev)
       - containerPort: 30080
         hostPort: 30080
-        protocol: TCP
-      - containerPort: 30443
-        hostPort: 30443
         protocol: TCP
       # Istio Gateway NodePort
       - containerPort: 31080


### PR DESCRIPTION
## 관련 이슈
- Closes #2
- Closes #3

## 개요
dev-kind 환경용 Kind 클러스터 설정과 ArgoCD/Istio 서비스 메시 Helm chart 래퍼를 추가합니다.

## 작업 내용
- `kind/cluster-config.yaml` — 3노드 클러스터 (1 CP + 2 Worker), extraPortMappings (80, 443, 30080, 31080, 31443)
- `infrastructure/argocd/` — argo-cd Helm chart 래퍼 (Chart.yaml, values.yaml, values-dev.yaml)
- `infrastructure/istio/base/` — Istio CRDs (base chart)
- `infrastructure/istio/istiod/` — Istio control plane (istiod chart + dev 최적화)
- `infrastructure/istio/gateway/` — Istio ingress gateway (NodePort 31080/31443)

## 테스트
- [ ] `kind create cluster --config kind/cluster-config.yaml` → 3노드 확인
- [ ] `helm lint` 통과
- [ ] `helm template` 렌더링 검증