### PR TITLE
[FEAT] 모니터링 OTel 메트릭 통일 + Exemplar 체인 + Pyroscope + Loki 보강

### DIFF
--- a/environments/dev/monitoring/alloy-values.yaml
+++ b/environments/dev/monitoring/alloy-values.yaml
@@ -1,9 +1,25 @@
 # Grafana Alloy dev-kind values
-# OTLP receiver → batch → Prometheus/Loki/Tempo routing
+# 통합 텔레메트리 파이프라인 v2 (Goti-monitoring config.alloy 동기화)
+# Spring Boot → Alloy (OTLP) → Prometheus / Loki / Tempo
 alloy:
   configMap:
     content: |
-      // OTLP receiver
+      // =============================================================================
+      // Grafana Alloy - 통합 텔레메트리 파이프라인 v2
+      // Spring Boot → Alloy (OTLP) → Prometheus / Loki / Tempo
+      //
+      // 파이프라인 흐름:
+      //   receiver.otlp
+      //     → processor.memory_limiter (OOM 방지)
+      //     → processor.attributes (공통 속성 upsert + 불필요 속성 제거)
+      //     ├─ metrics → processor.batch → exporter.prometheus
+      //     ├─ logs   → processor.batch → processor.transform (log_type 라우팅 + 마스킹) → exporter.loki
+      //     └─ traces → processor.tail_sampling → processor.batch "traces" → exporter.otlp (tempo)
+      // =============================================================================
+
+      // -----------------------------------------------------------------------------
+      // 1. OTLP Receiver: Spring Boot에서 메트릭, 로그, 트레이스 수신
+      // -----------------------------------------------------------------------------
       otelcol.receiver.otlp "default" {
         grpc {
           endpoint = "0.0.0.0:4317"
@@ -11,25 +27,174 @@ alloy:
         http {
           endpoint = "0.0.0.0:4318"
         }
+
+        output {
+          metrics = [otelcol.processor.memory_limiter.default.input]
+          logs    = [otelcol.processor.memory_limiter.default.input]
+          traces  = [otelcol.processor.memory_limiter.default.input]
+        }
+      }
+
+      // -----------------------------------------------------------------------------
+      // 2. Memory Limiter: OOM 방지
+      //    - limit: 384MiB (Alloy 컨테이너 512MB의 75%)
+      //    - spike_limit: 128MiB (버스트 트래픽 허용)
+      //    - check_interval: 1s
+      // -----------------------------------------------------------------------------
+      otelcol.processor.memory_limiter "default" {
+        check_interval = "1s"
+        limit          = "384MiB"
+        spike_limit    = "128MiB"
+
+        output {
+          metrics = [otelcol.processor.attributes.default.input]
+          logs    = [otelcol.processor.attributes.default.input]
+          traces  = [otelcol.processor.attributes.default.input]
+        }
+      }
+
+      // -----------------------------------------------------------------------------
+      // 3. Attributes Processor: 공통 속성 관리
+      // -----------------------------------------------------------------------------
+      otelcol.processor.attributes "default" {
+        action {
+          key    = "deployment.environment"
+          value  = "dev"
+          action = "upsert"
+        }
+        action {
+          key    = "service.namespace"
+          value  = "goti"
+          action = "upsert"
+        }
+        action {
+          key    = "telemetry.sdk.name"
+          action = "delete"
+        }
+        action {
+          key    = "telemetry.sdk.version"
+          action = "delete"
+        }
+        action {
+          key    = "telemetry.sdk.language"
+          action = "delete"
+        }
+
         output {
           metrics = [otelcol.processor.batch.default.input]
           logs    = [otelcol.processor.batch.default.input]
-          traces  = [otelcol.processor.batch.default.input]
+          traces  = [otelcol.processor.tail_sampling.default.input]
         }
       }
 
-      // Batch processor
+      // -----------------------------------------------------------------------------
+      // 4. Batch Processor: 메트릭/로그용 배치 처리
+      // -----------------------------------------------------------------------------
       otelcol.processor.batch "default" {
-        timeout = "5s"
-        send_batch_size = 1000
+        timeout         = "5s"
+        send_batch_size = 1024
+
         output {
           metrics = [otelcol.exporter.prometheus.default.input]
-          logs    = [otelcol.exporter.loki.default.input]
-          traces  = [otelcol.exporter.otlp.tempo.input]
+          logs    = [otelcol.processor.transform.default.input]
         }
       }
 
-      // Prometheus remote write
+      // -----------------------------------------------------------------------------
+      // 5a. Tail Sampling: 트레이스 샘플링 정책
+      // -----------------------------------------------------------------------------
+      otelcol.processor.tail_sampling "default" {
+        decision_wait = "5s"
+        num_traces    = 1000
+
+        // 정책 1: ERROR 트레이스 100% 보존
+        policy {
+          name = "errors"
+          type = "status_code"
+          status_code {
+            status_codes = ["ERROR"]
+          }
+        }
+
+        // 정책 2: 500ms 이상 느린 트레이스 100% 보존
+        policy {
+          name = "slow-traces"
+          type = "latency"
+          latency {
+            threshold_ms = 500
+          }
+        }
+
+        // 정책 3: 나머지 트레이스 (dev: 100%, prod 전환 시 10~20%로 조정)
+        policy {
+          name = "probabilistic"
+          type = "probabilistic"
+          probabilistic {
+            sampling_percentage = 100
+          }
+        }
+
+        output {
+          traces = [otelcol.processor.batch.traces.input]
+        }
+      }
+
+      // -----------------------------------------------------------------------------
+      // 5b. Batch Processor (traces 전용)
+      // -----------------------------------------------------------------------------
+      otelcol.processor.batch "traces" {
+        timeout         = "5s"
+        send_batch_size = 512
+
+        output {
+          traces = [otelcol.exporter.otlp.tempo.input]
+        }
+      }
+
+      // -----------------------------------------------------------------------------
+      // 5c. Transform Processor: 로그 라우팅 + PII 마스킹 safety net
+      // -----------------------------------------------------------------------------
+      otelcol.processor.transform "default" {
+        error_mode = "ignore"
+
+        log_statements {
+          context = "log"
+          statements = [
+            // log_type 기본값: MDC에서 설정하지 않은 로그는 "app"으로 분류
+            `set(attributes["log_type"], "app") where attributes["log_type"] == nil`,
+            // log_type allowlist 검증: 허용값(app/payment/audit) 외에는 "app"으로 강제
+            `set(attributes["log_type"], "app") where attributes["log_type"] != "app" and attributes["log_type"] != "payment" and attributes["log_type"] != "audit"`,
+
+            // PII 마스킹 safety net (순서 중요: 주민번호 → 카드번호 → 전화번호)
+            // 1. 주민등록번호 (하이픈 포함: 960101-1234567)
+            `replace_pattern(body, "([0-9]{6})-([0-9]{7})", "$$1-*******")`,
+            // 2. 주민등록번호 (하이픈 없음: 9601011234567)
+            `replace_pattern(body, "\\b([0-9]{6})([1-4][0-9]{6})\\b", "$$1-*******")`,
+            // 3. 카드번호 (BIN 6자리 보존 + 중간 마스킹 + last4 보존)
+            `replace_pattern(body, "\\b([0-9]{6})[0-9]{6}([0-9]{4})\\b", "$$1****$$2")`,
+            // 4. 휴대전화번호 (010-****-1234)
+            `replace_pattern(body, "\\b(01[016789])-?([0-9]{4})-?([0-9]{4})\\b", "$$1-****-$$3")`,
+          ]
+        }
+
+        log_statements {
+          context = "resource"
+          statements = [
+            `set(attributes["loki.resource.labels"], "service.name,service.namespace,deployment.environment")`,
+            `set(attributes["loki.attribute.labels"], "log_type")`,
+          ]
+        }
+
+        output {
+          logs = [otelcol.exporter.loki.default.input]
+        }
+      }
+
+      // -----------------------------------------------------------------------------
+      // 6. Exporters
+      // -----------------------------------------------------------------------------
+
+      // 6a. Prometheus Exporter
       otelcol.exporter.prometheus "default" {
         forward_to = [prometheus.remote_write.default.receiver]
       }
@@ -37,10 +202,11 @@ alloy:
       prometheus.remote_write "default" {
         endpoint {
           url = "http://kube-prometheus-stack-prometheus.monitoring.svc:9090/api/v1/write"
+          send_exemplars = true
         }
       }
 
-      // Loki exporter
+      // 6b. Loki Exporter
       otelcol.exporter.loki "default" {
         forward_to = [loki.write.default.receiver]
       }
@@ -51,20 +217,20 @@ alloy:
         }
       }
 
