### PR TITLE
chore(validate): 대시보드 신규 변수 치환 추가

### DIFF
--- a/scripts/validate/extract-queries.sh
+++ b/scripts/validate/extract-queries.sh
@@ -59,6 +59,15 @@ substitute_vars() {
   expr="${expr//\$\{search\}/}"
   expr="${expr//\$datasource/}"
   expr="${expr//\$\{datasource\}/}"
+  # K8s 운영 변수 (cluster-nodes, pod-lifecycle, capacity-planning 등)
+  expr="${expr//\$namespace/.*}"
+  expr="${expr//\$\{namespace\}/.*}"
+  expr="${expr//\$node/.*}"
+  expr="${expr//\$\{node\}/.*}"
+  expr="${expr//\$workload/.*}"
+  expr="${expr//\$\{workload\}/.*}"
+  expr="${expr//\$deployment/.*}"
+  expr="${expr//\$\{deployment\}/.*}"
   # HTTP 필터 변수 (multi-select, includeAll → .* 치환)
   expr="${expr//\$http_route/.*}"
   expr="${expr//\$\{http_route\}/.*}"

--- a/scripts/validate/extract-queries.sh
+++ b/scripts/validate/extract-queries.sh
@@ -59,7 +59,8 @@ substitute_vars() {
   expr="${expr//\$\{search\}/}"
   expr="${expr//\$datasource/}"
   expr="${expr//\$\{datasource\}/}"
-  # K8s 운영 변수 (cluster-nodes, pod-lifecycle, capacity-planning 등)
+  # K8s 운영 변수 (includeAll=true, allValue=.* multi-select)
+  # 대상 대시보드: cluster-nodes, pod-lifecycle, capacity-planning, infra-health, istio-mesh
   expr="${expr//\$namespace/.*}"
   expr="${expr//\$\{namespace\}/.*}"
   expr="${expr//\$node/.*}"


### PR DESCRIPTION
## Summary
- `extract-queries.sh`의 `substitute_vars`에 `$namespace`, `$node`, `$workload`, `$deployment` 변수 치환 추가
- Goti-monitoring DevOps 대시보드 고도화에 따른 validate 스크립트 동기화

## Test plan
- [ ] `./validate.sh --lint-only` 실행 시 신규 변수 포함 쿼리 정상 추출 확인
- [ ] 치환 후 PromQL 문법 오류 없음 확인

Closes #38