### PR TITLE
[CHORE] 모니터링 스택 리뷰 피드백 반영

### DIFF
--- a/environments/dev/monitoring/alloy-values.yaml
+++ b/environments/dev/monitoring/alloy-values.yaml
@@ -37,14 +37,14 @@ alloy:
 
       // -----------------------------------------------------------------------------
       // 2. Memory Limiter: OOM 방지
-      //    - limit: 384MiB (Alloy 컨테이너 512MB의 75%)
-      //    - spike_limit: 128MiB (버스트 트래픽 허용)
+      //    - limit: 480MiB (Alloy 컨테이너 640MB의 75%)
+      //    - spike_limit: 160MiB (버스트 트래픽 허용)
       //    - check_interval: 1s
       // -----------------------------------------------------------------------------
       otelcol.processor.memory_limiter "default" {
         check_interval = "1s"
-        limit          = "384MiB"
-        spike_limit    = "128MiB"
+        limit          = "480MiB"
+        spike_limit    = "160MiB"
 
         output {
           metrics = [otelcol.processor.attributes.default.input]

--- a/environments/dev/monitoring/alloy-values.yaml
+++ b/environments/dev/monitoring/alloy-values.yaml
@@ -232,4 +232,4 @@ alloy:
       memory: 256Mi
     limits:
       cpu: 500m
-      memory: 512Mi
+      memory: 640Mi

--- a/environments/dev/monitoring/dashboards/business-dashboards.yaml
+++ b/environments/dev/monitoring/dashboards/business-dashboards.yaml
@@ -67,7 +67,7 @@ data:
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "targets": [
             {
-              "expr": "(1 - sum(rate(http_server_request_duration_seconds_count{job=\"$service_name\", http_response_status_code=~\"5..\"}[5m])) / (sum(rate(http_server_request_duration_seconds_count{job=\"$service_name\"}[5m])) > 0)) * 100",
+              "expr": "(1 - sum(rate(http_server_request_duration_seconds_count{job=\"$service_name\", http_response_status_code=~\"5..\"}[$interval])) / (sum(rate(http_server_request_duration_seconds_count{job=\"$service_name\"}[$interval])) > 0)) * 100",
               "legendFormat": "Success %"
             }
           ],
@@ -86,7 +86,7 @@ data:
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "targets": [
             {
-              "expr": "sum(rate(http_server_request_duration_seconds_sum{job=\"$service_name\"}[5m])) / (sum(rate(http_server_request_duration_seconds_count{job=\"$service_name\"}[5m])) > 0)",
+              "expr": "sum(rate(http_server_request_duration_seconds_sum{job=\"$service_name\"}[$interval])) / (sum(rate(http_server_request_duration_seconds_count{job=\"$service_name\"}[$interval])) > 0)",
               "legendFormat": "Avg"
             }
           ],
@@ -183,7 +183,7 @@ data:
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "targets": [
             {
-              "expr": "topk(15, sum(rate(http_server_request_duration_seconds_count{job=\"$service_name\"}[5m])) by (http_route))",
+              "expr": "topk(15, sum(rate(http_server_request_duration_seconds_count{job=\"$service_name\"}[$interval])) by (http_route))",
               "legendFormat": "{{http_route}}",
               "instant": true
             }
@@ -204,7 +204,7 @@ data:
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "targets": [
             {
-              "expr": "topk(15, sum(rate(http_server_request_duration_seconds_sum{job=\"$service_name\"}[5m])) by (http_route) / (sum(rate(http_server_request_duration_seconds_count{job=\"$service_name\"}[5m])) by (http_route) > 0))",
+              "expr": "topk(15, sum(rate(http_server_request_duration_seconds_sum{job=\"$service_name\"}[$interval])) by (http_route) / (sum(rate(http_server_request_duration_seconds_count{job=\"$service_name\"}[$interval])) by (http_route) > 0))",
               "legendFormat": "{{http_route}}",
               "instant": true
             }

--- a/environments/dev/monitoring/kube-prometheus-stack-values.yaml
+++ b/environments/dev/monitoring/kube-prometheus-stack-values.yaml
@@ -3,7 +3,7 @@ prometheus:
   prometheusSpec:
     replicas: 1
     retention: 24h
-    retentionSize: "3GB"  # retention/retentionSize 중 먼저 도달하는 조건 트리거. PVC 5Gi 중 WAL 여유 확보
+    retentionSize: "3GiB"  # retention/retentionSize 중 먼저 도달하는 조건 트리거. PVC 5Gi: WAL ~1GiB + blocks 3GiB + compaction headroom ~1GiB
     enableRemoteWriteReceiver: true
     enableFeatures:
       - exemplar-storage

--- a/environments/dev/monitoring/kube-prometheus-stack-values.yaml
+++ b/environments/dev/monitoring/kube-prometheus-stack-values.yaml
@@ -3,7 +3,7 @@ prometheus:
   prometheusSpec:
     replicas: 1
     retention: 24h
-    retentionSize: "4GB"
+    retentionSize: "3GB"  # retention/retentionSize 중 먼저 도달하는 조건 트리거. PVC 5Gi 중 WAL 여유 확보
     enableRemoteWriteReceiver: true
     enableFeatures:
       - exemplar-storage

--- a/environments/dev/monitoring/kube-prometheus-stack-values.yaml
+++ b/environments/dev/monitoring/kube-prometheus-stack-values.yaml
@@ -3,6 +3,7 @@ prometheus:
   prometheusSpec:
     replicas: 1
     retention: 24h
+    retentionSize: "4GB"
     enableRemoteWriteReceiver: true
     enableFeatures:
       - exemplar-storage
@@ -378,7 +379,7 @@ grafana:
       memory: 128Mi
     limits:
       cpu: 200m
-      memory: 256Mi
+      memory: 384Mi
   additionalDataSources:
     - name: Loki
       type: loki

--- a/environments/dev/monitoring/pyroscope-values.yaml
+++ b/environments/dev/monitoring/pyroscope-values.yaml
@@ -5,9 +5,8 @@ pyroscope:
       backend: filesystem
       filesystem:
         dir: /data
-    compactor:
-      blocks_retention:
-        period: 3d
+  extraArgs:
+    pyroscopedb.retention-period: "72h"
   resources:
     requests:
       cpu: 100m

--- a/environments/dev/monitoring/pyroscope-values.yaml
+++ b/environments/dev/monitoring/pyroscope-values.yaml
@@ -5,8 +5,9 @@ pyroscope:
       backend: filesystem
       filesystem:
         dir: /data
+  # compactor.blocks_retention deprecated → CLI flag 사용
   extraArgs:
-    pyroscopedb.retention-period: "72h"
+    pyroscopedb.retention-period: 72h
   resources:
     requests:
       cpu: 100m

--- a/gitops/applicationsets/monitoring-appset.yaml
+++ b/gitops/applicationsets/monitoring-appset.yaml
@@ -18,7 +18,7 @@ spec:
                   chartVersion: "82.4.3"
                   valuesFile: environments/dev/monitoring/kube-prometheus-stack-values.yaml
                 - component: loki
-                  chartRepo: https://grafana-community.github.io/helm-charts
+                  chartRepo: https://grafana.github.io/helm-charts  # NOTE: Loki는 grafana.github.io 유지 (community 미이관, 2026-03 확인)
                   chartName: loki
                   chartVersion: "6.53.0"
                   valuesFile: environments/dev/monitoring/loki-values.yaml
@@ -50,7 +50,7 @@ spec:
             valueFiles:
               - "$values/{{valuesFile}}"
         - repoURL: "https://github.com/Team-Ikujo/Goti-k8s.git"
-          targetRevision: main
+          targetRevision: main  # dev only: HEAD tracking. prod MUST pin to tag/SHA
           ref: values
       destination:
         server: "https://kubernetes.default.svc"

--- a/gitops/applicationsets/monitoring-appset.yaml
+++ b/gitops/applicationsets/monitoring-appset.yaml
@@ -28,12 +28,12 @@ spec:
                   chartVersion: "1.24.4"
                   valuesFile: environments/dev/monitoring/tempo-values.yaml
                 - component: alloy
-                  chartRepo: https://grafana.github.io/helm-charts
+                  chartRepo: https://grafana.github.io/helm-charts  # NOTE: Alloy는 grafana.github.io 유지 (community 미이관)
                   chartName: alloy
                   chartVersion: "1.6.1"
                   valuesFile: environments/dev/monitoring/alloy-values.yaml
                 - component: pyroscope
-                  chartRepo: https://grafana.github.io/helm-charts
+                  chartRepo: https://grafana.github.io/helm-charts  # NOTE: Pyroscope는 grafana.github.io 유지 (community 미이관)
                   chartName: pyroscope
                   chartVersion: "1.18.1"
                   valuesFile: environments/dev/monitoring/pyroscope-values.yaml

--- a/gitops/applicationsets/monitoring-appset.yaml
+++ b/gitops/applicationsets/monitoring-appset.yaml
@@ -18,12 +18,12 @@ spec:
                   chartVersion: "82.4.3"
                   valuesFile: environments/dev/monitoring/kube-prometheus-stack-values.yaml
                 - component: loki
-                  chartRepo: https://grafana.github.io/helm-charts
+                  chartRepo: https://grafana-community.github.io/helm-charts
                   chartName: loki
                   chartVersion: "6.53.0"
                   valuesFile: environments/dev/monitoring/loki-values.yaml
                 - component: tempo
-                  chartRepo: https://grafana.github.io/helm-charts
+                  chartRepo: https://grafana-community.github.io/helm-charts
                   chartName: tempo
                   chartVersion: "1.24.4"
                   valuesFile: environments/dev/monitoring/tempo-values.yaml

--- a/gitops/projects/monitoring-project.yaml
+++ b/gitops/projects/monitoring-project.yaml
@@ -9,7 +9,7 @@ spec:
     - "https://github.com/Team-Ikujo/Goti-k8s.git"
     - "https://prometheus-community.github.io/helm-charts"
     - "https://grafana.github.io/helm-charts"
-    - "https://grafana-community.github.io/helm-charts"  # Loki, Tempo community chart 이관
+    - "https://grafana-community.github.io/helm-charts"  # Tempo community chart 이관 (Loki는 미이관, 2026-03 확인)
   destinations:
     - namespace: monitoring
       server: "https://kubernetes.default.svc"

--- a/gitops/projects/monitoring-project.yaml
+++ b/gitops/projects/monitoring-project.yaml
@@ -9,6 +9,7 @@ spec:
     - "https://github.com/Team-Ikujo/Goti-k8s.git"
     - "https://prometheus-community.github.io/helm-charts"
     - "https://grafana.github.io/helm-charts"
+    - "https://grafana-community.github.io/helm-charts"  # Loki, Tempo community chart 이관
   destinations:
     - namespace: monitoring
       server: "https://kubernetes.default.svc"


### PR DESCRIPTION
## Summary
- Loki/Tempo Helm repo를 `grafana-community/helm-charts`로 이관 (공식 마이그레이션 반영)
- Prometheus `retentionSize: 4GB` 추가, Grafana/Alloy 메모리 상향
- Pyroscope compactor deprecated → extraArgs 방식으로 전환
- 비즈니스 대시보드 하드코딩 `[5m]` → `[$interval]` 변수화 (4개 패널)

## Test plan
- [ ] ArgoCD sync 후 Loki/Tempo 정상 배포 확인 (chart 다운로드 성공)
- [ ] Prometheus `retentionSize` 적용 확인 (`prometheus --storage.tsdb.retention.size`)
- [ ] Grafana/Alloy Pod OOMKill 없이 정상 기동
- [ ] 비즈니스 대시보드 `$interval` 변수 반영 확인

Closes #27
Closes #29