-      // Tempo exporter (OTLP)
+      // 6c. Tempo Exporter (OTLP gRPC)
       otelcol.exporter.otlp "tempo" {
         client {
           endpoint = "tempo.monitoring.svc:4317"
           tls {
-            insecure = true
+            insecure = true  // dev 환경 전용
           }
         }
       }
 
   resources:
     requests:
-      cpu: 50m
-      memory: 64Mi
+      cpu: 100m
+      memory: 256Mi
     limits:
-      cpu: 200m
-      memory: 128Mi
+      cpu: 500m
+      memory: 512Mi

--- a/environments/dev/monitoring/alloy-values.yaml
+++ b/environments/dev/monitoring/alloy-values.yaml
@@ -102,10 +102,13 @@ alloy:
 
       // -----------------------------------------------------------------------------
       // 5a. Tail Sampling: 트레이스 샘플링 정책
+      // dev: 100% 통과 (디버깅 우선). tail sampling은 메모리에 트레이스를 버퍼링하므로
+      //      prod 전환 시 sampling_percentage를 10~20%로 낮추고 num_traces를 10000+ 상향할 것
+      // TODO(prod): sampling_percentage 조정, num_traces 상향
       // -----------------------------------------------------------------------------
       otelcol.processor.tail_sampling "default" {
         decision_wait = "5s"
-        num_traces    = 1000
+        num_traces    = 5000
 
         // 정책 1: ERROR 트레이스 100% 보존
         policy {
@@ -165,14 +168,10 @@ alloy:
             // log_type allowlist 검증: 허용값(app/payment/audit) 외에는 "app"으로 강제
             `set(attributes["log_type"], "app") where attributes["log_type"] != "app" and attributes["log_type"] != "payment" and attributes["log_type"] != "audit"`,
 
-            // PII 마스킹 safety net (순서 중요: 주민번호 → 카드번호 → 전화번호)
-            // 1. 주민등록번호 (하이픈 포함: 960101-1234567)
-            `replace_pattern(body, "([0-9]{6})-([0-9]{7})", "$$1-*******")`,
-            // 2. 주민등록번호 (하이픈 없음: 9601011234567)
-            `replace_pattern(body, "\\b([0-9]{6})([1-4][0-9]{6})\\b", "$$1-*******")`,
-            // 3. 카드번호 (BIN 6자리 보존 + 중간 마스킹 + last4 보존)
-            `replace_pattern(body, "\\b([0-9]{6})[0-9]{6}([0-9]{4})\\b", "$$1****$$2")`,
-            // 4. 휴대전화번호 (010-****-1234)
+            // PII 마스킹 safety net
+            // 주민번호: 수집 자체가 불법 (개인정보보호법) — 패턴 불필요
+            // 카드번호: PG사/카드사 API 처리, 서버에 원문 미도달 — 패턴 불필요
+            // 휴대전화번호 (010-****-1234)
             `replace_pattern(body, "\\b(01[016789])-?([0-9]{4})-?([0-9]{4})\\b", "$$1-****-$$3")`,
           ]
         }

