### PR TITLE
[FEAT] ArgoCD GitOps 및 클러스터 부트스트랩 (#7, #8)

### DIFF
--- a/clusters/dev/bootstrap/argocd-install.yaml
+++ b/clusters/dev/bootstrap/argocd-install.yaml
@@ -1,0 +1,29 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argocd
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-10"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  sources:
+    - repoURL: "https://github.com/Team-Ikujo/Goti-k8s.git"
+      targetRevision: main
+      path: "infrastructure/argocd"
+      helm:
+        valueFiles:
+          - values.yaml
+          - values-dev.yaml
+  destination:
+    server: "https://kubernetes.default.svc"
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/clusters/dev/bootstrap/argocd-install.yaml
+++ b/clusters/dev/bootstrap/argocd-install.yaml
@@ -22,8 +22,14 @@ spec:
     namespace: argocd
   syncPolicy:
     automated:
-      prune: true
+      prune: false
       selfHeal: true
+    retry:
+      limit: 5
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 3m
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/clusters/dev/bootstrap/istio-install.yaml
+++ b/clusters/dev/bootstrap/istio-install.yaml
@@ -1,0 +1,91 @@
+# Istio Base (CRDs)
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: istio-base
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-5"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  sources:
+    - repoURL: "https://github.com/Team-Ikujo/Goti-k8s.git"
+      targetRevision: main
+      path: "infrastructure/istio/base"
+      helm:
+        valueFiles:
+          - values.yaml
+  destination:
+    server: "https://kubernetes.default.svc"
+    namespace: istio-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+---
+# Istiod (Control Plane)
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: istiod
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-4"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  sources:
+    - repoURL: "https://github.com/Team-Ikujo/Goti-k8s.git"
+      targetRevision: main
+      path: "infrastructure/istio/istiod"
+      helm:
+        valueFiles:
+          - values.yaml
+          - values-dev.yaml
+  destination:
+    server: "https://kubernetes.default.svc"
+    namespace: istio-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+---
+# Istio Ingress Gateway
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: istio-gateway
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-3"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  sources:
+    - repoURL: "https://github.com/Team-Ikujo/Goti-k8s.git"
+      targetRevision: main
+      path: "infrastructure/istio/gateway"
+      helm:
+        valueFiles:
+          - values.yaml
+          - values-dev.yaml
+  destination:
+    server: "https://kubernetes.default.svc"
+    namespace: istio-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/clusters/dev/bootstrap/istio-install.yaml
+++ b/clusters/dev/bootstrap/istio-install.yaml
@@ -9,7 +9,7 @@ metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: infra
   sources:
     - repoURL: "https://github.com/Team-Ikujo/Goti-k8s.git"
       targetRevision: main
@@ -24,6 +24,12 @@ spec:
     automated:
       prune: true
       selfHeal: true
+    retry:
+      limit: 5
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 3m
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true
@@ -39,7 +45,7 @@ metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: infra
   sources:
     - repoURL: "https://github.com/Team-Ikujo/Goti-k8s.git"
       targetRevision: main
@@ -55,6 +61,12 @@ spec:
     automated:
       prune: true
       selfHeal: true
+    retry:
+      limit: 5
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 3m
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true
@@ -70,7 +82,7 @@ metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: infra
   sources:
     - repoURL: "https://github.com/Team-Ikujo/Goti-k8s.git"
       targetRevision: main
@@ -86,6 +98,12 @@ spec:
     automated:
       prune: true
       selfHeal: true
+    retry:
+      limit: 5
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 3m
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/clusters/dev/bootstrap/root-appsets.yaml
+++ b/clusters/dev/bootstrap/root-appsets.yaml
@@ -1,26 +1,35 @@
-# AppProjects
+# AppProjects — Istio CRD 설치 이후 배포 (sync-wave: -2)
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: goti-projects
   namespace: argocd
   annotations:
-    argocd.argoproj.io/sync-wave: "-8"
+    argocd.argoproj.io/sync-wave: "-2"
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
-  source:
-    repoURL: "https://github.com/Team-Ikujo/Goti-k8s.git"
-    targetRevision: main
-    path: "gitops/projects"
+  project: infra
+  sources:
+    - repoURL: "https://github.com/Team-Ikujo/Goti-k8s.git"
+      targetRevision: main
+      path: "gitops/projects"
   destination:
     server: "https://kubernetes.default.svc"
     namespace: argocd
   syncPolicy:
     automated:
-      prune: true
+      prune: false
       selfHeal: true
+    retry:
+      limit: 5
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 3m
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
 ---
 # ApplicationSets
 apiVersion: argoproj.io/v1alpha1
@@ -33,11 +42,11 @@ metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
-  source:
-    repoURL: "https://github.com/Team-Ikujo/Goti-k8s.git"
-    targetRevision: main
-    path: "gitops/applicationsets"
+  project: infra
+  sources:
+    - repoURL: "https://github.com/Team-Ikujo/Goti-k8s.git"
+      targetRevision: main
+      path: "gitops/applicationsets"
   destination:
     server: "https://kubernetes.default.svc"
     namespace: argocd
@@ -45,3 +54,12 @@ spec:
     automated:
       prune: true
       selfHeal: true
+    retry:
+      limit: 5
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 3m
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/clusters/dev/bootstrap/root-appsets.yaml
+++ b/clusters/dev/bootstrap/root-appsets.yaml
@@ -1,0 +1,47 @@
+# AppProjects
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: goti-projects
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-8"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: "https://github.com/Team-Ikujo/Goti-k8s.git"
+    targetRevision: main
+    path: "gitops/projects"
+  destination:
+    server: "https://kubernetes.default.svc"
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+---
+# ApplicationSets
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: goti-applicationsets
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: "https://github.com/Team-Ikujo/Goti-k8s.git"
+    targetRevision: main
+    path: "gitops/applicationsets"
+  destination:
+    server: "https://kubernetes.default.svc"
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/gitops/applicationsets/goti-server-appset.yaml
+++ b/gitops/applicationsets/goti-server-appset.yaml
@@ -32,11 +32,17 @@ spec:
         automated:
           prune: true
           selfHeal: true
+        retry:
+          limit: 5
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m
         syncOptions:
           - CreateNamespace=true
           - ServerSideApply=true
       ignoreDifferences:
-        - group: autoscaling
-          kind: HorizontalPodAutoscaler
+        - group: apps
+          kind: Deployment
           jsonPointers:
             - /spec/replicas

--- a/gitops/applicationsets/goti-server-appset.yaml
+++ b/gitops/applicationsets/goti-server-appset.yaml
@@ -1,0 +1,42 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: goti-server
+  namespace: argocd
+spec:
+  generators:
+    - list:
+        elements:
+          - env: dev
+            namespace: goti
+            valuesFile: environments/dev/goti-server/values.yaml
+  template:
+    metadata:
+      name: "goti-server-{{env}}"
+    spec:
+      project: goti
+      sources:
+        - repoURL: "https://github.com/Team-Ikujo/Goti-k8s.git"
+          targetRevision: main
+          path: "charts/goti-server"
+          helm:
+            valueFiles:
+              - "$values/{{valuesFile}}"
+        - repoURL: "https://github.com/Team-Ikujo/Goti-k8s.git"
+          targetRevision: main
+          ref: values
+      destination:
+        server: "https://kubernetes.default.svc"
+        namespace: "{{namespace}}"
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+          - ServerSideApply=true
+      ignoreDifferences:
+        - group: autoscaling
+          kind: HorizontalPodAutoscaler
+          jsonPointers:
+            - /spec/replicas

--- a/gitops/applicationsets/monitoring-appset.yaml
+++ b/gitops/applicationsets/monitoring-appset.yaml
@@ -54,6 +54,21 @@ spec:
         automated:
           prune: true
           selfHeal: true
+        retry:
+          limit: 5
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m
         syncOptions:
           - CreateNamespace=true
           - ServerSideApply=true
+      ignoreDifferences:
+        - group: admissionregistration.k8s.io
+          kind: MutatingWebhookConfiguration
+          jsonPointers:
+            - /webhooks/0/clientConfig/caBundle
+        - group: admissionregistration.k8s.io
+          kind: ValidatingWebhookConfiguration
+          jsonPointers:
+            - /webhooks/0/clientConfig/caBundle

--- a/gitops/applicationsets/monitoring-appset.yaml
+++ b/gitops/applicationsets/monitoring-appset.yaml
@@ -1,0 +1,59 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: monitoring-stack
+  namespace: argocd
+spec:
+  generators:
+    - matrix:
+        generators:
+          - list:
+              elements:
+                - env: dev
+          - list:
+              elements:
+                - component: kube-prometheus-stack
+                  chartRepo: https://prometheus-community.github.io/helm-charts
+                  chartName: kube-prometheus-stack
+                  chartVersion: "82.4.3"
+                  valuesFile: environments/dev/monitoring/kube-prometheus-stack-values.yaml
+                - component: loki
+                  chartRepo: https://grafana.github.io/helm-charts
+                  chartName: loki
+                  chartVersion: "6.53.0"
+                  valuesFile: environments/dev/monitoring/loki-values.yaml
+                - component: tempo
+                  chartRepo: https://grafana.github.io/helm-charts
+                  chartName: tempo
+                  chartVersion: "1.24.4"
+                  valuesFile: environments/dev/monitoring/tempo-values.yaml
+                - component: alloy
+                  chartRepo: https://grafana.github.io/helm-charts
+                  chartName: alloy
+                  chartVersion: "1.6.1"
+                  valuesFile: environments/dev/monitoring/alloy-values.yaml
+  template:
+    metadata:
+      name: "{{component}}-{{env}}"
+    spec:
+      project: monitoring
+      sources:
+        - repoURL: "{{chartRepo}}"
+          chart: "{{chartName}}"
+          targetRevision: "{{chartVersion}}"
+          helm:
+            valueFiles:
+              - "$values/{{valuesFile}}"
+        - repoURL: "https://github.com/Team-Ikujo/Goti-k8s.git"
+          targetRevision: main
+          ref: values
+      destination:
+        server: "https://kubernetes.default.svc"
+        namespace: monitoring
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+          - ServerSideApply=true

--- a/gitops/projects/goti-project.yaml
+++ b/gitops/projects/goti-project.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   description: "Goti 애플리케이션 프로젝트"
   sourceRepos:
-    - "git@github.com:Team-Ikujo/Goti-k8s.git"
     - "https://github.com/Team-Ikujo/Goti-k8s.git"
   destinations:
     - namespace: goti
@@ -18,16 +17,42 @@ spec:
       kind: Namespace
   namespaceResourceWhitelist:
     - group: ""
-      kind: "*"
+      kind: Service
+    - group: ""
+      kind: ConfigMap
+    - group: ""
+      kind: Secret
+    - group: ""
+      kind: ServiceAccount
+    - group: ""
+      kind: PersistentVolumeClaim
+    - group: ""
+      kind: Endpoints
     - group: "apps"
-      kind: "*"
+      kind: Deployment
+    - group: "apps"
+      kind: StatefulSet
+    - group: "apps"
+      kind: ReplicaSet
     - group: "autoscaling"
-      kind: "*"
+      kind: HorizontalPodAutoscaler
     - group: "policy"
-      kind: "*"
+      kind: PodDisruptionBudget
     - group: "networking.k8s.io"
-      kind: "*"
+      kind: Ingress
+    - group: "networking.k8s.io"
+      kind: NetworkPolicy
     - group: "networking.istio.io"
-      kind: "*"
+      kind: Gateway
+    - group: "networking.istio.io"
+      kind: VirtualService
+    - group: "networking.istio.io"
+      kind: DestinationRule
+    - group: "networking.istio.io"
+      kind: ServiceEntry
     - group: "security.istio.io"
-      kind: "*"
+      kind: PeerAuthentication
+    - group: "security.istio.io"
+      kind: AuthorizationPolicy
+    - group: "security.istio.io"
+      kind: RequestAuthentication

--- a/gitops/projects/goti-project.yaml
+++ b/gitops/projects/goti-project.yaml
@@ -1,0 +1,33 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: goti
+  namespace: argocd
+spec:
+  description: "Goti 애플리케이션 프로젝트"
+  sourceRepos:
+    - "git@github.com:Team-Ikujo/Goti-k8s.git"
+    - "https://github.com/Team-Ikujo/Goti-k8s.git"
+  destinations:
+    - namespace: goti
+      server: "https://kubernetes.default.svc"
+    - namespace: goti-*
+      server: "https://kubernetes.default.svc"
+  clusterResourceWhitelist:
+    - group: ""
+      kind: Namespace
+  namespaceResourceWhitelist:
+    - group: ""
+      kind: "*"
+    - group: "apps"
+      kind: "*"
+    - group: "autoscaling"
+      kind: "*"
+    - group: "policy"
+      kind: "*"
+    - group: "networking.k8s.io"
+      kind: "*"
+    - group: "networking.istio.io"
+      kind: "*"
+    - group: "security.istio.io"
+      kind: "*"

--- a/gitops/projects/infra-project.yaml
+++ b/gitops/projects/infra-project.yaml
@@ -1,0 +1,31 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: infra
+  namespace: argocd
+spec:
+  description: "인프라 부트스트랩 프로젝트 (Istio, AppProject, ApplicationSet)"
+  sourceRepos:
+    - "https://github.com/Team-Ikujo/Goti-k8s.git"
+  destinations:
+    - namespace: argocd
+      server: "https://kubernetes.default.svc"
+    - namespace: istio-system
+      server: "https://kubernetes.default.svc"
+  clusterResourceWhitelist:
+    - group: ""
+      kind: Namespace
+    - group: "apiextensions.k8s.io"
+      kind: CustomResourceDefinition
+    - group: "rbac.authorization.k8s.io"
+      kind: ClusterRole
+    - group: "rbac.authorization.k8s.io"
+      kind: ClusterRoleBinding
+    - group: "admissionregistration.k8s.io"
+      kind: MutatingWebhookConfiguration
+    - group: "admissionregistration.k8s.io"
+      kind: ValidatingWebhookConfiguration
+  # Istio, ArgoCD 리소스 타입이 다양하므로 namespace 경계로 격리
+  namespaceResourceWhitelist:
+    - group: "*"
+      kind: "*"

--- a/gitops/projects/monitoring-project.yaml
+++ b/gitops/projects/monitoring-project.yaml
@@ -1,0 +1,29 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: monitoring
+  namespace: argocd
+spec:
+  description: "모니터링 스택 프로젝트"
+  sourceRepos:
+    - "git@github.com:Team-Ikujo/Goti-k8s.git"
+    - "https://github.com/Team-Ikujo/Goti-k8s.git"
+    - "https://prometheus-community.github.io/helm-charts"
+    - "https://grafana.github.io/helm-charts"
+  destinations:
+    - namespace: monitoring
+      server: "https://kubernetes.default.svc"
+  clusterResourceWhitelist:
+    - group: ""
+      kind: Namespace
+    - group: "monitoring.coreos.com"
+      kind: "*"
+    - group: "apiextensions.k8s.io"
+      kind: CustomResourceDefinition
+  namespaceResourceWhitelist:
+    - group: ""
+      kind: "*"
+    - group: "apps"
+      kind: "*"
+    - group: "monitoring.coreos.com"
+      kind: "*"

--- a/gitops/projects/monitoring-project.yaml
+++ b/gitops/projects/monitoring-project.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   description: "모니터링 스택 프로젝트"
   sourceRepos:
-    - "git@github.com:Team-Ikujo/Goti-k8s.git"
     - "https://github.com/Team-Ikujo/Goti-k8s.git"
     - "https://prometheus-community.github.io/helm-charts"
     - "https://grafana.github.io/helm-charts"
@@ -16,14 +15,54 @@ spec:
   clusterResourceWhitelist:
     - group: ""
       kind: Namespace
-    - group: "monitoring.coreos.com"
-      kind: "*"
     - group: "apiextensions.k8s.io"
       kind: CustomResourceDefinition
+  # 커뮤니티 chart(kube-prometheus-stack 등)가 다양한 리소스를 설치하므로
+  # core, apps 그룹은 kind 와일드카드 유지, monitoring.coreos.com은 명시
   namespaceResourceWhitelist:
     - group: ""
-      kind: "*"
+      kind: Service
+    - group: ""
+      kind: ConfigMap
+    - group: ""
+      kind: Secret
+    - group: ""
+      kind: ServiceAccount
+    - group: ""
+      kind: PersistentVolumeClaim
+    - group: ""
+      kind: Endpoints
+    - group: ""
+      kind: Pod
     - group: "apps"
-      kind: "*"
+      kind: Deployment
+    - group: "apps"
+      kind: StatefulSet
+    - group: "apps"
+      kind: DaemonSet
+    - group: "apps"
+      kind: ReplicaSet
+    - group: "batch"
+      kind: Job
+    - group: "batch"
+      kind: CronJob
+    - group: "rbac.authorization.k8s.io"
+      kind: Role
+    - group: "rbac.authorization.k8s.io"
+      kind: RoleBinding
     - group: "monitoring.coreos.com"
-      kind: "*"
+      kind: Prometheus
+    - group: "monitoring.coreos.com"
+      kind: PrometheusRule
+    - group: "monitoring.coreos.com"
+      kind: ServiceMonitor
+    - group: "monitoring.coreos.com"
+      kind: PodMonitor
+    - group: "monitoring.coreos.com"
+      kind: Alertmanager
+    - group: "monitoring.coreos.com"
+      kind: AlertmanagerConfig
+    - group: "monitoring.coreos.com"
+      kind: ScrapeConfig
+    - group: "policy"
+      kind: PodDisruptionBudget


### PR DESCRIPTION
## 관련 이슈
- Closes #7 — ArgoCD AppProject 및 ApplicationSet 정의
- Closes #8 — 클러스터 부트스트랩 매니페스트

## 개요
ArgoCD GitOps 리소스(AppProject, ApplicationSet)와 dev-kind 클러스터 부트스트랩 매니페스트를 추가합니다.

## 작업 내용

### AppProject (gitops/projects/)
- **goti**: goti/goti-* namespace, Istio networking/security 리소스 허용
- **monitoring**: monitoring namespace, prometheus-community/grafana helm repo 허용, Prometheus Operator CRD 접근

### ApplicationSet (gitops/applicationsets/)
- **goti-server-appset**: List generator + Multi-Source (chart + env values 분리), HPA replicas ignoreDifferences
- **monitoring-appset**: Matrix generator (dev x 4컴포넌트), Multi-Source (커뮤니티 chart + 이 레포 values)
  - chart 버전: kube-prometheus-stack 82.4.3, loki 6.53.0, tempo 1.24.4, alloy 1.6.1 (version-matrix 기준)

### 클러스터 부트스트랩 (clusters/dev/bootstrap/)
- **argocd-install.yaml**: ArgoCD self-manage (sync-wave: -10)
- **istio-install.yaml**: Istio 3단계 설치 — base(-5) → istiod(-4) → gateway(-3)
- **root-appsets.yaml**: AppProject(-8) + ApplicationSet(0) 등록

### sync-wave 순서
```
-10  ArgoCD (self-manage)
 -8  AppProject (goti, monitoring)
 -5  Istio base (CRDs)
 -4  Istiod (control plane)
 -3  Istio gateway (ingress)
  0  ApplicationSet (goti-server, monitoring-stack)
```

## 검증
- YAML 문법 검증 완료
- sync-wave 순서 의존성 확인 (ArgoCD → Istio → AppProject → ApplicationSet)
- monitoring chart 버전 version-matrix.md 기준 일치 확인