### PR TITLE
[FEAT] Kind 클러스터 HA 구성 + 포트 매핑 수정 — 외부 접근 및 트래픽 테스트 대비

### DIFF
--- a/kind/cluster-config.yaml
+++ b/kind/cluster-config.yaml
@@ -1,10 +1,12 @@
 # Goti 로컬 개발 환경 Kind 클러스터 설정
-# control-plane 1개 + worker 2개 구성
+# control-plane 3개 (HA) + worker 4개 (대규모 트래픽 테스트 + HPA 여유)
 # K8s 1.34 고정 — ArgoCD v3.3이 1.35 미지원 (protobuf 이슈 #25767)
+# 호스트 PC: Ryzen 5 7500F 6C/12T, RAM 30GB
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 name: goti-dev
 nodes:
+  # 첫 번째 control-plane에만 extraPortMappings (hostPort 충돌 방지)
   - role: control-plane
     image: kindest/node:v1.34.3
     kubeadmConfigPatches:
@@ -26,6 +28,14 @@ nodes:
       - containerPort: 30080
         hostPort: 30080
         protocol: TCP
+  - role: control-plane
+    image: kindest/node:v1.34.3
+  - role: control-plane
+    image: kindest/node:v1.34.3
+  - role: worker
+    image: kindest/node:v1.34.3
+  - role: worker
+    image: kindest/node:v1.34.3
   - role: worker
     image: kindest/node:v1.34.3
   - role: worker

--- a/kind/cluster-config.yaml
+++ b/kind/cluster-config.yaml
@@ -14,23 +14,17 @@ nodes:
           kubeletExtraArgs:
             node-labels: "ingress-ready=true"
     extraPortMappings:
-      # HTTP/HTTPS (Ingress)
-      - containerPort: 80
+      # HTTP → Istio Gateway NodePort (CloudFront Origin은 80으로 접근)
+      - containerPort: 31080
         hostPort: 80
         protocol: TCP
-      - containerPort: 443
+      # HTTPS → Istio Gateway NodePort
+      - containerPort: 31443
         hostPort: 443
         protocol: TCP
       # ArgoCD NodePort (HTTP only, insecure mode in dev)
       - containerPort: 30080
         hostPort: 30080
-        protocol: TCP
-      # Istio Gateway NodePort
-      - containerPort: 31080
-        hostPort: 31080
-        protocol: TCP
-      - containerPort: 31443
-        hostPort: 31443
         protocol: TCP
   - role: worker
     image: kindest/node:v1.34.3

--- a/kind/cluster-config.yaml
+++ b/kind/cluster-config.yaml
@@ -1,14 +1,15 @@
 # Goti 로컬 개발 환경 Kind 클러스터 설정
 # control-plane 3개 (HA) + worker 4개 (대규모 트래픽 테스트 + HPA 여유)
 # K8s 1.34 고정 — ArgoCD v3.3이 1.35 미지원 (protobuf 이슈 #25767)
-# 호스트 PC: Ryzen 5 7500F 6C/12T, RAM 30GB
+# 최소 권장 스펙: CPU 6C+, RAM 16GB+ (7노드 기준)
+# 클러스터 재생성 필요: kind delete cluster → kind create cluster --config
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 name: goti-dev
 nodes:
   # 첫 번째 control-plane에만 extraPortMappings (hostPort 충돌 방지)
   - role: control-plane
-    image: kindest/node:v1.34.3
+    image: &nodeImage kindest/node:v1.34.3
     kubeadmConfigPatches:
       - |
         kind: InitConfiguration
@@ -17,6 +18,7 @@ nodes:
             node-labels: "ingress-ready=true"
     extraPortMappings:
       # HTTP → Istio Gateway NodePort (CloudFront Origin은 80으로 접근)
+      # 호스트 curl localhost:80 → 실제로 NodePort 31080으로 포워딩
       - containerPort: 31080
         hostPort: 80
         protocol: TCP
@@ -28,15 +30,16 @@ nodes:
       - containerPort: 30080
         hostPort: 30080
         protocol: TCP
+  # 2-3번 CP: extraPortMappings/labels 불필요 (첫 번째 CP만 외부 트래픽 수신)
   - role: control-plane
-    image: kindest/node:v1.34.3
+    image: *nodeImage
   - role: control-plane
-    image: kindest/node:v1.34.3
+    image: *nodeImage
   - role: worker
-    image: kindest/node:v1.34.3
+    image: *nodeImage
   - role: worker
-    image: kindest/node:v1.34.3
+    image: *nodeImage
   - role: worker
-    image: kindest/node:v1.34.3
+    image: *nodeImage
   - role: worker
-    image: kindest/node:v1.34.3
+    image: *nodeImage


### PR DESCRIPTION
## Summary
- Kind extraPortMappings 수정: hostPort 80/443 → Istio Gateway NodePort 31080/31443 매핑 (기존 미사용 Ingress 80/443 제거)
- control-plane 1개 → 3개 HA 구성 (첫 번째 CP에만 extraPortMappings, hostPort 충돌 방지)
- worker 2개 → 4개 확장 (대규모 트래픽 테스트 + HPA 여유)
- 클러스터 재생성 필요 (`kind delete cluster` + `kind create cluster`)

## Test plan
- [ ] `kind delete cluster --name goti-dev` → `kind create cluster --config kind/cluster-config.yaml`
- [ ] 노드 7개 정상 생성 확인: `kubectl get nodes`
- [ ] ArgoCD 30080 접근 확인
- [ ] Istio Gateway 80 → 31080 라우팅 확인: `curl -H "Host: kind.go-ti.shop" http://localhost/grafana/`
- [ ] CloudFront → kind.go-ti.shop 외부 접근 확인