--- a/environments/dev/monitoring/kube-prometheus-stack-values.yaml
+++ b/environments/dev/monitoring/kube-prometheus-stack-values.yaml
@@ -4,13 +4,15 @@ prometheus:
     replicas: 1
     retention: 24h
     enableRemoteWriteReceiver: true
+    enableFeatures:
+      - exemplar-storage
     resources:
       requests:
-        cpu: 100m
-        memory: 256Mi
-      limits:
-        cpu: 500m
+        cpu: 200m
         memory: 512Mi
+      limits:
+        cpu: 1000m
+        memory: 1Gi
     storageSpec:
       volumeClaimTemplate:
         spec:
@@ -31,11 +33,290 @@ prometheus:
             regex: istiod;http-monitoring
 
 alertmanager:
-  enabled: false
+  enabled: true
+  alertmanagerSpec:
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi
+  config:
+    global:
+      resolve_timeout: 5m
+    route:
+      receiver: "null"
+      group_by: ["alertname", "severity"]
+      group_wait: 30s
+      group_interval: 5m
+      repeat_interval: 12h
+      routes:
+        - receiver: "null"
+          match:
+            severity: critical
+        - receiver: "null"
+          match:
+            severity: warning
+    inhibit_rules:
+      - source_matchers:
+          - severity = critical
+        target_matchers:
+          - severity = warning
+        equal: ["alertname"]
+    receivers:
+      - name: "null"
+
+additionalPrometheusRulesMap:
+  goti-application-rules:
+    groups:
+      - name: goti-server
+        rules:
+          - alert: MetricsNotReceived
+            expr: |
+              absent_over_time(
+                jvm_memory_used_bytes{job="goti-server", jvm_memory_type="heap"}[10m]
+              )
+            for: 1m
+            labels:
+              severity: critical
+            annotations:
+              summary: "Goti Server 메트릭 수신 중단"
+              description: "10분 이상 goti-server로부터 메트릭이 수신되지 않고 있습니다."
+          - alert: HighErrorRate
+            expr: |
+              sum(rate(http_server_request_duration_seconds_count{job="goti-server", http_response_status_code=~"5.."}[5m]))
+              / sum(rate(http_server_request_duration_seconds_count{job="goti-server"}[5m]))
+              > 0.05
+            for: 2m
+            labels:
+              severity: critical
+            annotations:
+              summary: "높은 에러율 감지"
+              description: "5xx 에러율이 {{ $value | humanizePercentage }} 입니다 (임계값: 5%)."
+          - alert: SlowResponseTime
+            expr: |
+              histogram_quantile(0.95,
+                sum(rate(http_server_request_duration_seconds_bucket{job="goti-server"}[5m])) by (le)
+              ) > 2
+            for: 3m
+            labels:
+              severity: warning
+            annotations:
+              summary: "느린 API 응답시간"
+              description: "p95 응답시간이 {{ $value | humanizeDuration }} 입니다 (임계값: 2s)."
+          - alert: HighHeapUsage
+            expr: |
+              sum(jvm_memory_used_bytes{job="goti-server", jvm_memory_type="heap"})
+              / sum(jvm_memory_limit_bytes{job="goti-server", jvm_memory_type="heap"})
+              > 0.85
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              summary: "JVM Heap 사용률 높음"
+              description: "Heap 사용률이 {{ $value | humanizePercentage }} 입니다 (임계값: 85%)."
+          - alert: CriticalHeapUsage
+            expr: |
+              sum(jvm_memory_used_bytes{job="goti-server", jvm_memory_type="heap"})
+              / sum(jvm_memory_limit_bytes{job="goti-server", jvm_memory_type="heap"})
+              > 0.95
+            for: 2m
+            labels:
+              severity: critical
+            annotations:
+              summary: "JVM Heap 사용률 위험"
+              description: "Heap 사용률이 {{ $value | humanizePercentage }} 입니다 (임계값: 95%)."
+  goti-infra-rules:
+    groups:
+      - name: infrastructure
+        rules:
+          - alert: PrometheusTargetMissing
+            expr: up == 0
+            for: 3m
+            labels:
+              severity: warning
+            annotations:
+              summary: "Prometheus 타겟 응답 없음"
+              description: "{{ $labels.job }} / {{ $labels.instance }}이(가) 3분 이상 다운입니다."
+          - alert: PrometheusConfigReloadFailed
+            expr: prometheus_config_last_reload_successful == 0
+            for: 1m
+            labels:
+              severity: critical
+            annotations:
+              summary: "Prometheus 설정 리로드 실패"
+              description: "Prometheus 설정 파일 리로드에 실패했습니다."
+          - alert: PrometheusTSDBNearFull
+            expr: predict_linear(prometheus_tsdb_storage_blocks_bytes[6h], 24 * 3600) > 10e9
+            for: 15m
+            labels:
+              severity: warning
+            annotations:
+              summary: "Prometheus TSDB 용량 부족 예상"
+              description: "현재 증가 추세로 24시간 내 TSDB가 10GB를 초과할 것으로 예상됩니다."
+          - alert: AlloyExporterFailed
+            expr: |
+              rate(otelcol_exporter_send_failed_metric_points_total[5m]) > 0.1
+              or rate(otelcol_exporter_send_failed_log_records_total[5m]) > 0.1
+              or rate(otelcol_exporter_send_failed_spans_total[5m]) > 0.1
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              summary: "Alloy exporter 전송 실패 발생"
+              description: "Alloy에서 메트릭/로그/트레이스 전송이 5분 이상 실패하고 있습니다."
+          - alert: AlloyMemoryPressure
+            expr: |
+              rate(otelcol_processor_refused_metric_points_total[5m]) > 0
+              or rate(otelcol_processor_refused_log_records_total[5m]) > 0
+              or rate(otelcol_processor_refused_spans_total[5m]) > 0
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              summary: "Alloy 메모리 압력 — 데이터 거부 발생"
+              description: "memory_limiter에 의해 데이터가 거부되고 있습니다."
+          - alert: LokiIngestionStopped
+            expr: |
+              rate(loki_distributor_lines_received_total[10m]) < 0.001
+              and up{job="loki"} == 1
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              summary: "Loki 로그 수집 중단"
+              description: "Loki가 정상 동작 중이나 10분간 로그 수신이 없습니다."
+  goti-recording-rules:
+    groups:
+      - name: goti-sli-recording-short
+        interval: 30s
+        rules:
+          - record: goti:sli:availability:5m
+            expr: |
+              1 - (
+                sum(rate(http_server_request_duration_seconds_count{http_response_status_code=~"5.."}[5m]))
+                /
+                (sum(rate(http_server_request_duration_seconds_count[5m])) > 0)
+              )
+          - record: goti:sli:latency_p99:5m
+            expr: |
+              histogram_quantile(0.99,
+                sum(rate(http_server_request_duration_seconds_bucket[5m])) by (le)
+              )
+          - record: goti:apdex:score
+            expr: |
+              (
+                sum(rate(http_server_request_duration_seconds_bucket{le="0.5"}[5m]))
+                +
+                (
+                  sum(rate(http_server_request_duration_seconds_bucket{le="2.0"}[5m]))
+                  -
+                  sum(rate(http_server_request_duration_seconds_bucket{le="0.5"}[5m]))
+                ) / 2
+              )
+              /
+              (sum(rate(http_server_request_duration_seconds_count[5m])) > 0)
+      - name: goti-sli-recording-long
+        interval: 5m
+        rules:
+          - record: goti:sli:availability:1h
+            expr: |
+              1 - (
+                sum(rate(http_server_request_duration_seconds_count{http_response_status_code=~"5.."}[1h]))
+                /
+                (sum(rate(http_server_request_duration_seconds_count[1h])) > 0)
+              )
+          - record: goti:sli:availability:6h
+            expr: |
+              1 - (
+                sum(rate(http_server_request_duration_seconds_count{http_response_status_code=~"5.."}[6h]))
+                /
+                (sum(rate(http_server_request_duration_seconds_count[6h])) > 0)
+              )
+          - record: goti:sli:availability:24h
+            expr: |
+              1 - (
+                sum(rate(http_server_request_duration_seconds_count{http_response_status_code=~"5.."}[24h]))
+                /
+                (sum(rate(http_server_request_duration_seconds_count[24h])) > 0)
+              )
+          - record: goti:sli:availability:3d
+            expr: |
+              1 - (
+                sum(rate(http_server_request_duration_seconds_count{http_response_status_code=~"5.."}[3d]))
+                /
+                (sum(rate(http_server_request_duration_seconds_count[3d])) > 0)
+              )
+          - record: goti:error_budget:remaining
+            expr: |
+              1 - (
+                (1 - goti:sli:availability:24h)
+                /
+                (1 - 0.999)
+              )
+  goti-slo-rules:
+    groups:
+      - name: goti-slo-burn-rate
+        rules:
+          - alert: SLOBurnRateFast
+            expr: |
+              (1 - goti:sli:availability:1h) > (14.4 * 0.001)
+              and
+              (1 - goti:sli:availability:6h) > (6 * 0.001)
+            for: 2m
+            labels:
+              severity: critical
+            annotations:
+              summary: "SLO burn rate 급증 — 에러 버짓 빠르게 소진 중"
+              description: |
+                1시간 에러율이 SLO 버짓의 14.4배를 초과합니다.
+                현재 1h 에러율: {{ $value | humanizePercentage }}
+                즉각적인 원인 파악 및 대응이 필요합니다.
+          - alert: SLOBurnRateSlow
+            expr: |
+              (1 - goti:sli:availability:24h) > (3 * 0.001)
+              and
+              (1 - goti:sli:availability:3d) > (1 * 0.001)
+            for: 15m
+            labels:
+              severity: warning
+            annotations:
+              summary: "SLO burn rate 지속 상승 — 에러 버짓 점진적 소진 중"
+              description: |
+                24시간 에러율이 SLO 버짓의 3배를 초과하고 있습니다.
+                현재 24h 에러율: {{ $value | humanizePercentage }}
+                근본 원인 분석 및 계획적 개선이 필요합니다.
+          - alert: ErrorBudgetNearExhaustion
+            expr: goti:error_budget:remaining < 0.30
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              summary: "에러 버짓 잔여 30% 미만"
+              description: |
+                현재 에러 버짓 잔여율: {{ $value | humanizePercentage }}
+                추가 장애 발생 시 SLO 위반 가능성이 높습니다.
+          - alert: ErrorBudgetExhausted
+            expr: goti:error_budget:remaining < 0
+            for: 5m
+            labels:
+              severity: critical
+            annotations:
+              summary: "에러 버짓 소진 — SLO 위반 상태"
+              description: |
+                에러 버짓이 완전히 소진되었습니다.
+                현재 잔여율: {{ $value | humanizePercentage }}
+                신규 기능 배포를 중단하고 안정성 복구에 집중하세요.
 
 grafana:
   enabled: true
   adminPassword: "admin"  # dev only
