### PR TITLE
[FEAT] Makefile, 자동화 스크립트 및 README 작성 (#9)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: up down port-forward lint validate status clean help
 
-CLUSTER_NAME := goti-dev
+export CLUSTER_NAME ?= goti-dev
+export ARGOCD_NAMESPACE ?= argocd
 SHELL := /bin/bash
 
 ## 클러스터 관리
@@ -18,7 +19,7 @@ status: ## 클러스터 및 ArgoCD 상태 확인
 	@kubectl get nodes -o wide 2>/dev/null || echo "클러스터에 연결할 수 없습니다"
 	@echo ""
 	@echo "=== ArgoCD Applications ==="
-	@kubectl get applications -n argocd 2>/dev/null || echo "ArgoCD가 설치되지 않았습니다"
+	@kubectl get applications -n $(ARGOCD_NAMESPACE) 2>/dev/null || echo "ArgoCD가 설치되지 않았습니다"
 	@echo ""
 	@echo "=== Istio 상태 ==="
 	@kubectl get pods -n istio-system 2>/dev/null || echo "Istio가 설치되지 않았습니다"
@@ -35,15 +36,15 @@ validate: ## Helm template 렌더링 + dry-run 검증
 	helm dependency build charts/goti-server/
 	helm template goti-server charts/goti-server/ \
 		-f environments/dev/goti-server/values.yaml \
-		--namespace goti | kubectl apply --dry-run=client -f - 2>&1 | head -20
+		--namespace goti | kubectl apply --dry-run=client -f -
 	@echo ""
 	@echo "=== 부트스트랩 매니페스트 검증 ==="
-	kubectl apply --dry-run=client -f clusters/dev/bootstrap/ 2>&1 | head -20
+	kubectl apply --dry-run=client -f clusters/dev/bootstrap/
 
 ## 유틸리티
 clean: ## Helm dependency cache 정리
-	find charts/ -name "charts" -type d -exec rm -rf {} + 2>/dev/null || true
-	find charts/ -name "*.tgz" -delete 2>/dev/null || true
+	find charts/ -maxdepth 3 -name "charts" -type d -exec rm -rf {} + 2>/dev/null || true
+	find charts/ -maxdepth 3 -name "*.tgz" -delete 2>/dev/null || true
 
 help: ## 도움말 표시
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,52 @@
+.PHONY: up down port-forward lint validate status clean help
+
+CLUSTER_NAME := goti-dev
+SHELL := /bin/bash
+
+## 클러스터 관리
+up: ## Kind 클러스터 생성 + ArgoCD 설치 + 부트스트랩
+	@bash scripts/setup.sh
+
+down: ## Kind 클러스터 삭제
+	@bash scripts/teardown.sh
+
+port-forward: ## Grafana/Prometheus/goti-server 포트포워딩
+	@bash scripts/port-forward.sh
+
+status: ## 클러스터 및 ArgoCD 상태 확인
+	@echo "=== 클러스터 노드 ==="
+	@kubectl get nodes -o wide 2>/dev/null || echo "클러스터에 연결할 수 없습니다"
+	@echo ""
+	@echo "=== ArgoCD Applications ==="
+	@kubectl get applications -n argocd 2>/dev/null || echo "ArgoCD가 설치되지 않았습니다"
+	@echo ""
+	@echo "=== Istio 상태 ==="
+	@kubectl get pods -n istio-system 2>/dev/null || echo "Istio가 설치되지 않았습니다"
+	@echo ""
+	@echo "=== Pods (all namespaces) ==="
+	@kubectl get pods -A --sort-by='.metadata.namespace' 2>/dev/null || true
+
+## Helm 검증
+lint: ## Helm charts lint
+	helm lint charts/goti-server/ -f environments/dev/goti-server/values.yaml
+
+validate: ## Helm template 렌더링 + dry-run 검증
+	@echo "=== goti-server 렌더링 ==="
+	helm dependency build charts/goti-server/
+	helm template goti-server charts/goti-server/ \
+		-f environments/dev/goti-server/values.yaml \
+		--namespace goti | kubectl apply --dry-run=client -f - 2>&1 | head -20
+	@echo ""
+	@echo "=== 부트스트랩 매니페스트 검증 ==="
+	kubectl apply --dry-run=client -f clusters/dev/bootstrap/ 2>&1 | head -20
+
+## 유틸리티
+clean: ## Helm dependency cache 정리
+	find charts/ -name "charts" -type d -exec rm -rf {} + 2>/dev/null || true
+	find charts/ -name "*.tgz" -delete 2>/dev/null || true
+
+help: ## 도움말 표시
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+.DEFAULT_GOAL := help

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Goti 티켓팅 서비스의 Kubernetes GitOps 레포지토리.
 ## 전제조건
 
 - [Kind](https://kind.sigs.k8s.io/) v0.31+
-- [kubectl](https://kubernetes.io/docs/tasks/tools/) v1.33+
+- [kubectl](https://kubernetes.io/docs/tasks/tools/) v1.34+
 - [Helm](https://helm.sh/) v3.14+
 - Docker Desktop 또는 Docker Engine
 

--- a/scripts/port-forward.sh
+++ b/scripts/port-forward.sh
@@ -1,10 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# 백그라운드 프로세스 정리
+cleanup() {
+  echo ""
+  echo "포트포워딩 종료..."
+  kill $(jobs -p) 2>/dev/null || true
+  wait 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
 echo "=== 포트포워딩 시작 ==="
-echo "ArgoCD:     https://localhost:30080 (NodePort, 포트포워딩 불필요)"
-echo "Grafana:    http://localhost:3000"
-echo "Prometheus: http://localhost:9090"
+echo "ArgoCD:      http://localhost:30080 (NodePort, 포트포워딩 불필요)"
+echo "Grafana:     http://localhost:3000"
+echo "Prometheus:  http://localhost:9090"
 echo "goti-server: http://localhost:8080"
 echo ""
 echo "종료: Ctrl+C"

--- a/scripts/port-forward.sh
+++ b/scripts/port-forward.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "=== 포트포워딩 시작 ==="
+echo "ArgoCD:     https://localhost:30080 (NodePort, 포트포워딩 불필요)"
+echo "Grafana:    http://localhost:3000"
+echo "Prometheus: http://localhost:9090"
+echo "goti-server: http://localhost:8080"
+echo ""
+echo "종료: Ctrl+C"
+echo ""
+
+# Background port-forwards
+kubectl port-forward -n monitoring svc/kube-prometheus-stack-grafana 3000:80 &
+kubectl port-forward -n monitoring svc/kube-prometheus-stack-prometheus 9090:9090 &
+kubectl port-forward -n goti svc/goti-server 8080:8080 &
+
+# Wait for all background processes
+wait

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -3,13 +3,13 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"
-CLUSTER_NAME="goti-dev"
-ARGOCD_NAMESPACE="argocd"
+CLUSTER_NAME="${CLUSTER_NAME:-goti-dev}"
+ARGOCD_NAMESPACE="${ARGOCD_NAMESPACE:-argocd}"
 
 echo "=== Goti Dev 환경 셋업 시작 ==="
 
 # 1. Kind 클러스터 생성
-echo "[1/5] Kind 클러스터 생성..."
+echo "[1/4] Kind 클러스터 생성..."
 if kind get clusters 2>/dev/null | grep -q "^${CLUSTER_NAME}$"; then
   echo "  클러스터 '${CLUSTER_NAME}'가 이미 존재합니다. 건너뜁니다."
 else
@@ -17,10 +17,10 @@ else
   echo "  클러스터 생성 완료"
 fi
 
-# 2. Istio namespace 생성
-echo "[2/5] 네임스페이스 생성..."
+# 2. 네임스페이스 생성
+echo "[2/4] 네임스페이스 생성..."
 kubectl create namespace istio-system --dry-run=client -o yaml | kubectl apply -f -
-kubectl create namespace ${ARGOCD_NAMESPACE} --dry-run=client -o yaml | kubectl apply -f -
+kubectl create namespace "${ARGOCD_NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
 kubectl create namespace goti --dry-run=client -o yaml | kubectl apply -f -
 kubectl create namespace monitoring --dry-run=client -o yaml | kubectl apply -f -
 
@@ -28,33 +28,30 @@ kubectl create namespace monitoring --dry-run=client -o yaml | kubectl apply -f 
 kubectl label namespace goti istio-injection=enabled --overwrite
 
 # 3. ArgoCD Helm 설치
-echo "[3/5] ArgoCD 설치..."
-cd "${ROOT_DIR}/infrastructure/argocd"
-helm dependency build
-helm upgrade --install argocd . \
-  -n ${ARGOCD_NAMESPACE} \
-  -f values.yaml \
-  -f values-dev.yaml \
-  --wait --timeout 5m
+echo "[3/4] ArgoCD 설치..."
+(
+  cd "${ROOT_DIR}/infrastructure/argocd"
+  helm dependency build
+  helm upgrade --install argocd . \
+    -n "${ARGOCD_NAMESPACE}" \
+    -f values.yaml \
+    -f values-dev.yaml \
+    --wait --timeout 5m
+)
 
-# 4. ArgoCD 준비 대기
-echo "[4/5] ArgoCD 준비 대기..."
-kubectl wait --for=condition=available deployment/argocd-server \
-  -n ${ARGOCD_NAMESPACE} --timeout=300s
-
-# 5. 부트스트랩 적용
-echo "[5/5] 부트스트랩 매니페스트 적용..."
+# 4. 부트스트랩 적용
+echo "[4/4] 부트스트랩 매니페스트 적용..."
 kubectl apply -f "${ROOT_DIR}/clusters/dev/bootstrap/"
 
-# ArgoCD 초기 비밀번호 출력
+# ArgoCD 접속 정보 출력
 echo ""
 echo "=== 셋업 완료! ==="
 echo ""
 echo "ArgoCD 접속 정보:"
 echo "  URL: http://localhost:30080"
-ARGOCD_PASSWORD=$(kubectl -n ${ARGOCD_NAMESPACE} get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" 2>/dev/null | base64 -d || echo "비밀번호를 가져올 수 없습니다")
 echo "  Username: admin"
-echo "  Password: ${ARGOCD_PASSWORD}"
+echo "  Password: 아래 명령으로 확인"
+echo "    kubectl -n ${ARGOCD_NAMESPACE} get secret argocd-initial-admin-secret -o jsonpath='{.data.password}' | base64 -d"
 echo ""
 echo "포트포워딩: make port-forward"
 echo "상태 확인: make status"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+CLUSTER_NAME="goti-dev"
+ARGOCD_NAMESPACE="argocd"
+
+echo "=== Goti Dev 환경 셋업 시작 ==="
+
+# 1. Kind 클러스터 생성
+echo "[1/5] Kind 클러스터 생성..."
+if kind get clusters 2>/dev/null | grep -q "^${CLUSTER_NAME}$"; then
+  echo "  클러스터 '${CLUSTER_NAME}'가 이미 존재합니다. 건너뜁니다."
+else
+  kind create cluster --config "${ROOT_DIR}/kind/cluster-config.yaml" --wait 60s
+  echo "  클러스터 생성 완료"
+fi
+
+# 2. Istio namespace 생성
+echo "[2/5] 네임스페이스 생성..."
+kubectl create namespace istio-system --dry-run=client -o yaml | kubectl apply -f -
+kubectl create namespace ${ARGOCD_NAMESPACE} --dry-run=client -o yaml | kubectl apply -f -
+kubectl create namespace goti --dry-run=client -o yaml | kubectl apply -f -
+kubectl create namespace monitoring --dry-run=client -o yaml | kubectl apply -f -
+
+# goti namespace에 istio sidecar injection 활성화
+kubectl label namespace goti istio-injection=enabled --overwrite
+
+# 3. ArgoCD Helm 설치
+echo "[3/5] ArgoCD 설치..."
+cd "${ROOT_DIR}/infrastructure/argocd"
+helm dependency build
+helm upgrade --install argocd . \
+  -n ${ARGOCD_NAMESPACE} \
+  -f values.yaml \
+  -f values-dev.yaml \
+  --wait --timeout 5m
+
+# 4. ArgoCD 준비 대기
+echo "[4/5] ArgoCD 준비 대기..."
+kubectl wait --for=condition=available deployment/argocd-server \
+  -n ${ARGOCD_NAMESPACE} --timeout=300s
+
+# 5. 부트스트랩 적용
+echo "[5/5] 부트스트랩 매니페스트 적용..."
+kubectl apply -f "${ROOT_DIR}/clusters/dev/bootstrap/"
+
+# ArgoCD 초기 비밀번호 출력
+echo ""
+echo "=== 셋업 완료! ==="
+echo ""
+echo "ArgoCD 접속 정보:"
+echo "  URL: http://localhost:30080"
+ARGOCD_PASSWORD=$(kubectl -n ${ARGOCD_NAMESPACE} get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" 2>/dev/null | base64 -d || echo "비밀번호를 가져올 수 없습니다")
+echo "  Username: admin"
+echo "  Password: ${ARGOCD_PASSWORD}"
+echo ""
+echo "포트포워딩: make port-forward"
+echo "상태 확인: make status"

--- a/scripts/teardown.sh
+++ b/scripts/teardown.sh
@@ -1,10 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-CLUSTER_NAME="goti-dev"
+CLUSTER_NAME="${CLUSTER_NAME:-goti-dev}"
 
 echo "=== Goti Dev 환경 삭제 ==="
-read -p "정말 '${CLUSTER_NAME}' 클러스터를 삭제하시겠습니까? (y/N): " confirm
+
+if [[ "${1:-}" == "--force" || "${1:-}" == "-y" ]]; then
+  confirm="y"
+else
+  read -p "정말 '${CLUSTER_NAME}' 클러스터를 삭제하시겠습니까? (y/N): " confirm
+fi
+
 if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
   echo "취소되었습니다."
   exit 0

--- a/scripts/teardown.sh
+++ b/scripts/teardown.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CLUSTER_NAME="goti-dev"
+
+echo "=== Goti Dev 환경 삭제 ==="
+read -p "정말 '${CLUSTER_NAME}' 클러스터를 삭제하시겠습니까? (y/N): " confirm
+if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
+  echo "취소되었습니다."
+  exit 0
+fi
+
+kind delete cluster --name "${CLUSTER_NAME}"
+echo "클러스터 삭제 완료"


### PR DESCRIPTION
## Summary
- `make up` 원커맨드로 Kind 클러스터 생성 → ArgoCD 설치 → 전체 스택 부트스트랩
- `make down/port-forward/status/lint/validate/clean` 유틸리티 타겟 제공
- README.md: 전제조건, 빠른 시작, 디렉토리 구조, 아키텍처, 트러블슈팅 가이드

## Test plan
- [ ] Ubuntu dev PC에서 `make up` → 3노드 클러스터 + ArgoCD UI 접속 확인
- [ ] `make port-forward` → Grafana/Prometheus/goti-server 접속 확인
- [ ] `make lint` / `make validate` → Helm 검증 통과
- [ ] `make down` → 클러스터 정상 삭제

Closes #9