### PR TITLE
[FEAT] ECR → Kind 배포 파이프라인 구축 (#18)

### DIFF
--- a/charts/goti-common/templates/_deployment.tpl
+++ b/charts/goti-common/templates/_deployment.tpl
@@ -25,6 +25,10 @@ spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ default (include "goti-common.fullname" .) .Values.serviceAccount.name }}
       {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/goti-server/templates/externalsecret.yaml
+++ b/charts/goti-server/templates/externalsecret.yaml
@@ -1,10 +1,12 @@
 {{- if .Values.externalSecret.enabled }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ include "goti-common.fullname" . }}-secrets
   labels:
     {{- include "goti-common.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
 spec:
   refreshInterval: {{ .Values.externalSecret.refreshInterval | default "1h" }}
   secretStoreRef:

--- a/charts/goti-server/templates/externalsecret.yaml
+++ b/charts/goti-server/templates/externalsecret.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.externalSecret.enabled }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ include "goti-common.fullname" . }}-secrets
+  labels:
+    {{- include "goti-common.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.externalSecret.refreshInterval | default "1h" }}
+  secretStoreRef:
+    name: {{ .Values.externalSecret.secretStoreRef.name }}
+    kind: {{ .Values.externalSecret.secretStoreRef.kind | default "ClusterSecretStore" }}
+  target:
+    name: {{ include "goti-common.fullname" . }}-secrets
+    creationPolicy: Owner
+  dataFrom:
+    - find:
+        path: {{ .Values.externalSecret.remoteRef.path }}
+        name:
+          regexp: ".*"
+{{- end }}

--- a/charts/goti-server/values.yaml
+++ b/charts/goti-server/values.yaml
@@ -63,6 +63,15 @@ configMap:
   enabled: false
   data: {}
 
+externalSecret:
+  enabled: false
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: ""
+    kind: ClusterSecretStore
+  remoteRef:
+    path: ""
+
 podAnnotations: {}
 nodeSelector: {}
 tolerations: []

--- a/charts/goti-server/values.yaml
+++ b/charts/goti-server/values.yaml
@@ -5,6 +5,8 @@ image:
   tag: "latest"
   pullPolicy: IfNotPresent
 
+imagePullSecrets: []
+
 serviceAccount:
   create: true
   name: ""

--- a/environments/dev/goti-server/values.yaml
+++ b/environments/dev/goti-server/values.yaml
@@ -1,5 +1,10 @@
 image:
-  tag: "latest"
+  repository: "<ACCOUNT_ID>.dkr.ecr.ap-northeast-2.amazonaws.com/goti-server"
+  tag: "dev-latest"
+  pullPolicy: Always
+
+imagePullSecrets:
+  - name: ecr-creds
 
 resources:
   requests:

--- a/environments/dev/goti-server/values.yaml
+++ b/environments/dev/goti-server/values.yaml
@@ -1,5 +1,5 @@
 image:
-  repository: "<ACCOUNT_ID>.dkr.ecr.ap-northeast-2.amazonaws.com/goti-server"
+  repository: "707925622666.dkr.ecr.ap-northeast-2.amazonaws.com/goti-server"
   tag: "dev-latest"
   pullPolicy: Always
 
@@ -38,3 +38,16 @@ env:
     value: "dev"
   - name: JAVA_TOOL_OPTIONS
     value: "-Xms256m -Xmx384m"
+
+envFrom:
+  - secretRef:
+      name: goti-server-secrets    # ExternalSecret이 SSM에서 자동 생성
+
+externalSecret:
+  enabled: true
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: aws-parameter-store
+    kind: ClusterSecretStore
+  remoteRef:
+    path: /dev/server

--- a/gitops/applicationsets/goti-server-appset.yaml
+++ b/gitops/applicationsets/goti-server-appset.yaml
@@ -18,6 +18,11 @@ spec:
         argocd-image-updater.argoproj.io/server.update-strategy: latest
         argocd-image-updater.argoproj.io/server.allow-tags: "regexp:^dev-"
         argocd-image-updater.argoproj.io/write-back-method: git
+        argocd-image-updater.argoproj.io/git-branch: main
+        argocd-image-updater.argoproj.io/git-repository: "https://github.com/Team-Ikujo/Goti-k8s.git"
+        argocd-image-updater.argoproj.io/write-back-target: "helmvalues:/{{valuesFile}}"
+        argocd-image-updater.argoproj.io/server.helm.image-name: image.repository
+        argocd-image-updater.argoproj.io/server.helm.image-tag: image.tag
     spec:
       project: goti
       sources:

--- a/gitops/applicationsets/goti-server-appset.yaml
+++ b/gitops/applicationsets/goti-server-appset.yaml
@@ -14,7 +14,7 @@ spec:
     metadata:
       name: "goti-server-{{env}}"
       annotations:
-        argocd-image-updater.argoproj.io/image-list: "server=<ACCOUNT_ID>.dkr.ecr.ap-northeast-2.amazonaws.com/goti-server"
+        argocd-image-updater.argoproj.io/image-list: "server=707925622666.dkr.ecr.ap-northeast-2.amazonaws.com/goti-server"
         argocd-image-updater.argoproj.io/server.update-strategy: latest
         argocd-image-updater.argoproj.io/server.allow-tags: "regexp:^dev-"
         argocd-image-updater.argoproj.io/write-back-method: git

--- a/gitops/applicationsets/goti-server-appset.yaml
+++ b/gitops/applicationsets/goti-server-appset.yaml
@@ -13,6 +13,11 @@ spec:
   template:
     metadata:
       name: "goti-server-{{env}}"
+      annotations:
+        argocd-image-updater.argoproj.io/image-list: "server=<ACCOUNT_ID>.dkr.ecr.ap-northeast-2.amazonaws.com/goti-server"
+        argocd-image-updater.argoproj.io/server.update-strategy: latest
+        argocd-image-updater.argoproj.io/server.allow-tags: "regexp:^dev-"
+        argocd-image-updater.argoproj.io/write-back-method: git
     spec:
       project: goti
       sources:

--- a/infrastructure/argocd-image-updater/application.yaml
+++ b/infrastructure/argocd-image-updater/application.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argocd-image-updater
+  namespace: argocd
+spec:
+  project: default
+  sources:
+    - repoURL: https://argoproj.github.io/argo-helm
+      chart: argocd-image-updater
+      targetRevision: 0.12.*
+      helm:
+        valueFiles:
+          - $values/infrastructure/argocd-image-updater/values.yaml
+    - repoURL: https://github.com/Team-Ikujo/Goti-k8s.git
+      targetRevision: main
+      ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      selfHeal: true

--- a/infrastructure/argocd-image-updater/values.yaml
+++ b/infrastructure/argocd-image-updater/values.yaml
@@ -1,7 +1,7 @@
 config:
   registries:
     - name: ECR
-      api_url: https://<ACCOUNT_ID>.dkr.ecr.ap-northeast-2.amazonaws.com
-      prefix: <ACCOUNT_ID>.dkr.ecr.ap-northeast-2.amazonaws.com
+      api_url: https://707925622666.dkr.ecr.ap-northeast-2.amazonaws.com
+      prefix: 707925622666.dkr.ecr.ap-northeast-2.amazonaws.com
       credentials: secret:argocd/ecr-creds#.dockerconfigjson
       credentialsType: pullsecret

--- a/infrastructure/argocd-image-updater/values.yaml
+++ b/infrastructure/argocd-image-updater/values.yaml
@@ -1,0 +1,7 @@
+config:
+  registries:
+    - name: ECR
+      api_url: https://<ACCOUNT_ID>.dkr.ecr.ap-northeast-2.amazonaws.com
+      prefix: <ACCOUNT_ID>.dkr.ecr.ap-northeast-2.amazonaws.com
+      credentials: secret:argocd/ecr-creds#.dockerconfigjson
+      credentialsType: pullsecret

--- a/infrastructure/external-secrets/application.yaml
+++ b/infrastructure/external-secrets/application.yaml
@@ -8,7 +8,7 @@ spec:
   sources:
     - repoURL: https://charts.external-secrets.io
       chart: external-secrets
-      targetRevision: 0.16.*
+      targetRevision: 2.1.*
       helm:
         valueFiles:
           - $values/infrastructure/external-secrets/values.yaml

--- a/infrastructure/external-secrets/application.yaml
+++ b/infrastructure/external-secrets/application.yaml
@@ -1,0 +1,26 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: external-secrets
+  namespace: argocd
+spec:
+  project: default
+  sources:
+    - repoURL: https://charts.external-secrets.io
+      chart: external-secrets
+      targetRevision: 0.16.*
+      helm:
+        valueFiles:
+          - $values/infrastructure/external-secrets/values.yaml
+    - repoURL: https://github.com/Team-Ikujo/Goti-k8s.git
+      targetRevision: main
+      ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: external-secrets
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: true
+    syncOptions:
+      - CreateNamespace=true

--- a/infrastructure/external-secrets/config-application.yaml
+++ b/infrastructure/external-secrets/config-application.yaml
@@ -1,0 +1,27 @@
+# ESO 설치 완료 후 ClusterSecretStore 등 설정을 배포하는 Application
+# syncPolicy.automated + retry로 ESO CRD 준비 전 실패 시 자동 재시도
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: external-secrets-config
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/Team-Ikujo/Goti-k8s.git
+    targetRevision: main
+    path: infrastructure/external-secrets/config
+  destination:
+    server: https://kubernetes.default.svc
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: true
+    retry:
+      limit: 10
+      backoff:
+        duration: 30s
+        factor: 2
+        maxDuration: 5m

--- a/infrastructure/external-secrets/config-application.yaml
+++ b/infrastructure/external-secrets/config-application.yaml
@@ -1,12 +1,11 @@
 # ESO 설치 완료 후 ClusterSecretStore 등 설정을 배포하는 Application
-# syncPolicy.automated + retry로 ESO CRD 준비 전 실패 시 자동 재시도
+# ESO operator(external-secrets)와 별도 Application이므로 sync-wave로 순서 보장 불가
+# retry backoff로 CRD 미준비 시 자동 수렴 (최대 10회, 30s~5m)
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: external-secrets-config
   namespace: argocd
-  annotations:
-    argocd.argoproj.io/sync-wave: "1"
 spec:
   project: default
   source:
@@ -19,6 +18,8 @@ spec:
     automated:
       selfHeal: true
       prune: true
+    syncOptions:
+      - SkipDryRunOnMissingResource=true
     retry:
       limit: 10
       backoff:

--- a/infrastructure/external-secrets/config/cluster-secret-store.yaml
+++ b/infrastructure/external-secrets/config/cluster-secret-store.yaml
@@ -1,0 +1,22 @@
+# ClusterSecretStore — 전체 클러스터에서 사용 가능한 AWS SSM 연결
+# Kind: IAM User credentials (aws-ecr-creds Secret 재사용)
+# EKS 전환 시: spec.provider.aws.auth를 IRSA로 교체
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: aws-parameter-store
+spec:
+  provider:
+    aws:
+      service: ParameterStore
+      region: ap-northeast-2
+      auth:
+        secretRef:
+          accessKeyIDSecretRef:
+            name: aws-ecr-creds
+            namespace: goti
+            key: AWS_ACCESS_KEY_ID
+          secretAccessKeySecretRef:
+            name: aws-ecr-creds
+            namespace: goti
+            key: AWS_SECRET_ACCESS_KEY

--- a/infrastructure/external-secrets/config/cluster-secret-store.yaml
+++ b/infrastructure/external-secrets/config/cluster-secret-store.yaml
@@ -1,11 +1,14 @@
 # ClusterSecretStore — 전체 클러스터에서 사용 가능한 AWS SSM 연결
 # Kind: IAM User credentials (aws-ecr-creds Secret 재사용)
 # EKS 전환 시: spec.provider.aws.auth를 IRSA로 교체
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ClusterSecretStore
 metadata:
   name: aws-parameter-store
 spec:
+  conditions:
+    - namespaces:
+        - goti
   provider:
     aws:
       service: ParameterStore

--- a/infrastructure/external-secrets/values.yaml
+++ b/infrastructure/external-secrets/values.yaml
@@ -1,0 +1,9 @@
+installCRDs: true
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 100m
+    memory: 128Mi

--- a/manifests/ecr-credential-renewer.yaml
+++ b/manifests/ecr-credential-renewer.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ecr-credential-renewer
   namespace: goti
 ---
-# goti 네임스페이스 Role
+# goti 네임스페이스 Role — create는 resourceNames 제한 불가 (K8s 제약)
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -13,7 +13,11 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "create", "delete"]
+    resourceNames: ["ecr-creds"]
+    verbs: ["get", "patch", "update"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -38,7 +42,11 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "create", "delete"]
+    resourceNames: ["ecr-creds"]
+    verbs: ["get", "patch", "update"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -61,10 +69,13 @@ metadata:
   namespace: goti
 spec:
   schedule: "0 */6 * * *"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 300
   successfulJobsHistoryLimit: 1
-  failedJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
+      activeDeadlineSeconds: 600
       template:
         metadata:
           annotations:
@@ -74,20 +85,41 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: ecr-renewer
-              image: bitnami/kubectl:1.34
+              image: amazon/aws-cli:2.27.31
               envFrom:
                 - secretRef:
                     name: aws-ecr-creds
+              # amazon/aws-cli 이미지는 root(uid 0)로 실행됨
+              # TODO: 커스텀 이미지(non-root) 빌드 후 runAsNonRoot: true 전환
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+                limits:
+                  cpu: 200m
+                  memory: 256Mi
               command:
                 - /bin/sh
                 - -c
                 - |
-                  # aws-cli 설치
-                  curl -s "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
-                  unzip -q /tmp/awscliv2.zip -d /tmp
-                  /tmp/aws/install --bin-dir /usr/local/bin --install-dir /tmp/aws-cli
+                  set -euo pipefail
 
-                  TOKEN=$(aws ecr get-login-password --region $AWS_REGION)
+                  # kubectl 설치 (aws-cli 이미지에 미포함)
+                  curl -sLo /tmp/kubectl "https://dl.k8s.io/release/v1.34.0/bin/linux/amd64/kubectl"
+                  curl -sLo /tmp/kubectl.sha256 "https://dl.k8s.io/release/v1.34.0/bin/linux/amd64/kubectl.sha256"
+                  echo "$(cat /tmp/kubectl.sha256)  /tmp/kubectl" | sha256sum -c -
+                  chmod +x /tmp/kubectl
+
+                  TOKEN=$(aws ecr get-login-password --region "$AWS_REGION")
+                  if [ -z "$TOKEN" ]; then
+                    echo "ERROR: Failed to get ECR token" >&2
+                    exit 1
+                  fi
+
                   ACCOUNT=$(aws sts get-caller-identity --query Account --output text)
                   REGISTRY="${ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com"
 
@@ -95,11 +127,11 @@ spec:
                   NAMESPACES="goti argocd"
 
                   for NS in $NAMESPACES; do
-                    kubectl delete secret ecr-creds --namespace $NS --ignore-not-found
-                    kubectl create secret docker-registry ecr-creds \
-                      --namespace $NS \
-                      --docker-server=${REGISTRY} \
+                    /tmp/kubectl create secret docker-registry ecr-creds \
+                      --namespace "$NS" \
+                      --docker-server="${REGISTRY}" \
                       --docker-username=AWS \
-                      --docker-password=${TOKEN}
+                      --docker-password="${TOKEN}" \
+                      --dry-run=client -o yaml | /tmp/kubectl apply -f -
                     echo "Updated ecr-creds in namespace: $NS"
                   done

--- a/manifests/ecr-credential-renewer.yaml
+++ b/manifests/ecr-credential-renewer.yaml
@@ -1,0 +1,105 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ecr-credential-renewer
+  namespace: goti
+---
+# goti 네임스페이스 Role
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ecr-credential-renewer
+  namespace: goti
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "create", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ecr-credential-renewer
+  namespace: goti
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ecr-credential-renewer
+subjects:
+  - kind: ServiceAccount
+    name: ecr-credential-renewer
+    namespace: goti
+---
+# argocd 네임스페이스 Role (Image Updater용)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ecr-credential-renewer
+  namespace: argocd
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "create", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ecr-credential-renewer
+  namespace: argocd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ecr-credential-renewer
+subjects:
+  - kind: ServiceAccount
+    name: ecr-credential-renewer
+    namespace: goti
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: ecr-credential-renewer
+  namespace: goti
+spec:
+  schedule: "0 */6 * * *"
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          annotations:
+            sidecar.istio.io/inject: "false"
+        spec:
+          serviceAccountName: ecr-credential-renewer
+          restartPolicy: OnFailure
+          containers:
+            - name: ecr-renewer
+              image: bitnami/kubectl:1.34
+              envFrom:
+                - secretRef:
+                    name: aws-ecr-creds
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  # aws-cli 설치
+                  curl -s "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
+                  unzip -q /tmp/awscliv2.zip -d /tmp
+                  /tmp/aws/install --bin-dir /usr/local/bin --install-dir /tmp/aws-cli
+
+                  TOKEN=$(aws ecr get-login-password --region $AWS_REGION)
+                  ACCOUNT=$(aws sts get-caller-identity --query Account --output text)
+                  REGISTRY="${ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com"
+
+                  # 대상 네임스페이스 목록 (MSA 추가 시 여기만 확장)
+                  NAMESPACES="goti argocd"
+
+                  for NS in $NAMESPACES; do
+                    kubectl delete secret ecr-creds --namespace $NS --ignore-not-found
+                    kubectl create secret docker-registry ecr-creds \
+                      --namespace $NS \
+                      --docker-server=${REGISTRY} \
+                      --docker-username=AWS \
+                      --docker-password=${TOKEN}
+                    echo "Updated ecr-creds in namespace: $NS"
+                  done


### PR DESCRIPTION
## 관련 이슈
Closes #18

## 개요
goti-server ECR 이미지를 Kind 클러스터에서 pull하여 배포하는 파이프라인 구축.
Helm imagePullSecrets 지원, CronJob 기반 ECR credential 갱신, ArgoCD Image Updater 자동 이미지 업데이트.

## 작업 내용

### Helm 차트
- **goti-common** `_deployment.tpl`: `imagePullSecrets` 블록 추가 (MSA 전환 시 모든 서비스 자동 적용)
- **goti-server** `values.yaml`: `imagePullSecrets: []` 기본값 추가
- **dev values**: ECR repository URL + `imagePullSecrets: [{name: ecr-creds}]` 설정

### ECR Credential 갱신
- **`manifests/ecr-credential-renewer.yaml`**: ServiceAccount + Role/RoleBinding(goti, argocd) + CronJob(6시간)
- `aws-ecr-creds` Secret에서 AWS 인증 → `ecr-creds` docker-registry Secret 생성/갱신
- Istio sidecar inject 비활성화

### ArgoCD Image Updater
- **`infrastructure/argocd-image-updater/`**: Helm values(ECR 레지스트리 설정) + ArgoCD Application(Multi-Source)
- **`goti-server-appset.yaml`**: Image Updater annotation 추가 (`dev-` 태그 필터, git write-back)

## 수동 작업 (1회, Kind PC)
```bash
# aws-ecr-creds Secret 생성
kubectl create secret generic aws-ecr-creds \
  --namespace goti \
  --from-literal=AWS_ACCESS_KEY_ID=<KEY> \
  --from-literal=AWS_SECRET_ACCESS_KEY=<SECRET> \
  --from-literal=AWS_REGION=ap-northeast-2

# CronJob 최초 트리거
kubectl create job --from=cronjob/ecr-credential-renewer ecr-init -n goti
```

## 참고
- `<ACCOUNT_ID>` 플레이스홀더 → 실제 AWS Account ID 교체 필요 (3개 파일)
- Terraform: Kind ECR ReadOnly IAM User 생성 완료 (별도 커밋)
- MSA 확장: imagePullSecrets는 goti-common 레벨, ECR credential은 네임스페이스 단위 → 서비스 추가 시 변경 불필요