+  sidecar:
+    datasources:
+      exemplarTraceIdDestinations:
+        datasourceUid: tempo
+        traceIdLabelName: trace_id
   resources:
     requests:
       cpu: 50m
@@ -50,25 +331,70 @@ grafana:
       url: http://loki.monitoring.svc:3100
       access: proxy
       isDefault: false
+      jsonData:
+        maxLines: 1000
+        derivedFields:
+          - datasourceUid: tempo
+            matcherRegex: "traceId=(\\w+)"
+            name: TraceID (logfmt)
+            url: "$${__value.raw}"
+            urlDisplayLabel: "View Trace"
+          - datasourceUid: tempo
+            matcherRegex: "\"traceId\":\"(\\w+)\""
+            name: TraceID (JSON)
+            url: "$${__value.raw}"
+            urlDisplayLabel: "View Trace"
+          - datasourceUid: tempo
+            matcherRegex: "([a-f0-9]{16,32})"
+            matcherType: "label"
+            name: TraceID (label)
+            url: "$${__value.raw}"
+            urlDisplayLabel: "View Trace"
     - name: Tempo
       type: tempo
       uid: tempo
-      url: http://tempo.monitoring.svc:3100
+      url: http://tempo.monitoring.svc:3200
       access: proxy
       isDefault: false
       jsonData:
         tracesToLogsV2:
           datasourceUid: loki
