### PR TITLE
[FEAT] Monitoring Istio Gateway 추가 — kind.go-ti.shop 외부 접근

### DIFF
--- a/environments/dev/monitoring/kube-prometheus-stack-values.yaml
+++ b/environments/dev/monitoring/kube-prometheus-stack-values.yaml
@@ -4,6 +4,8 @@ prometheus:
     replicas: 1
     retention: 24h
     enableRemoteWriteReceiver: true
+    externalUrl: "/prometheus"
+    routePrefix: "/prometheus"
     resources:
       requests:
         cpu: 100m
@@ -36,6 +38,10 @@ alertmanager:
 grafana:
   enabled: true
   adminPassword: "admin"  # dev only
+  grafana.ini:
+    server:
+      root_url: "https://kind.go-ti.shop/grafana/"
+      serve_from_sub_path: true
   resources:
     requests:
       cpu: 50m

--- a/environments/dev/monitoring/monitoring-gateway.yaml
+++ b/environments/dev/monitoring/monitoring-gateway.yaml
@@ -1,0 +1,45 @@
+# Monitoring Istio Gateway + VirtualService
+# CloudFront → kind.go-ti.shop → Kind PC(31080) → Istio Gateway → monitoring 서비스
+apiVersion: networking.istio.io/v1
+kind: Gateway
+metadata:
+  name: monitoring-gateway
+  namespace: monitoring
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+    - port:
+        number: 80
+        name: http
+        protocol: HTTP
+      hosts:
+        - "kind.go-ti.shop"
+---
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: monitoring-routes
+  namespace: monitoring
+spec:
+  hosts:
+    - "kind.go-ti.shop"
+  gateways:
+    - monitoring-gateway
+  http:
+    - match:
+        - uri:
+            prefix: /grafana
+      route:
+        - destination:
+            host: kube-prometheus-stack-grafana.monitoring.svc.cluster.local
+            port:
+              number: 80
+    - match:
+        - uri:
+            prefix: /prometheus
+      route:
+        - destination:
+            host: kube-prometheus-stack-prometheus.monitoring.svc.cluster.local
+            port:
+              number: 9090

--- a/environments/dev/monitoring/monitoring-gateway.yaml
+++ b/environments/dev/monitoring/monitoring-gateway.yaml
@@ -1,5 +1,6 @@
 # Monitoring Istio Gateway + VirtualService
 # CloudFront → kind.go-ti.shop → Kind PC(31080) → Istio Gateway → monitoring 서비스
+# CloudFront가 TLS 종단, Gateway↔Origin 구간은 HTTP
 apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
@@ -29,17 +30,29 @@ spec:
   http:
     - match:
         - uri:
-            prefix: /grafana
+            exact: /grafana
+        - uri:
+            prefix: /grafana/
       route:
         - destination:
             host: kube-prometheus-stack-grafana.monitoring.svc.cluster.local
             port:
               number: 80
+      timeout: 30s
+      retries:
+        attempts: 2
+        perTryTimeout: 10s
     - match:
         - uri:
-            prefix: /prometheus
+            exact: /prometheus
+        - uri:
+            prefix: /prometheus/
       route:
         - destination:
             host: kube-prometheus-stack-prometheus.monitoring.svc.cluster.local
             port:
               number: 9090
+      timeout: 30s
+      retries:
+        attempts: 2
+        perTryTimeout: 10s

--- a/gitops/applicationsets/monitoring-gateway-app.yaml
+++ b/gitops/applicationsets/monitoring-gateway-app.yaml
@@ -1,0 +1,30 @@
+# Monitoring Istio Gateway — raw manifest 배포
+# monitoring-appset은 Helm chart 전용이므로 별도 Application으로 관리
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: monitoring-gateway
+  namespace: argocd
+spec:
+  project: monitoring
+  sources:
+    - repoURL: "https://github.com/Team-Ikujo/Goti-k8s.git"
+      targetRevision: main
+      path: "environments/dev/monitoring"
+      directory:
+        include: "monitoring-gateway.yaml"
+  destination:
+    server: "https://kubernetes.default.svc"
+    namespace: monitoring
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    retry:
+      limit: 5
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 3m
+    syncOptions:
+      - CreateNamespace=true

--- a/gitops/applicationsets/monitoring-gateway-app.yaml
+++ b/gitops/applicationsets/monitoring-gateway-app.yaml
@@ -1,5 +1,6 @@
 # Monitoring Istio Gateway — raw manifest 배포
 # monitoring-appset은 Helm chart 전용이므로 별도 Application으로 관리
+# applicationsets/ 디렉토리에 위치하지만 raw YAML 배포용 Application
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -27,4 +28,5 @@ spec:
         factor: 2
         maxDuration: 3m
     syncOptions:
-      - CreateNamespace=true
+      - CreateNamespace=false
+      - ServerSideApply=true

--- a/gitops/projects/monitoring-project.yaml
+++ b/gitops/projects/monitoring-project.yaml
@@ -64,5 +64,9 @@ spec:
       kind: AlertmanagerConfig
     - group: "monitoring.coreos.com"
       kind: ScrapeConfig
+    - group: "networking.istio.io"
+      kind: Gateway
+    - group: "networking.istio.io"
+      kind: VirtualService
     - group: "policy"
       kind: PodDisruptionBudget


### PR DESCRIPTION
## Summary
- Istio Gateway + VirtualService로 monitoring 서비스 외부 라우팅 (`kind.go-ti.shop`)
- CloudFront → Kind PC:31080 → Istio Gateway → Grafana/Prometheus
- PR #15 (monitoring values 동기화) 머지 후 함께 동작

## Changes
- `kube-prometheus-stack-values.yaml`: Grafana `serve_from_sub_path` + Prometheus `externalUrl/routePrefix`
- `monitoring-gateway.yaml`: Istio Gateway + VirtualService (신규)
  - `/grafana` → kube-prometheus-stack-grafana:80
  - `/prometheus` → kube-prometheus-stack-prometheus:9090
- `monitoring-gateway-app.yaml`: ArgoCD Application for raw manifest (신규)
- `monitoring-project.yaml`: Istio Gateway/VirtualService CRD 권한 추가

## 인프라 사전 설정 (콘솔/Kind PC)
- [x] CloudFront distribution 생성 (Origin: Kind PC:31080)
- [x] ACM 와일드카드 인증서 (`*.go-ti.shop`)
- [ ] Route53: `kind.go-ti.shop` → CloudFront Alias
- [ ] Kind PC 방화벽: 31080 인바운드 허용
- [ ] Grafana Secret 생성 (PR #15 연관)

## Test plan
- [ ] ArgoCD sync: monitoring-gateway Application 정상 배포
- [ ] `https://kind.go-ti.shop/grafana` 접속 확인
- [ ] `https://kind.go-ti.shop/prometheus` 접속 확인