### PR TITLE
fix(monitoring): CrashLoopBackOff 3건 수정 — image-updater, loki, pyroscope

### DIFF
--- a/environments/dev/monitoring/loki-values.yaml
+++ b/environments/dev/monitoring/loki-values.yaml
@@ -30,7 +30,7 @@ loki:
           priority: 2
           period: 336h    # 14d (dev) — prod: 17520h (2년, 개인정보보호법)
     compactor:
-      working_directory: /loki/compactor
+      working_directory: /var/loki/compactor
       compaction_interval: 10m
       retention_enabled: true
       delete_request_store: filesystem
@@ -38,8 +38,8 @@ loki:
       storage:
         type: local
         local:
-          directory: /loki/rules
-      rule_path: /loki/rules-temp
+          directory: /var/loki/rules
+      rule_path: /var/loki/rules-temp
       alertmanager_url: http://kube-prometheus-stack-alertmanager.monitoring.svc:9093
       ring:
         kvstore:
@@ -64,7 +64,7 @@ singleBinary:
         name: loki-alert-rules
   extraVolumeMounts:
     - name: loki-rules
-      mountPath: /loki/rules/fake
+      mountPath: /var/loki/rules/fake
       readOnly: true
 
 gateway:

--- a/environments/dev/monitoring/pyroscope-values.yaml
+++ b/environments/dev/monitoring/pyroscope-values.yaml
@@ -1,7 +1,13 @@
 # Pyroscope dev-kind values
 pyroscope:
-  extraArgs:
-    storage.retention-period: "3d"
+  structuredConfig:
+    storage:
+      backend: filesystem
+      filesystem:
+        dir: /data
+    compactor:
+      blocks_retention:
+        period: 3d
   resources:
     requests:
       cpu: 100m

--- a/infrastructure/argocd-image-updater/values.yaml
+++ b/infrastructure/argocd-image-updater/values.yaml
@@ -3,5 +3,4 @@ config:
     - name: ECR
       api_url: https://707925622666.dkr.ecr.ap-northeast-2.amazonaws.com
       prefix: 707925622666.dkr.ecr.ap-northeast-2.amazonaws.com
-      credentials: secret:argocd/ecr-creds#.dockerconfigjson
-      credentialType: pullsecret
+      credentials: pullsecret:argocd/ecr-creds


### PR DESCRIPTION
## 관련 이슈
Closes #21

## 개요
ArgoCD 전체 현황 확인 결과 3개 Application이 CrashLoopBackOff/Degraded 상태.
goti-server ECR 이미지 갱신(image-updater)과 로그 수집(Loki)이 차단되어 P0~P1 긴급 수정.

## 작업 내용

### 1. argocd-image-updater (P0)
- `credentialType` 비표준 필드 제거
- `credentials` 값에 `pullsecret:` type prefix 포함 (공식 문법)

### 2. loki-dev (P1)
- compactor/ruler 경로 `/loki/` → `/var/loki/` (PVC 마운트 경로 내부)
- 대상: `working_directory`, `directory`, `rule_path`, `mountPath` (4곳)

### 3. pyroscope-dev (P2)
- 존재하지 않는 CLI 플래그 `extraArgs.storage.retention-period` 제거
- `structuredConfig`로 retention 설정 이동 (storage + compactor.blocks_retention)

## Test plan
- [ ] argocd-image-updater Pod Healthy + 로그에 `Loaded 1 registries` 확인
- [ ] loki-dev Pod Running + compactor 정상 기동
- [ ] pyroscope-dev Pod Running + startup 에러 없음