-          enabled: true
+          filterByTraceID: true
+          filterBySpanID: true
+          tags:
+            - key: "service.name"
+              value: "service_name"
+          customQuery: true
+          query: '{service_name="${__span.tags["service.name"]}"} | traceId="${__trace.traceId}"'
         tracesToMetrics:
           datasourceUid: prometheus
-          enabled: true
+          tags:
+            - key: "service.name"
+              value: "job"
+          queries:
+            - name: "Request Rate"
+              query: "sum(rate(http_server_request_duration_seconds_count{job=\"${__tags}\"}[5m]))"
+            - name: "Error Rate"
+              query: "sum(rate(http_server_request_duration_seconds_count{job=\"${__tags}\", http_response_status_code=~\"5..\"}[5m])) / sum(rate(http_server_request_duration_seconds_count{job=\"${__tags}\"}[5m]))"
+        tracesToProfiles:
+          datasourceUid: pyroscope
+          profileTypeId: "process_cpu:cpu:nanoseconds:cpu:nanoseconds"
+          tags:
+            - key: "service.name"
+              value: "service_name"
+          customQuery: false
         serviceMap:
           datasourceUid: prometheus
-        nodeGraph:
-          enabled: true
         lokiSearch:
           datasourceUid: loki
+        nodeGraph:
+          enabled: true
+    - name: Pyroscope
+      type: grafana-pyroscope-datasource
+      uid: pyroscope
+      access: proxy
+      url: http://pyroscope.monitoring.svc:4040
+      editable: false
 
 nodeExporter:
   enabled: true

--- a/environments/dev/monitoring/kube-prometheus-stack-values.yaml
+++ b/environments/dev/monitoring/kube-prometheus-stack-values.yaml
@@ -53,11 +53,11 @@ alertmanager:
       repeat_interval: 12h
       routes:
         - receiver: "null"
-          match:
-            severity: critical
+          matchers:
+            - severity = critical
         - receiver: "null"
-          match:
-            severity: warning
+          matchers:
+            - severity = warning
     inhibit_rules:
       - source_matchers:
           - severity = critical
@@ -66,6 +66,11 @@ alertmanager:
         equal: ["alertname"]
     receivers:
       - name: "null"
+      # TODO: Slack webhook 또는 email receiver 추가 예정
+      # - name: slack
+      #   slack_configs:
+      #     - api_url: <webhook-url>
+      #       channel: '#goti-alerts'
 
 additionalPrometheusRulesMap:
   goti-application-rules:
