### PR TITLE
[FEAT] Helm Charts 및 모니터링 스택 values 추가 (#4, #5, #6)

### DIFF
--- a/charts/goti-common/Chart.yaml
+++ b/charts/goti-common/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: goti-common
+description: Goti 공통 Helm Library Chart — MSA 전환 대비 공통 템플릿
+type: library
+version: 0.1.0

--- a/charts/goti-common/templates/_deployment.tpl
+++ b/charts/goti-common/templates/_deployment.tpl
@@ -1,0 +1,68 @@
+{{- define "goti-common.deployment" -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "goti-common.fullname" . }}
+  labels:
+    {{- include "goti-common.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "goti-common.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "goti-common.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ default (include "goti-common.fullname" .) .Values.serviceAccount.name }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: {{ default "http" .Values.service.name }}
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          {{- if .Values.probes }}
+          {{- with .Values.probes.liveness }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.probes.readiness }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/goti-common/templates/_gateway.tpl
+++ b/charts/goti-common/templates/_gateway.tpl
@@ -1,0 +1,42 @@
+{{- define "goti-common.gateway" -}}
+{{- if .Values.gateway.enabled }}
+apiVersion: networking.istio.io/v1
+kind: Gateway
+metadata:
+  name: {{ include "goti-common.fullname" . }}
+  labels:
+    {{- include "goti-common.labels" . | nindent 4 }}
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+    - port:
+        number: 80
+        name: http
+        protocol: HTTP
+      hosts:
+        {{- range .Values.gateway.hosts }}
+        - {{ . | quote }}
+        {{- end }}
+---
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: {{ include "goti-common.fullname" . }}
+  labels:
+    {{- include "goti-common.labels" . | nindent 4 }}
+spec:
+  hosts:
+    {{- range .Values.gateway.hosts }}
+    - {{ . | quote }}
+    {{- end }}
+  gateways:
+    - {{ include "goti-common.fullname" . }}
+  http:
+    - route:
+        - destination:
+            host: {{ include "goti-common.fullname" . }}
+            port:
+              number: {{ .Values.service.port }}
+{{- end }}
+{{- end }}

--- a/charts/goti-common/templates/_helpers.tpl
+++ b/charts/goti-common/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Chart name truncated to 63 chars.
+*/}}
+{{- define "goti-common.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Fully qualified app name.
+Release name truncated to 63 chars.
+*/}}
+{{- define "goti-common.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Chart name and version for chart label.
+*/}}
+{{- define "goti-common.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "goti-common.labels" -}}
+helm.sh/chart: {{ include "goti-common.chart" . }}
+{{ include "goti-common.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: goti
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "goti-common.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "goti-common.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/goti-common/templates/_hpa.tpl
+++ b/charts/goti-common/templates/_hpa.tpl
@@ -1,0 +1,24 @@
+{{- define "goti-common.hpa" -}}
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "goti-common.fullname" . }}
+  labels:
+    {{- include "goti-common.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "goti-common.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}
+{{- end }}

--- a/charts/goti-common/templates/_pdb.tpl
+++ b/charts/goti-common/templates/_pdb.tpl
@@ -1,0 +1,15 @@
+{{- define "goti-common.pdb" -}}
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "goti-common.fullname" . }}
+  labels:
+    {{- include "goti-common.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "goti-common.selectorLabels" . | nindent 6 }}
+{{- end }}
+{{- end }}

--- a/charts/goti-common/templates/_service.tpl
+++ b/charts/goti-common/templates/_service.tpl
@@ -1,0 +1,17 @@
+{{- define "goti-common.service" -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "goti-common.fullname" . }}
+  labels:
+    {{- include "goti-common.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ default "http" .Values.service.name }}
+      protocol: TCP
+      name: {{ default "http" .Values.service.name }}
+  selector:
+    {{- include "goti-common.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/goti-common/templates/_service.tpl
+++ b/charts/goti-common/templates/_service.tpl
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "goti-common.labels" . | nindent 4 }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: {{ default "http" .Values.service.name }}

--- a/charts/goti-common/templates/_serviceaccount.tpl
+++ b/charts/goti-common/templates/_serviceaccount.tpl
@@ -1,0 +1,14 @@
+{{- define "goti-common.serviceaccount" -}}
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ default (include "goti-common.fullname" .) .Values.serviceAccount.name }}
+  labels:
+    {{- include "goti-common.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/goti-common/values.yaml
+++ b/charts/goti-common/values.yaml
@@ -1,0 +1,3 @@
+# goti-common은 library chart입니다.
+# 이 chart는 직접 설치되지 않으며, 다른 chart에서 의존성으로 사용됩니다.
+# 기본값은 각 application chart의 values.yaml에서 정의합니다.

--- a/charts/goti-server/Chart.yaml
+++ b/charts/goti-server/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: goti-server
+description: Goti 백엔드 서버 Helm Chart (Spring Boot)
+type: application
+version: 0.1.0
+appVersion: "0.0.1"
+dependencies:
+  - name: goti-common
+    version: "0.1.0"
+    repository: "file://../goti-common"

--- a/charts/goti-server/templates/NOTES.txt
+++ b/charts/goti-server/templates/NOTES.txt
@@ -1,0 +1,14 @@
+Goti Server가 배포되었습니다!
+
+1. 서비스 접근:
+   kubectl port-forward svc/{{ include "goti-common.fullname" . }} 8080:{{ .Values.service.port }} -n {{ .Release.Namespace }}
+
+2. 헬스 체크:
+   curl http://localhost:8080/actuator/health
+
+{{- if .Values.gateway.enabled }}
+3. Gateway 접근:
+   {{- range .Values.gateway.hosts }}
+   http://{{ . }}
+   {{- end }}
+{{- end }}

--- a/charts/goti-server/templates/configmap.yaml
+++ b/charts/goti-server/templates/configmap.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.configMap.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "goti-common.fullname" . }}
+  labels:
+    {{- include "goti-common.labels" . | nindent 4 }}
+data:
+  {{- toYaml .Values.configMap.data | nindent 2 }}
+{{- end }}

--- a/charts/goti-server/templates/deployment.yaml
+++ b/charts/goti-server/templates/deployment.yaml
@@ -1,0 +1,1 @@
+{{- include "goti-common.deployment" . }}

--- a/charts/goti-server/templates/gateway.yaml
+++ b/charts/goti-server/templates/gateway.yaml
@@ -1,0 +1,1 @@
+{{- include "goti-common.gateway" . }}

--- a/charts/goti-server/templates/hpa.yaml
+++ b/charts/goti-server/templates/hpa.yaml
@@ -1,0 +1,1 @@
+{{- include "goti-common.hpa" . }}

--- a/charts/goti-server/templates/pdb.yaml
+++ b/charts/goti-server/templates/pdb.yaml
@@ -1,0 +1,1 @@
+{{- include "goti-common.pdb" . }}

--- a/charts/goti-server/templates/service.yaml
+++ b/charts/goti-server/templates/service.yaml
@@ -1,0 +1,1 @@
+{{- include "goti-common.service" . }}

--- a/charts/goti-server/templates/serviceaccount.yaml
+++ b/charts/goti-server/templates/serviceaccount.yaml
@@ -1,0 +1,1 @@
+{{- include "goti-common.serviceaccount" . }}

--- a/charts/goti-server/values.schema.json
+++ b/charts/goti-server/values.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["image"],
+  "properties": {
+    "image": {
+      "type": "object",
+      "required": ["repository", "tag"],
+      "properties": {
+        "repository": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Container image repository"
+        },
+        "tag": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Container image tag"
+        }
+      }
+    },
+    "replicaCount": {
+      "type": "integer",
+      "minimum": 0
+    }
+  }
+}

--- a/charts/goti-server/values.yaml
+++ b/charts/goti-server/values.yaml
@@ -1,0 +1,67 @@
+replicaCount: 1
+
+image:
+  repository: goti-server
+  tag: "latest"
+  pullPolicy: IfNotPresent
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+service:
+  type: ClusterIP
+  port: 8080
+  name: http
+
+gateway:
+  enabled: false
+  hosts:
+    - "goti.local"
+
+probes:
+  liveness:
+    httpGet:
+      path: /actuator/health/liveness
+      port: http
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    failureThreshold: 3
+  readiness:
+    httpGet:
+      path: /actuator/health/readiness
+      port: http
+    initialDelaySeconds: 10
+    periodSeconds: 5
+    failureThreshold: 3
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 512Mi
+  limits:
+    cpu: "1"
+    memory: 1Gi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+
+pdb:
+  enabled: false
+  minAvailable: 1
+
+env: []
+envFrom: []
+
+configMap:
+  enabled: false
+  data: {}
+
+podAnnotations: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/environments/dev/goti-server/values.yaml
+++ b/environments/dev/goti-server/values.yaml
@@ -1,9 +1,5 @@
-replicaCount: 1
-
 image:
-  repository: goti-server
   tag: "latest"
-  pullPolicy: IfNotPresent
 
 resources:
   requests:
@@ -35,5 +31,5 @@ probes:
 env:
   - name: SPRING_PROFILES_ACTIVE
     value: "dev"
-  - name: JAVA_OPTS
+  - name: JAVA_TOOL_OPTIONS
     value: "-Xms256m -Xmx384m"

--- a/environments/dev/goti-server/values.yaml
+++ b/environments/dev/goti-server/values.yaml
@@ -1,0 +1,39 @@
+replicaCount: 1
+
+image:
+  repository: goti-server
+  tag: "latest"
+  pullPolicy: IfNotPresent
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+gateway:
+  enabled: true
+  hosts:
+    - "goti.local"
+
+probes:
+  liveness:
+    httpGet:
+      path: /actuator/health/liveness
+      port: http
+    initialDelaySeconds: 60
+    periodSeconds: 10
+  readiness:
+    httpGet:
+      path: /actuator/health/readiness
+      port: http
+    initialDelaySeconds: 30
+    periodSeconds: 5
+
+env:
+  - name: SPRING_PROFILES_ACTIVE
+    value: "dev"
+  - name: JAVA_OPTS
+    value: "-Xms256m -Xmx384m"

--- a/environments/dev/monitoring/alloy-values.yaml
+++ b/environments/dev/monitoring/alloy-values.yaml
@@ -1,0 +1,70 @@
+# Grafana Alloy dev-kind values
+# OTLP receiver → batch → Prometheus/Loki/Tempo routing
+alloy:
+  configMap:
+    content: |
+      // OTLP receiver
+      otelcol.receiver.otlp "default" {
+        grpc {
+          endpoint = "0.0.0.0:4317"
+        }
+        http {
+          endpoint = "0.0.0.0:4318"
+        }
+        output {
+          metrics = [otelcol.processor.batch.default.input]
+          logs    = [otelcol.processor.batch.default.input]
+          traces  = [otelcol.processor.batch.default.input]
+        }
+      }
+
+      // Batch processor
+      otelcol.processor.batch "default" {
+        timeout = "5s"
+        send_batch_size = 1000
+        output {
+          metrics = [otelcol.exporter.prometheus.default.input]
+          logs    = [otelcol.exporter.loki.default.input]
+          traces  = [otelcol.exporter.otlp.tempo.input]
+        }
+      }
+
+      // Prometheus remote write
+      otelcol.exporter.prometheus "default" {
+        forward_to = [prometheus.remote_write.default.receiver]
+      }
+
+      prometheus.remote_write "default" {
+        endpoint {
+          url = "http://kube-prometheus-stack-prometheus.monitoring.svc:9090/api/v1/write"
+        }
+      }
+
+      // Loki exporter
+      otelcol.exporter.loki "default" {
+        forward_to = [loki.write.default.receiver]
+      }
+
+      loki.write "default" {
+        endpoint {
+          url = "http://loki.monitoring.svc:3100/loki/api/v1/push"
+        }
+      }
+
+      // Tempo exporter (OTLP)
+      otelcol.exporter.otlp "tempo" {
+        client {
+          endpoint = "tempo.monitoring.svc:4317"
+          tls {
+            insecure = true
+          }
+        }
+      }
+
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi

--- a/environments/dev/monitoring/kube-prometheus-stack-values.yaml
+++ b/environments/dev/monitoring/kube-prometheus-stack-values.yaml
@@ -1,0 +1,74 @@
+# kube-prometheus-stack dev-kind values
+prometheus:
+  prometheusSpec:
+    replicas: 1
+    retention: 24h
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+    storageSpec:
+      volumeClaimTemplate:
+        spec:
+          accessModes: ["ReadWriteOnce"]
+          resources:
+            requests:
+              storage: 5Gi
+    # Istio metrics scraping
+    additionalScrapeConfigs:
+      - job_name: 'istio-mesh'
+        kubernetes_sd_configs:
+          - role: endpoints
+            namespaces:
+              names: ['istio-system']
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+            action: keep
+            regex: istiod;http-monitoring
+
+alertmanager:
+  enabled: false
+
+grafana:
+  enabled: true
+  adminPassword: "admin"  # dev only
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
+  additionalDataSources:
+    - name: Loki
+      type: loki
+      url: http://loki.monitoring.svc:3100
+      access: proxy
+      isDefault: false
+    - name: Tempo
+      type: tempo
+      url: http://tempo.monitoring.svc:3100
+      access: proxy
+      isDefault: false
+      jsonData:
+        tracesToLogsV2:
+          datasourceUid: loki
+          enabled: true
+        tracesToMetrics:
+          datasourceUid: prometheus
+          enabled: true
+        serviceMap:
+          datasourceUid: prometheus
+        nodeGraph:
+          enabled: true
+        lokiSearch:
+          datasourceUid: loki
+
+nodeExporter:
+  enabled: true
+
+kubeStateMetrics:
+  enabled: true

--- a/environments/dev/monitoring/kube-prometheus-stack-values.yaml
+++ b/environments/dev/monitoring/kube-prometheus-stack-values.yaml
@@ -3,6 +3,7 @@ prometheus:
   prometheusSpec:
     replicas: 1
     retention: 24h
+    enableRemoteWriteReceiver: true
     resources:
       requests:
         cpu: 100m
@@ -45,11 +46,13 @@ grafana:
   additionalDataSources:
     - name: Loki
       type: loki
+      uid: loki
       url: http://loki.monitoring.svc:3100
       access: proxy
       isDefault: false
     - name: Tempo
       type: tempo
+      uid: tempo
       url: http://tempo.monitoring.svc:3100
       access: proxy
       isDefault: false

--- a/environments/dev/monitoring/loki-values.yaml
+++ b/environments/dev/monitoring/loki-values.yaml
@@ -1,0 +1,47 @@
+# Loki dev-kind values — SingleBinary mode
+deploymentMode: SingleBinary
+
+loki:
+  auth_enabled: false
+  commonConfig:
+    replication_factor: 1
+  storage:
+    type: filesystem
+  schemaConfig:
+    configs:
+      - from: "2024-01-01"
+        store: tsdb
+        object_store: filesystem
+        schema: v13
+        index:
+          prefix: index_
+          period: 24h
+
+singleBinary:
+  replicas: 1
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
+  persistence:
+    enabled: true
+    size: 5Gi
+
+gateway:
+  enabled: false
+
+read:
+  replicas: 0
+write:
+  replicas: 0
+backend:
+  replicas: 0
+
+monitoring:
+  selfMonitoring:
+    enabled: false
+  lokiCanary:
+    enabled: false

--- a/environments/dev/monitoring/tempo-values.yaml
+++ b/environments/dev/monitoring/tempo-values.yaml
@@ -1,0 +1,30 @@
+# Tempo dev-kind values
+tempo:
+  storage:
+    trace:
+      backend: local
+      local:
+        path: /var/tempo/traces
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: "0.0.0.0:4317"
+        http:
+          endpoint: "0.0.0.0:4318"
+    zipkin:
+      endpoint: "0.0.0.0:9411"
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
+
+persistence:
+  enabled: true
+  size: 5Gi
+
+tempoQuery:
+  enabled: false


### PR DESCRIPTION
## 관련 이슈
- Closes #4 — goti-common Library Chart 생성
- Closes #5 — goti-server Helm Chart 생성
- Closes #6 — 모니터링 스택 Helm values 설정

## 개요
Goti 서비스 배포를 위한 Helm Charts와 dev-kind 환경 모니터링 스택 values를 추가합니다.

## 작업 내용

### goti-common (Library Chart)
- `type: library` Chart — MSA 전환 대비 공통 템플릿 분리
- 템플릿: _helpers, _deployment, _service, _serviceaccount, _gateway (Istio), _hpa, _pdb
- Istio sidecar injection 기본 활성화
- Istio Gateway/VirtualService API v1 사용

### goti-server (Application Chart)
- goti-common 의존성 (`file://../goti-common`)
- values.schema.json으로 image.repository/tag 필수값 검증
- Spring Boot Actuator 기반 health probe (liveness/readiness 분리)
- ConfigMap, HPA, PDB 조건부 생성 (enabled 플래그)
- `environments/dev/goti-server/values.yaml` — dev-kind 최적화 (리소스 축소, gateway 활성화)

### 모니터링 스택 dev values
- **kube-prometheus-stack**: 단일 레플리카, 24h retention, Grafana 내장, Loki/Tempo datasource 자동 프로비저닝, Istio 메트릭 scrape
- **Loki**: SingleBinary 모드, filesystem 스토리지, 5Gi
- **Tempo**: local backend, OTLP gRPC/HTTP + Zipkin 수신
- **Alloy**: OTLP receiver → batch → Prometheus/Loki/Tempo 라우팅 (config.alloy 인라인)

## 검증
- `helm dependency build` 성공
- `helm lint charts/goti-server/ -f environments/dev/goti-server/values.yaml` 통과
- `helm template` 렌더링 정상 (Deployment, Service, ServiceAccount, Gateway, VirtualService)