### PR TITLE
[CHORE] 보안 hardening + 대시보드 interval 변수화 (#28, #30)

### DIFF
--- a/environments/dev/monitoring/alloy-values.yaml
+++ b/environments/dev/monitoring/alloy-values.yaml
@@ -226,6 +226,12 @@ alloy:
         }
       }
 
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: [ALL]
+    readOnlyRootFilesystem: true
+
   resources:
     requests:
       cpu: 100m
@@ -233,3 +239,6 @@ alloy:
     limits:
       cpu: 500m
       memory: 640Mi
+
+serviceAccount:
+  automountServiceAccountToken: false

--- a/environments/dev/monitoring/dashboards/developer-dashboards.yaml
+++ b/environments/dev/monitoring/dashboards/developer-dashboards.yaml
@@ -250,7 +250,7 @@ data:
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "targets": [
             {
-              "expr": "topk(10, sum(rate(http_server_request_duration_seconds_count{job=\"$service_name\", http_response_status_code=~\"5..\"}[5m])) by (http_route))",
+              "expr": "topk(10, sum(rate(http_server_request_duration_seconds_count{job=\"$service_name\", http_response_status_code=~\"5..\"}[$interval])) by (http_route))",
               "legendFormat": "{{http_route}}",
               "instant": true
             }
@@ -271,7 +271,7 @@ data:
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "targets": [
             {
-              "expr": "topk(10, sum(rate(http_server_request_duration_seconds_count{job=\"$service_name\", http_response_status_code=~\"4..\"}[5m])) by (http_route))",
+              "expr": "topk(10, sum(rate(http_server_request_duration_seconds_count{job=\"$service_name\", http_response_status_code=~\"4..\"}[$interval])) by (http_route))",
               "legendFormat": "{{http_route}}",
               "instant": true
             }
@@ -293,7 +293,7 @@ data:
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "targets": [
             {
-              "expr": "topk(10, sum(rate(http_server_request_duration_seconds_count{job=\"$service_name\", http_response_status_code=~\"5..\"}[5m])) by (http_route) / (sum(rate(http_server_request_duration_seconds_count{job=\"$service_name\"}[5m])) by (http_route) > 0) * 100)",
+              "expr": "topk(10, sum(rate(http_server_request_duration_seconds_count{job=\"$service_name\", http_response_status_code=~\"5..\"}[$interval])) by (http_route) / (sum(rate(http_server_request_duration_seconds_count{job=\"$service_name\"}[$interval])) by (http_route) > 0) * 100)",
               "format": "table",
               "instant": true
             }
@@ -356,17 +356,17 @@ data:
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "targets": [
             {
-              "expr": "histogram_quantile(0.50, sum(rate(http_server_request_duration_seconds_bucket{job=\"$service_name\", http_route=~\"$http_route\"}[5m])) by (le))",
+              "expr": "histogram_quantile(0.50, sum(rate(http_server_request_duration_seconds_bucket{job=\"$service_name\", http_route=~\"$http_route\"}[$interval])) by (le))",
               "legendFormat": "p50",
               "exemplar": true
             },
             {
-              "expr": "histogram_quantile(0.95, sum(rate(http_server_request_duration_seconds_bucket{job=\"$service_name\", http_route=~\"$http_route\"}[5m])) by (le))",
+              "expr": "histogram_quantile(0.95, sum(rate(http_server_request_duration_seconds_bucket{job=\"$service_name\", http_route=~\"$http_route\"}[$interval])) by (le))",
               "legendFormat": "p95",
               "exemplar": true
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(http_server_request_duration_seconds_bucket{job=\"$service_name\", http_route=~\"$http_route\"}[5m])) by (le))",
+              "expr": "histogram_quantile(0.99, sum(rate(http_server_request_duration_seconds_bucket{job=\"$service_name\", http_route=~\"$http_route\"}[$interval])) by (le))",
               "legendFormat": "p99",
               "exemplar": true
             }
@@ -386,7 +386,7 @@ data:
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "targets": [
             {
-              "expr": "topk(10, histogram_quantile(0.99, sum(rate(http_server_request_duration_seconds_bucket{job=\"$service_name\", http_route=~\"$http_route\"}[5m])) by (le, http_route)))",
+              "expr": "topk(10, histogram_quantile(0.99, sum(rate(http_server_request_duration_seconds_bucket{job=\"$service_name\", http_route=~\"$http_route\"}[$interval])) by (le, http_route)))",
               "format": "table",
               "instant": true
             }
@@ -433,7 +433,7 @@ data:
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "targets": [
             {
-              "expr": "topk(10, sum(rate(http_server_request_duration_seconds_sum{job=\"$service_name\"}[5m])) by (http_request_method, http_route) / (sum(rate(http_server_request_duration_seconds_count{job=\"$service_name\"}[5m])) by (http_request_method, http_route) > 0))",
+              "expr": "topk(10, sum(rate(http_server_request_duration_seconds_sum{job=\"$service_name\"}[$interval])) by (http_request_method, http_route) / (sum(rate(http_server_request_duration_seconds_count{job=\"$service_name\"}[$interval])) by (http_request_method, http_route) > 0))",
               "format": "table",
               "instant": true
             }
@@ -638,7 +638,7 @@ data:
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "targets": [
             {
-              "expr": "rate(jvm_gc_duration_seconds_sum{job=\"$service_name\"}[5m]) / (rate(jvm_gc_duration_seconds_count{job=\"$service_name\"}[5m]) > 0)",
+              "expr": "rate(jvm_gc_duration_seconds_sum{job=\"$service_name\"}[$interval]) / (rate(jvm_gc_duration_seconds_count{job=\"$service_name\"}[$interval]) > 0)",
               "legendFormat": "{{jvm_gc_name}}"
             }
           ],
@@ -654,7 +654,7 @@ data:
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "targets": [
             {
-              "expr": "rate(jvm_gc_duration_seconds_count{job=\"$service_name\"}[5m])",
+              "expr": "rate(jvm_gc_duration_seconds_count{job=\"$service_name\"}[$interval])",
               "legendFormat": "{{jvm_gc_name}}"
             }
           ],
@@ -670,7 +670,7 @@ data:
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "targets": [
             {
-              "expr": "rate(jvm_gc_duration_seconds_sum{job=\"$service_name\"}[5m])",
+              "expr": "rate(jvm_gc_duration_seconds_sum{job=\"$service_name\"}[$interval])",
               "legendFormat": "{{jvm_gc_name}}"
             }
           ],
@@ -687,11 +687,11 @@ data:
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "targets": [
             {
-              "expr": "histogram_quantile(0.95, sum(rate(jvm_gc_duration_seconds_bucket{job=\"$service_name\"}[5m])) by (le, jvm_gc_name))",
+              "expr": "histogram_quantile(0.95, sum(rate(jvm_gc_duration_seconds_bucket{job=\"$service_name\"}[$interval])) by (le, jvm_gc_name))",
               "legendFormat": "p95 {{jvm_gc_name}}"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(jvm_gc_duration_seconds_bucket{job=\"$service_name\"}[5m])) by (le, jvm_gc_name))",
+              "expr": "histogram_quantile(0.99, sum(rate(jvm_gc_duration_seconds_bucket{job=\"$service_name\"}[$interval])) by (le, jvm_gc_name))",
               "legendFormat": "p99 {{jvm_gc_name}}"
             }
           ],
@@ -826,7 +826,7 @@ data:
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "targets": [
             {
-              "expr": "rate(jvm_cpu_time_seconds_total{job=\"$service_name\"}[5m])",
+              "expr": "rate(jvm_cpu_time_seconds_total{job=\"$service_name\"}[$interval])",
               "legendFormat": "CPU Time Rate"
             }
           ],
@@ -939,11 +939,11 @@ data:
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "targets": [
             {
-              "expr": "rate(jvm_class_loaded_total{job=\"$service_name\"}[5m])",
+              "expr": "rate(jvm_class_loaded_total{job=\"$service_name\"}[$interval])",
               "legendFormat": "Loaded/s"
             },
             {
-              "expr": "rate(jvm_class_unloaded_total{job=\"$service_name\"}[5m])",
+              "expr": "rate(jvm_class_unloaded_total{job=\"$service_name\"}[$interval])",
               "legendFormat": "Unloaded/s"
             }
           ],
@@ -1009,11 +1009,11 @@ data:
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "targets": [
             {
-              "expr": "histogram_quantile(0.95, sum(rate(db_client_connections_wait_time_milliseconds_bucket{job=\"$service_name\"}[5m])) by (le))",
+              "expr": "histogram_quantile(0.95, sum(rate(db_client_connections_wait_time_milliseconds_bucket{job=\"$service_name\"}[$interval])) by (le))",
               "legendFormat": "p95 Acquire"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(db_client_connections_wait_time_milliseconds_bucket{job=\"$service_name\"}[5m])) by (le))",
+              "expr": "histogram_quantile(0.99, sum(rate(db_client_connections_wait_time_milliseconds_bucket{job=\"$service_name\"}[$interval])) by (le))",
               "legendFormat": "p99 Acquire"
             }
           ],
@@ -1030,11 +1030,11 @@ data:
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "targets": [
             {
-              "expr": "histogram_quantile(0.95, sum(rate(db_client_connections_use_time_milliseconds_bucket{job=\"$service_name\"}[5m])) by (le))",
+              "expr": "histogram_quantile(0.95, sum(rate(db_client_connections_use_time_milliseconds_bucket{job=\"$service_name\"}[$interval])) by (le))",
               "legendFormat": "p95 Usage"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(db_client_connections_use_time_milliseconds_bucket{job=\"$service_name\"}[5m])) by (le))",
+              "expr": "histogram_quantile(0.99, sum(rate(db_client_connections_use_time_milliseconds_bucket{job=\"$service_name\"}[$interval])) by (le))",
               "legendFormat": "p99 Usage"
             }
           ],
@@ -1051,11 +1051,11 @@ data:
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "targets": [
             {
-              "expr": "histogram_quantile(0.95, sum(rate(db_client_connections_create_time_milliseconds_bucket{job=\"$service_name\"}[5m])) by (le))",
+              "expr": "histogram_quantile(0.95, sum(rate(db_client_connections_create_time_milliseconds_bucket{job=\"$service_name\"}[$interval])) by (le))",
               "legendFormat": "p95 Create"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(db_client_connections_create_time_milliseconds_bucket{job=\"$service_name\"}[5m])) by (le))",
+              "expr": "histogram_quantile(0.99, sum(rate(db_client_connections_create_time_milliseconds_bucket{job=\"$service_name\"}[$interval])) by (le))",
               "legendFormat": "p99 Create"
             }
           ],
@@ -1195,7 +1195,7 @@ data:
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "targets": [
             {
-              "expr": "histogram_quantile(0.95, sum(rate(traces_spanmetrics_latency_bucket[5m])) by (le, service))",
+              "expr": "histogram_quantile(0.95, sum(rate(traces_spanmetrics_latency_bucket[$interval])) by (le, service))",
               "legendFormat": "{{service}}",
               "exemplar": true
             }
@@ -1215,7 +1215,7 @@ data:
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "targets": [
             {
-              "expr": "sum(rate(traces_spanmetrics_calls_total[5m])) by (service)",
+              "expr": "sum(rate(traces_spanmetrics_calls_total[$interval])) by (service)",
               "legendFormat": "{{service}}"
             }
           ],
@@ -1231,7 +1231,7 @@ data:
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "targets": [
             {
-              "expr": "sum(rate(traces_spanmetrics_calls_total{status_code=\"STATUS_CODE_ERROR\"}[5m])) by (service) / (sum(rate(traces_spanmetrics_calls_total[5m])) by (service) > 0)",
+              "expr": "sum(rate(traces_spanmetrics_calls_total{status_code=\"STATUS_CODE_ERROR\"}[$interval])) by (service) / (sum(rate(traces_spanmetrics_calls_total[$interval])) by (service) > 0)",
               "legendFormat": "{{service}}"
             }
           ],
@@ -1254,7 +1254,7 @@ data:
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "targets": [
             {
-              "expr": "sum(rate(traces_spanmetrics_latency_bucket[5m])) by (le)",
+              "expr": "sum(rate(traces_spanmetrics_latency_bucket[$interval])) by (le)",
               "format": "heatmap",
               "legendFormat": "{{le}}"
             }
@@ -1519,7 +1519,7 @@ data:
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "targets": [
             {
-              "expr": "topk(1, sum(rate(http_server_request_duration_seconds_count{job=\"$service_name\", http_response_status_code=~\"5..\"}[5m])) by (http_response_status_code))",
+              "expr": "topk(1, sum(rate(http_server_request_duration_seconds_count{job=\"$service_name\", http_response_status_code=~\"5..\"}[$interval])) by (http_response_status_code))",
               "legendFormat": "{{http_response_status_code}}"
             }
           ],
@@ -1581,7 +1581,7 @@ data:
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "targets": [
             {
-              "expr": "topk(10, sum(rate(http_server_request_duration_seconds_count{job=\"$service_name\", http_response_status_code=~\"5..\"}[5m])) by (http_request_method, http_route))",
+              "expr": "topk(10, sum(rate(http_server_request_duration_seconds_count{job=\"$service_name\", http_response_status_code=~\"5..\"}[$interval])) by (http_request_method, http_route))",
               "legendFormat": "{{http_request_method}} {{http_route}}",
               "instant": true
             }
@@ -1602,7 +1602,7 @@ data:
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "targets": [
             {
-              "expr": "topk(10, sum(rate(http_server_request_duration_seconds_count{job=\"$service_name\", http_response_status_code=~\"4..\"}[5m])) by (http_request_method, http_route))",
+              "expr": "topk(10, sum(rate(http_server_request_duration_seconds_count{job=\"$service_name\", http_response_status_code=~\"4..\"}[$interval])) by (http_request_method, http_route))",
               "legendFormat": "{{http_request_method}} {{http_route}}",
               "instant": true
             }

--- a/environments/dev/monitoring/dashboards/devops-dashboards.yaml
+++ b/environments/dev/monitoring/dashboards/devops-dashboards.yaml
@@ -17,6 +17,16 @@ data:
       "editable": true,
       "refresh": "30s",
       "time": { "from": "now-1h", "to": "now" },
+      "templating": {
+        "list": [
+          {
+            "name": "interval",
+            "type": "interval",
+            "query": "5m,15m,1h",
+            "current": { "text": "5m", "value": "5m" }
+          }
+        ]
+      },
       "panels": [
         {
           "id": 100,
@@ -157,7 +167,7 @@ data:
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "targets": [
             {
-              "expr": "rate(prometheus_tsdb_head_samples_appended_total[5m])",
+              "expr": "rate(prometheus_tsdb_head_samples_appended_total[$interval])",
               "legendFormat": "Samples/s"
             }
           ],
@@ -196,7 +206,7 @@ data:
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "targets": [
             {
-              "expr": "rate(loki_distributor_lines_received_total[5m])",
+              "expr": "rate(loki_distributor_lines_received_total[$interval])",
               "legendFormat": "Lines/s"
             }
           ],
@@ -232,7 +242,7 @@ data:
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "targets": [
             {
-              "expr": "rate(tempo_distributor_spans_received_total[5m])",
+              "expr": "rate(tempo_distributor_spans_received_total[$interval])",
               "legendFormat": "Spans/s"
             }
           ],
@@ -248,7 +258,7 @@ data:
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "targets": [
             {
-              "expr": "rate(tempo_discarded_spans_total[5m])",
+              "expr": "rate(tempo_discarded_spans_total[$interval])",
               "legendFormat": "{{reason}}"
             }
           ],
@@ -301,7 +311,7 @@ data:
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "targets": [
             {
-              "expr": "rate(process_cpu_seconds_total{job=\"alloy\"}[5m])",
+              "expr": "rate(process_cpu_seconds_total{job=\"alloy\"}[$interval])",
               "legendFormat": "CPU Usage"
             }
           ],
@@ -317,15 +327,15 @@ data:
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "targets": [
             {
-              "expr": "rate(otelcol_exporter_send_failed_metric_points_total[5m])",
+              "expr": "rate(otelcol_exporter_send_failed_metric_points_total[$interval])",
               "legendFormat": "Failed Metrics"
             },
             {
-              "expr": "rate(otelcol_exporter_send_failed_log_records_total[5m])",
+              "expr": "rate(otelcol_exporter_send_failed_log_records_total[$interval])",
               "legendFormat": "Failed Logs"
             },
             {
-              "expr": "rate(otelcol_exporter_send_failed_spans_total[5m])",
+              "expr": "rate(otelcol_exporter_send_failed_spans_total[$interval])",
               "legendFormat": "Failed Spans"
             }
           ],
@@ -353,6 +363,12 @@ data:
             "query": "critical,warning",
             "includeAll": true,
             "current": { "text": "All", "value": "$__all" }
+          },
+          {
+            "name": "interval",
+            "type": "interval",
+            "query": "5m,15m,1h",
+            "current": { "text": "5m", "value": "5m" }
           }
         ]
       },
@@ -518,6 +534,16 @@ data:
       "editable": true,
       "refresh": "30s",
       "time": { "from": "now-1h", "to": "now" },
+      "templating": {
+        "list": [
+          {
+            "name": "interval",
+            "type": "interval",
+            "query": "5m,15m,1h",
+            "current": { "text": "5m", "value": "5m" }
+          }
+        ]
+      },
       "panels": [
         {
           "id": 100,
@@ -534,11 +560,11 @@ data:
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "targets": [
             {
-              "expr": "rate(otelcol_receiver_accepted_metric_points_total[5m])",
+              "expr": "rate(otelcol_receiver_accepted_metric_points_total[$interval])",
               "legendFormat": "Accepted"
             },
             {
-              "expr": "rate(otelcol_receiver_refused_metric_points_total[5m])",
+              "expr": "rate(otelcol_receiver_refused_metric_points_total[$interval])",
               "legendFormat": "Refused"
             }
           ],
@@ -554,11 +580,11 @@ data:
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "targets": [
             {
-              "expr": "rate(otelcol_receiver_accepted_log_records_total[5m])",
+              "expr": "rate(otelcol_receiver_accepted_log_records_total[$interval])",
               "legendFormat": "Accepted"
             },
             {
-              "expr": "rate(otelcol_receiver_refused_log_records_total[5m])",
+              "expr": "rate(otelcol_receiver_refused_log_records_total[$interval])",
               "legendFormat": "Refused"
             }
           ],
@@ -574,11 +600,11 @@ data:
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "targets": [
             {
-              "expr": "rate(otelcol_receiver_accepted_spans_total[5m])",
+              "expr": "rate(otelcol_receiver_accepted_spans_total[$interval])",
               "legendFormat": "Accepted"
             },
             {
-              "expr": "rate(otelcol_receiver_refused_spans_total[5m])",
+              "expr": "rate(otelcol_receiver_refused_spans_total[$interval])",
               "legendFormat": "Refused"
             }
           ],
@@ -601,7 +627,7 @@ data:
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "targets": [
             {
-              "expr": "rate(otelcol_processor_batch_batch_send_size_sum[5m])",
+              "expr": "rate(otelcol_processor_batch_batch_send_size_sum[$interval])",
               "legendFormat": "Batch Size/s"
             }
           ],
@@ -617,15 +643,15 @@ data:
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "targets": [
             {
-              "expr": "rate(otelcol_processor_refused_metric_points_total[5m])",
+              "expr": "rate(otelcol_processor_refused_metric_points_total[$interval])",
               "legendFormat": "Metrics Refused"
             },
             {
-              "expr": "rate(otelcol_processor_refused_log_records_total[5m])",
+              "expr": "rate(otelcol_processor_refused_log_records_total[$interval])",
               "legendFormat": "Logs Refused"
             },
             {
-              "expr": "rate(otelcol_processor_refused_spans_total[5m])",
+              "expr": "rate(otelcol_processor_refused_spans_total[$interval])",
               "legendFormat": "Spans Refused"
             }
           ],
@@ -641,7 +667,7 @@ data:
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "targets": [
             {
-              "expr": "rate(otelcol_processor_tail_sampling_count_traces_sampled[5m])",
+              "expr": "rate(otelcol_processor_tail_sampling_count_traces_sampled[$interval])",
               "legendFormat": "{{policy}}"
             }
           ],
@@ -664,15 +690,15 @@ data:
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "targets": [
             {
-              "expr": "rate(otelcol_exporter_sent_metric_points_total[5m])",
+              "expr": "rate(otelcol_exporter_sent_metric_points_total[$interval])",
               "legendFormat": "Metrics"
             },
             {
-              "expr": "rate(otelcol_exporter_sent_log_records_total[5m])",
+              "expr": "rate(otelcol_exporter_sent_log_records_total[$interval])",
               "legendFormat": "Logs"
             },
             {
-              "expr": "rate(otelcol_exporter_sent_spans_total[5m])",
+              "expr": "rate(otelcol_exporter_sent_spans_total[$interval])",
               "legendFormat": "Spans"
             }
           ],
@@ -688,15 +714,15 @@ data:
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "targets": [
             {
-              "expr": "rate(otelcol_exporter_send_failed_metric_points_total[5m])",
+              "expr": "rate(otelcol_exporter_send_failed_metric_points_total[$interval])",
               "legendFormat": "Failed Metrics"
             },
             {
-              "expr": "rate(otelcol_exporter_send_failed_log_records_total[5m])",
+              "expr": "rate(otelcol_exporter_send_failed_log_records_total[$interval])",
               "legendFormat": "Failed Logs"
             },
             {
-              "expr": "rate(otelcol_exporter_send_failed_spans_total[5m])",
+              "expr": "rate(otelcol_exporter_send_failed_spans_total[$interval])",
               "legendFormat": "Failed Spans"
             }
           ],
@@ -752,7 +778,7 @@ data:
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "targets": [
             {
-              "expr": "rate(process_cpu_seconds_total{job=\"alloy\"}[5m])",
+              "expr": "rate(process_cpu_seconds_total{job=\"alloy\"}[$interval])",
               "legendFormat": "CPU Usage"
             }
           ],
@@ -772,6 +798,16 @@ data:
       "editable": true,
       "refresh": "30s",
       "time": { "from": "now-1h", "to": "now" },
+      "templating": {
+        "list": [
+          {
+            "name": "interval",
+            "type": "interval",
+            "query": "5m,15m,1h",
+            "current": { "text": "5m", "value": "5m" }
+          }
+        ]
+      },
       "panels": [
         {
           "id": 100,
@@ -807,7 +843,7 @@ data:
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "targets": [
             {
-              "expr": "rate(traces_service_graph_request_total[5m])",
+              "expr": "rate(traces_service_graph_request_total[$interval])",
               "legendFormat": "{{client}} → {{server}}"
             }
           ],
@@ -823,7 +859,7 @@ data:
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "targets": [
             {
-              "expr": "rate(traces_service_graph_request_failed_total[5m]) / (rate(traces_service_graph_request_total[5m]) > 0)",
+              "expr": "rate(traces_service_graph_request_failed_total[$interval]) / (rate(traces_service_graph_request_total[$interval]) > 0)",
               "legendFormat": "{{client}} → {{server}}"
             }
           ],
@@ -846,7 +882,7 @@ data:
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "targets": [
             {
-              "expr": "histogram_quantile(0.95, rate(traces_service_graph_request_server_seconds_bucket[5m]))",
+              "expr": "histogram_quantile(0.95, rate(traces_service_graph_request_server_seconds_bucket[$interval]))",
               "legendFormat": "{{server}}"
             }
           ],
@@ -873,6 +909,12 @@ data:
             "type": "custom",
             "query": "1h,6h,24h,3d",
             "current": { "text": "1h", "value": "1h" }
+          },
+          {
+            "name": "interval",
+            "type": "interval",
+            "query": "5m,15m,1h",
+            "current": { "text": "5m", "value": "5m" }
           }
         ]
       },
@@ -1086,11 +1128,11 @@ data:
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "targets": [
             {
-              "expr": "histogram_quantile(0.50, sum(rate(http_server_request_duration_seconds_bucket[5m])) by (le))",
+              "expr": "histogram_quantile(0.50, sum(rate(http_server_request_duration_seconds_bucket[$interval])) by (le))",
               "legendFormat": "p50"
             },
             {
-              "expr": "histogram_quantile(0.95, sum(rate(http_server_request_duration_seconds_bucket[5m])) by (le))",
+              "expr": "histogram_quantile(0.95, sum(rate(http_server_request_duration_seconds_bucket[$interval])) by (le))",
               "legendFormat": "p95"
             },
             {
@@ -1125,6 +1167,12 @@ data:
             "refresh": 2,
             "includeAll": true,
             "multi": true
+          },
+          {
+            "name": "interval",
+            "type": "interval",
+            "query": "5m,15m,1h",
+            "current": { "text": "5m", "value": "5m" }
           }
         ]
       },
@@ -1150,7 +1198,7 @@ data:
           "datasource": { "type": "loki", "uid": "loki" },
           "targets": [
             {
-              "expr": "sum(count_over_time({log_type=\"payment\", service_name=~\"$service\"} | detected_level=\"ERROR\" [5m])) / (sum(count_over_time({log_type=\"payment\", service_name=~\"$service\"} [5m])) > 0) * 100",
+              "expr": "sum(count_over_time({log_type=\"payment\", service_name=~\"$service\"} | detected_level=\"ERROR\" [$interval])) / (sum(count_over_time({log_type=\"payment\", service_name=~\"$service\"} [$interval])) > 0) * 100",
               "legendFormat": "Error %"
             }
           ],
@@ -1295,6 +1343,12 @@ data:
             "refresh": 2,
             "includeAll": true,
             "multi": true
+          },
+          {
+            "name": "interval",
+            "type": "interval",
+            "query": "5m,15m,1h",
+            "current": { "text": "5m", "value": "5m" }
           }
         ]
       },
@@ -1439,6 +1493,12 @@ data:
             "includeAll": true,
             "multi": true,
             "current": { "text": "All", "value": "$__all" }
+          },
+          {
+            "name": "interval",
+            "type": "interval",
+            "query": "5m,15m,1h",
+            "current": { "text": "5m", "value": "5m" }
           }
         ]
       },

--- a/environments/dev/monitoring/kube-prometheus-stack-values.yaml
+++ b/environments/dev/monitoring/kube-prometheus-stack-values.yaml
@@ -1,5 +1,7 @@
 # kube-prometheus-stack dev-kind values
 prometheus:
+  serviceAccount:
+    automountServiceAccountToken: true  # Prometheus는 scraping RBAC에 SA token 필요
   prometheusSpec:
     replicas: 1
     retention: 24h
@@ -37,6 +39,8 @@ prometheus:
 
 alertmanager:
   enabled: true
+  serviceAccount:
+    automountServiceAccountToken: false
   alertmanagerSpec:
     resources:
       requests:
@@ -351,6 +355,7 @@ additionalPrometheusRulesMap:
 
 grafana:
   enabled: true
+  automountServiceAccountToken: false
   admin:
     existingSecret: grafana-admin-secret
     userKey: admin-user

--- a/environments/dev/monitoring/kube-prometheus-stack-values.yaml
+++ b/environments/dev/monitoring/kube-prometheus-stack-values.yaml
@@ -355,7 +355,8 @@ additionalPrometheusRulesMap:
 
 grafana:
   enabled: true
-  automountServiceAccountToken: false
+  serviceAccount:
+    automountServiceAccountToken: false
   admin:
     existingSecret: grafana-admin-secret
     userKey: admin-user

--- a/environments/dev/monitoring/loki-values.yaml
+++ b/environments/dev/monitoring/loki-values.yaml
@@ -1,6 +1,9 @@
 # Loki dev-kind values — SingleBinary mode
 deploymentMode: SingleBinary
 
+serviceAccount:
+  automountServiceAccountToken: false
+
 loki:
   auth_enabled: false
   commonConfig:

--- a/environments/dev/monitoring/pyroscope-values.yaml
+++ b/environments/dev/monitoring/pyroscope-values.yaml
@@ -1,5 +1,9 @@
 # Pyroscope dev-kind values
 pyroscope:
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: [ALL]
   structuredConfig:
     storage:
       backend: filesystem

--- a/environments/dev/monitoring/pyroscope-values.yaml
+++ b/environments/dev/monitoring/pyroscope-values.yaml
@@ -1,9 +1,13 @@
 # Pyroscope dev-kind values
+serviceAccount:
+  automountServiceAccountToken: false
+
 pyroscope:
   securityContext:
     allowPrivilegeEscalation: false
     capabilities:
       drop: [ALL]
+    readOnlyRootFilesystem: true
   structuredConfig:
     storage:
       backend: filesystem

--- a/environments/dev/monitoring/tempo-values.yaml
+++ b/environments/dev/monitoring/tempo-values.yaml
@@ -1,5 +1,12 @@
 # Tempo dev-kind values
+serviceAccount:
+  automountServiceAccountToken: false
+
 tempo:
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: [ALL]
   storage:
     trace:
       backend: local

--- a/environments/dev/monitoring/tempo-values.yaml
+++ b/environments/dev/monitoring/tempo-values.yaml
@@ -2,11 +2,14 @@
 serviceAccount:
   automountServiceAccountToken: false
 
+# container-level securityContext (최상위 키)
+# readOnlyRootFilesystem: chart 공식 주석 "fails if true, do not enable"
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: [ALL]
+
 tempo:
-  securityContext:
-    allowPrivilegeEscalation: false
-    capabilities:
-      drop: [ALL]
   storage:
     trace:
       backend: local


### PR DESCRIPTION
## 관련 이슈
- Closes #28 (보안 hardening: automountServiceAccountToken + securityContext)
- Closes #30 (대시보드 하드코딩 interval 패턴)

## 개요
모니터링 스택 전체 보안 강화 및 대시보드 PromQL rate() interval을 사용자 설정 가능한 변수로 전환

## 작업 내용

### 보안 hardening (#28)
- **automountServiceAccountToken: false** — Loki, Tempo, Alloy, Pyroscope, Grafana, Alertmanager
  - Prometheus는 scraping RBAC 필요로 `true` 유지
- **securityContext 강화** — Tempo, Alloy, Pyroscope에 allowPrivilegeEscalation: false + capabilities drop ALL 추가
  - Alloy: readOnlyRootFilesystem: true 추가

### 대시보드 interval 변수화 (#30)
- **devops-dashboards.yaml**: rate()/increase() 내 `[5m]` → `[$interval]` (32건), 8개 대시보드에 $interval 템플릿 변수 추가
- **developer-dashboards.yaml**: `[5m]` → `[$interval]` (29건, 기존 $interval 변수 활용)

## Test plan
- [ ] ArgoCD sync 후 모든 모니터링 Pod 정상 기동 확인
- [ ] `kubectl get sa -n monitoring -o yaml` — automountServiceAccountToken 설정 검증
- [ ] Grafana 대시보드에서 $interval 드롭다운 동작 확인
- [ ] Prometheus scraping 정상 동작 확인 (SA token 필요)