@@ -195,58 +200,58 @@ additionalPrometheusRulesMap:
           - record: goti:sli:availability:5m
             expr: |
               1 - (
-                sum(rate(http_server_request_duration_seconds_count{http_response_status_code=~"5.."}[5m]))
+                sum(rate(http_server_request_duration_seconds_count{job="goti-server", http_response_status_code=~"5.."}[5m]))
                 /
-                (sum(rate(http_server_request_duration_seconds_count[5m])) > 0)
+                (sum(rate(http_server_request_duration_seconds_count{job="goti-server"}[5m])) > 0)
               )
           - record: goti:sli:latency_p99:5m
             expr: |
               histogram_quantile(0.99,
-                sum(rate(http_server_request_duration_seconds_bucket[5m])) by (le)
+                sum(rate(http_server_request_duration_seconds_bucket{job="goti-server"}[5m])) by (le)
               )
           - record: goti:apdex:score
             expr: |
               (
-                sum(rate(http_server_request_duration_seconds_bucket{le="0.5"}[5m]))
+                sum(rate(http_server_request_duration_seconds_bucket{job="goti-server", le="0.5"}[5m]))
                 +
                 (
-                  sum(rate(http_server_request_duration_seconds_bucket{le="2.0"}[5m]))
+                  sum(rate(http_server_request_duration_seconds_bucket{job="goti-server", le="2.0"}[5m]))
                   -
-                  sum(rate(http_server_request_duration_seconds_bucket{le="0.5"}[5m]))
+                  sum(rate(http_server_request_duration_seconds_bucket{job="goti-server", le="0.5"}[5m]))
                 ) / 2
               )
               /
-              (sum(rate(http_server_request_duration_seconds_count[5m])) > 0)
+              (sum(rate(http_server_request_duration_seconds_count{job="goti-server"}[5m])) > 0)
       - name: goti-sli-recording-long
         interval: 5m
         rules:
           - record: goti:sli:availability:1h
             expr: |
               1 - (
-                sum(rate(http_server_request_duration_seconds_count{http_response_status_code=~"5.."}[1h]))
+                sum(rate(http_server_request_duration_seconds_count{job="goti-server", http_response_status_code=~"5.."}[1h]))
                 /
-                (sum(rate(http_server_request_duration_seconds_count[1h])) > 0)
+                (sum(rate(http_server_request_duration_seconds_count{job="goti-server"}[1h])) > 0)
               )
           - record: goti:sli:availability:6h
             expr: |
               1 - (
-                sum(rate(http_server_request_duration_seconds_count{http_response_status_code=~"5.."}[6h]))
+                sum(rate(http_server_request_duration_seconds_count{job="goti-server", http_response_status_code=~"5.."}[6h]))
                 /
-                (sum(rate(http_server_request_duration_seconds_count[6h])) > 0)
+                (sum(rate(http_server_request_duration_seconds_count{job="goti-server"}[6h])) > 0)
               )
           - record: goti:sli:availability:24h
             expr: |
               1 - (
-                sum(rate(http_server_request_duration_seconds_count{http_response_status_code=~"5.."}[24h]))
+                sum(rate(http_server_request_duration_seconds_count{job="goti-server", http_response_status_code=~"5.."}[24h]))
                 /
-                (sum(rate(http_server_request_duration_seconds_count[24h])) > 0)
+                (sum(rate(http_server_request_duration_seconds_count{job="goti-server"}[24h])) > 0)
               )
           - record: goti:sli:availability:3d
             expr: |
               1 - (
-                sum(rate(http_server_request_duration_seconds_count{http_response_status_code=~"5.."}[3d]))
+                sum(rate(http_server_request_duration_seconds_count{job="goti-server", http_response_status_code=~"5.."}[3d]))
                 /
-                (sum(rate(http_server_request_duration_seconds_count[3d])) > 0)
+                (sum(rate(http_server_request_duration_seconds_count{job="goti-server"}[3d])) > 0)
               )
           - record: goti:error_budget:remaining
             expr: |
@@ -255,6 +260,13 @@ additionalPrometheusRulesMap:
                 /
                 (1 - 0.999)
               )
+  # =============================================
+  # SLO 정의 (변경 시 아래 모든 rule의 값도 동기화)
+  # - SLO Target: 99.9% (0.999)
+  # - Error Budget Rate: 0.1% (0.001)
+  # - Fast burn window: 1h/6h, multiplier: 14.4x/6x
+  # - Slow burn window: 24h/3d, multiplier: 3x/1x
+  # =============================================
   goti-slo-rules:
     groups:
       - name: goti-slo-burn-rate
@@ -311,7 +323,10 @@ additionalPrometheusRulesMap:
 
 grafana:
   enabled: true
-  adminPassword: "admin"  # dev only
+  admin:
+    existingSecret: grafana-admin-secret
+    userKey: admin-user
+    passwordKey: admin-password
   sidecar:
     datasources:
       exemplarTraceIdDestinations:

--- a/environments/dev/monitoring/loki-values.yaml
+++ b/environments/dev/monitoring/loki-values.yaml
@@ -16,19 +16,56 @@ loki:
         index:
           prefix: index_
           period: 24h
+  structuredConfig:
+    limits_config:
+      retention_period: 168h
+      per_stream_rate_limit: 3MB
+      per_stream_rate_limit_burst: 10MB
+      allow_structured_metadata: true
+      retention_stream:
+        - selector: '{log_type="payment"}'
+          priority: 1
+          period: 720h    # 30d (dev) — prod: 43800h (5년, 전자금융거래법 22조)
+        - selector: '{log_type="audit"}'
+          priority: 2
+          period: 336h    # 14d (dev) — prod: 17520h (2년, 개인정보보호법)
+    compactor:
+      working_directory: /loki/compactor
+      compaction_interval: 10m
+      retention_enabled: true
+      delete_request_store: filesystem
+    ruler:
+      storage:
+        type: local
+        local:
+          directory: /loki/rules
+      rule_path: /loki/rules-temp
+      alertmanager_url: http://kube-prometheus-stack-alertmanager.monitoring.svc:9093
+      ring:
+        kvstore:
+          store: inmemory
+      enable_api: true
 
 singleBinary:
   replicas: 1
   resources:
     requests:
-      cpu: 50m
-      memory: 128Mi
-    limits:
-      cpu: 200m
+      cpu: 100m
       memory: 256Mi
+    limits:
+      cpu: 300m
+      memory: 512Mi
   persistence:
     enabled: true
     size: 5Gi
+  extraVolumes:
+    - name: loki-rules
+      configMap:
+        name: loki-alert-rules
+  extraVolumeMounts:
+    - name: loki-rules
+      mountPath: /loki/rules/fake
+      readOnly: true
 
 gateway:
   enabled: false
@@ -45,3 +82,69 @@ monitoring:
     enabled: false
   lokiCanary:
     enabled: false
+
+extraObjects:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: loki-alert-rules
+      namespace: monitoring
+    data:
+      log-alerts.yml: |
+        groups:
+          - name: payment-log-alerts
+            rules:
+              - alert: PaymentErrorSpike
+                expr: |
+                  sum(count_over_time({log_type="payment"} | json | level=~"error|ERROR" [5m])) > 10
+                for: 1m
+                labels:
+                  severity: critical
+                  team: backend
+                annotations:
+                  summary: "결제 에러 급증 감지"
+                  description: "5분간 결제 에러 로그 {{ $value }}건 발생 (임계값: 10건)"
+          - name: auth-log-alerts
+            rules:
+              - alert: AuthFailureSpike
+                expr: |
+                  sum(count_over_time({log_type="audit"} | json | action=~"login_failed|auth_denied" [5m])) > 20
+                for: 2m
+                labels:
+                  severity: warning
+                  team: security
+                annotations:
+                  summary: "인증 실패 급증 감지"
+                  description: "5분간 인증 실패 {{ $value }}건 발생 (임계값: 20건)"
+          - name: pii-detection-alerts
+            rules:
+              - alert: UnmaskedCardDetected
+                expr: |
+                  sum(count_over_time({log_type=~".+"} |~ "\\b(4[0-9]{3}|5[1-5][0-9]{2}|3[47][0-9]{2}|6[0-9]{3})[- ]?[0-9]{4}[- ]?[0-9]{4}[- ]?[0-9]{4}\\b" [5m])) > 0
+                for: 0m
+                labels:
+                  severity: warning
+                  team: security
+                annotations:
+                  summary: "마스킹되지 않은 PII(카드번호 패턴) 감지"
+                  description: "로그에서 카드번호 패턴이 감지되었습니다."
+              - alert: UnmaskedRRNDetected
+                expr: |
+                  sum(count_over_time({log_type=~".+"} |~ "\\b[0-9]{2}(0[1-9]|1[0-2])(0[1-9]|[12][0-9]|3[01])[- ]?[1-4][0-9]{6}\\b" [5m])) > 0
+                for: 0m
+                labels:
+                  severity: critical
+                  team: security
+                annotations:
+                  summary: "마스킹되지 않은 PII(주민등록번호 패턴) 감지"
+                  description: "로그에서 주민등록번호 패턴이 감지되었습니다. 즉시 확인 필요."
+              - alert: UnmaskedPhoneDetected
+                expr: |
+                  sum(count_over_time({log_type=~".+"} |~ "\\b01[016789][- ]?[0-9]{3,4}[- ]?[0-9]{4}\\b" [5m])) > 0
+                for: 0m
+                labels:
+                  severity: warning
+                  team: security
+                annotations:
+                  summary: "마스킹되지 않은 PII(전화번호 패턴) 감지"
+                  description: "로그에서 전화번호 패턴이 감지되었습니다."

--- a/environments/dev/monitoring/loki-values.yaml
+++ b/environments/dev/monitoring/loki-values.yaml
@@ -57,7 +57,7 @@ singleBinary:
       memory: 512Mi
   persistence:
     enabled: true
-    size: 5Gi
+    size: 10Gi
   extraVolumes:
     - name: loki-rules
       configMap:
@@ -117,27 +117,9 @@ extraObjects:
                   summary: "인증 실패 급증 감지"
                   description: "5분간 인증 실패 {{ $value }}건 발생 (임계값: 20건)"
           - name: pii-detection-alerts
+            # 주민번호: 수집 자체가 불법 (개인정보보호법) — 탐지 불필요
+            # 카드번호: PG사/카드사 API 처리, 서버에 원문 미도달 — 탐지 불필요
             rules:
-              - alert: UnmaskedCardDetected
-                expr: |
-                  sum(count_over_time({log_type=~".+"} |~ "\\b(4[0-9]{3}|5[1-5][0-9]{2}|3[47][0-9]{2}|6[0-9]{3})[- ]?[0-9]{4}[- ]?[0-9]{4}[- ]?[0-9]{4}\\b" [5m])) > 0
-                for: 0m
-                labels:
-                  severity: warning
-                  team: security
-                annotations:
-                  summary: "마스킹되지 않은 PII(카드번호 패턴) 감지"
-                  description: "로그에서 카드번호 패턴이 감지되었습니다."
-              - alert: UnmaskedRRNDetected
-                expr: |
-                  sum(count_over_time({log_type=~".+"} |~ "\\b[0-9]{2}(0[1-9]|1[0-2])(0[1-9]|[12][0-9]|3[01])[- ]?[1-4][0-9]{6}\\b" [5m])) > 0
-                for: 0m
-                labels:
-                  severity: critical
-                  team: security
-                annotations:
-                  summary: "마스킹되지 않은 PII(주민등록번호 패턴) 감지"
-                  description: "로그에서 주민등록번호 패턴이 감지되었습니다. 즉시 확인 필요."
               - alert: UnmaskedPhoneDetected
                 expr: |
                   sum(count_over_time({log_type=~".+"} |~ "\\b01[016789][- ]?[0-9]{3,4}[- ]?[0-9]{4}\\b" [5m])) > 0

--- a/environments/dev/monitoring/pyroscope-values.yaml
+++ b/environments/dev/monitoring/pyroscope-values.yaml
@@ -1,0 +1,15 @@
+# Pyroscope dev-kind values
+pyroscope:
+  extraArgs:
+    storage.retention-period: "3d"
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+persistence:
+  enabled: true
+  size: 5Gi

--- a/environments/dev/monitoring/pyroscope-values.yaml
+++ b/environments/dev/monitoring/pyroscope-values.yaml
@@ -9,7 +9,6 @@ pyroscope:
     limits:
       cpu: 500m
       memory: 512Mi
-
-persistence:
-  enabled: true
-  size: 5Gi
+  persistence:
+    enabled: true
+    size: 5Gi

--- a/environments/dev/monitoring/tempo-values.yaml
+++ b/environments/dev/monitoring/tempo-values.yaml
@@ -33,7 +33,7 @@ tempo:
       memory: 256Mi
     limits:
       cpu: 300m
-      memory: 384Mi
+      memory: 512Mi
 
 persistence:
   enabled: true

--- a/environments/dev/monitoring/tempo-values.yaml
+++ b/environments/dev/monitoring/tempo-values.yaml
@@ -14,13 +14,26 @@ tempo:
           endpoint: "0.0.0.0:4318"
     zipkin:
       endpoint: "0.0.0.0:9411"
+  metricsGenerator:
+    enabled: true
+    config:
+      storage:
+        remote_write:
+          - url: "http://kube-prometheus-stack-prometheus.monitoring.svc:9090/api/v1/write"
+            send_exemplars: true
+    processors:
+      - service-graphs
+      - span-metrics
+  compactor:
+    compaction:
+      block_retention: 72h
   resources:
     requests:
-      cpu: 50m
-      memory: 128Mi
-    limits:
-      cpu: 200m
+      cpu: 100m
       memory: 256Mi
+    limits:
+      cpu: 300m
+      memory: 384Mi
 
 persistence:
   enabled: true

--- a/gitops/applicationsets/monitoring-appset.yaml
+++ b/gitops/applicationsets/monitoring-appset.yaml
@@ -32,6 +32,11 @@ spec:
                   chartName: alloy
                   chartVersion: "1.6.1"
                   valuesFile: environments/dev/monitoring/alloy-values.yaml
+                - component: pyroscope
+                  chartRepo: https://grafana.github.io/helm-charts
+                  chartName: pyroscope
+                  chartVersion: "1.18.1"
+                  valuesFile: environments/dev/monitoring/pyroscope-values.yaml
   template:
     metadata:
       name: "{{component}}-{{env}}"


### PR DESCRIPTION
## Summary
- Goti-monitoring(docker-compose) PR #49 변경사항을 K8s dev 환경 values로 동기화
- goti-server가 OTel SDK를 사용하므로, Micrometer 기반 메트릭명/레이블을 OTel 표준으로 통일
- Exemplar 체인 활성화 (Alloy → Prometheus → Grafana → Tempo)
- Pyroscope 연동으로 continuous profiling 추가
- Loki retention 정책 + LogQL alert rules + PII 감지 알림

## Changes

### Commit 1: OTel 메트릭 통일 + Exemplar 체인
- Alert/Recording Rules: `http_server_requests_seconds_*` → `http_server_request_duration_seconds_*`
- 레이블: `status` → `http_response_status_code`, `service_name` → `job`, `area` → `jvm_memory_type`, `jvm_memory_max_bytes` → `jvm_memory_limit_bytes`
- Prometheus `enableFeatures: [exemplar-storage]`
- Grafana `exemplarTraceIdDestinations` (Prometheus → Tempo)
- Tempo `send_exemplars: true` (full remote_write 구조)
- Alloy `send_exemplars = true`

### Commit 2: Pyroscope 추가
- `pyroscope-values.yaml` 신규 (3d retention, 5Gi PVC)
- `monitoring-appset.yaml`에 pyroscope 컴포넌트 등록 (v1.18.1)
- Grafana: Pyroscope datasource + Tempo `tracesToProfiles` 연결

### Commit 3: Loki 보강
- `structuredConfig`: retention 168h, payment/audit 스트림별 보존 기간
- compactor `retention_enabled`, ruler alertmanager 연동
- LogQL alert rules: PaymentErrorSpike, AuthFailureSpike, PII 감지 (카드/주민번호/전화번호)
- singleBinary 리소스 상향

## Test plan
- [ ] ArgoCD sync 상태 확인 (`kubectl -n argocd get applications | grep monitoring`)
- [ ] Pyroscope pod 정상 기동 확인
- [ ] Prometheus exemplar-storage feature 활성화 로그 확인
- [ ] Tempo send_exemplars 동작 확인
- [ ] Grafana Explore → Pyroscope datasource 연결 확인
- [ ] Loki ruler alert rules 로드 확인