### PR TITLE
[FEAT] MSA 서비스별 ApplicationSet + 환경별 values 생성 (#40)

### DIFF
--- a/environments/dev/goti-payment/values.yaml
+++ b/environments/dev/goti-payment/values.yaml
@@ -40,7 +40,7 @@ env:
   - name: SPRING_PROFILES_ACTIVE
     value: "dev"
   - name: JAVA_TOOL_OPTIONS
-    value: "-Xms256m -Xmx512m"
+    value: "-XX:MaxRAMPercentage=60.0"
 
 envFrom:
   - secretRef:
@@ -53,5 +53,5 @@ externalSecret:
     name: aws-parameter-store
     kind: ClusterSecretStore
   remoteRef:
-    path: /dev/server
+    path: /dev/server  # TODO: 서비스별 경로 분리 예정 (/dev/payment 등)
     overridePath: /dev/kind/server

--- a/environments/dev/goti-payment/values.yaml
+++ b/environments/dev/goti-payment/values.yaml
@@ -1,0 +1,57 @@
+nameOverride: goti-payment
+
+image:
+  repository: "707925622666.dkr.ecr.ap-northeast-2.amazonaws.com/goti-payment"
+  tag: "latest"
+  pullPolicy: Always
+
+imagePullSecrets:
+  - name: ecr-creds
+
+podAnnotations:
+  instrumentation.opentelemetry.io/inject-java: "goti/goti-java"
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+gateway:
+  enabled: false
+
+probes:
+  liveness:
+    httpGet:
+      path: /actuator/health/liveness
+      port: http
+    initialDelaySeconds: 60
+    periodSeconds: 10
+  readiness:
+    httpGet:
+      path: /actuator/health/readiness
+      port: http
+    initialDelaySeconds: 30
+    periodSeconds: 5
+
+env:
+  - name: SPRING_PROFILES_ACTIVE
+    value: "dev"
+  - name: JAVA_TOOL_OPTIONS
+    value: "-Xms256m -Xmx512m"
+
+envFrom:
+  - secretRef:
+      name: goti-payment-dev-secrets
+
+externalSecret:
+  enabled: true
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: aws-parameter-store
+    kind: ClusterSecretStore
+  remoteRef:
+    path: /dev/server
+    overridePath: /dev/kind/server

--- a/environments/dev/goti-resale/values.yaml
+++ b/environments/dev/goti-resale/values.yaml
@@ -40,7 +40,7 @@ env:
   - name: SPRING_PROFILES_ACTIVE
     value: "dev"
   - name: JAVA_TOOL_OPTIONS
-    value: "-Xms256m -Xmx512m"
+    value: "-XX:MaxRAMPercentage=60.0"
 
 envFrom:
   - secretRef:
@@ -53,5 +53,5 @@ externalSecret:
     name: aws-parameter-store
     kind: ClusterSecretStore
   remoteRef:
-    path: /dev/server
+    path: /dev/server  # TODO: 서비스별 경로 분리 예정 (/dev/resale 등)
     overridePath: /dev/kind/server

--- a/environments/dev/goti-resale/values.yaml
+++ b/environments/dev/goti-resale/values.yaml
@@ -1,0 +1,57 @@
+nameOverride: goti-resale
+
+image:
+  repository: "707925622666.dkr.ecr.ap-northeast-2.amazonaws.com/goti-resale"
+  tag: "latest"
+  pullPolicy: Always
+
+imagePullSecrets:
+  - name: ecr-creds
+
+podAnnotations:
+  instrumentation.opentelemetry.io/inject-java: "goti/goti-java"
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+gateway:
+  enabled: false
+
+probes:
+  liveness:
+    httpGet:
+      path: /actuator/health/liveness
+      port: http
+    initialDelaySeconds: 60
+    periodSeconds: 10
+  readiness:
+    httpGet:
+      path: /actuator/health/readiness
+      port: http
+    initialDelaySeconds: 30
+    periodSeconds: 5
+
+env:
+  - name: SPRING_PROFILES_ACTIVE
+    value: "dev"
+  - name: JAVA_TOOL_OPTIONS
+    value: "-Xms256m -Xmx512m"
+
+envFrom:
+  - secretRef:
+      name: goti-resale-dev-secrets
+
+externalSecret:
+  enabled: true
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: aws-parameter-store
+    kind: ClusterSecretStore
+  remoteRef:
+    path: /dev/server
+    overridePath: /dev/kind/server

--- a/environments/dev/goti-stadium/values.yaml
+++ b/environments/dev/goti-stadium/values.yaml
@@ -1,0 +1,57 @@
+nameOverride: goti-stadium
+
+image:
+  repository: "707925622666.dkr.ecr.ap-northeast-2.amazonaws.com/goti-stadium"
+  tag: "latest"
+  pullPolicy: Always
+
+imagePullSecrets:
+  - name: ecr-creds
+
+podAnnotations:
+  instrumentation.opentelemetry.io/inject-java: "goti/goti-java"
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+gateway:
+  enabled: false
+
+probes:
+  liveness:
+    httpGet:
+      path: /actuator/health/liveness
+      port: http
+    initialDelaySeconds: 60
+    periodSeconds: 10
+  readiness:
+    httpGet:
+      path: /actuator/health/readiness
+      port: http
+    initialDelaySeconds: 30
+    periodSeconds: 5
+
+env:
+  - name: SPRING_PROFILES_ACTIVE
+    value: "dev"
+  - name: JAVA_TOOL_OPTIONS
+    value: "-Xms256m -Xmx512m"
+
+envFrom:
+  - secretRef:
+      name: goti-stadium-dev-secrets
+
+externalSecret:
+  enabled: true
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: aws-parameter-store
+    kind: ClusterSecretStore
+  remoteRef:
+    path: /dev/server
+    overridePath: /dev/kind/server

--- a/environments/dev/goti-stadium/values.yaml
+++ b/environments/dev/goti-stadium/values.yaml
@@ -40,7 +40,7 @@ env:
   - name: SPRING_PROFILES_ACTIVE
     value: "dev"
   - name: JAVA_TOOL_OPTIONS
-    value: "-Xms256m -Xmx512m"
+    value: "-XX:MaxRAMPercentage=60.0"
 
 envFrom:
   - secretRef:
@@ -53,5 +53,5 @@ externalSecret:
     name: aws-parameter-store
     kind: ClusterSecretStore
   remoteRef:
-    path: /dev/server
+    path: /dev/server  # TODO: 서비스별 경로 분리 예정 (/dev/stadium 등)
     overridePath: /dev/kind/server

--- a/environments/dev/goti-ticketing/values.yaml
+++ b/environments/dev/goti-ticketing/values.yaml
@@ -1,0 +1,57 @@
+nameOverride: goti-ticketing
+
+image:
+  repository: "707925622666.dkr.ecr.ap-northeast-2.amazonaws.com/goti-ticketing"
+  tag: "latest"
+  pullPolicy: Always
+
+imagePullSecrets:
+  - name: ecr-creds
+
+podAnnotations:
+  instrumentation.opentelemetry.io/inject-java: "goti/goti-java"
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 384Mi
+  limits:
+    cpu: 500m
+    memory: 768Mi
+
+gateway:
+  enabled: false
+
+probes:
+  liveness:
+    httpGet:
+      path: /actuator/health/liveness
+      port: http
+    initialDelaySeconds: 60
+    periodSeconds: 10
+  readiness:
+    httpGet:
+      path: /actuator/health/readiness
+      port: http
+    initialDelaySeconds: 30
+    periodSeconds: 5
+
+env:
+  - name: SPRING_PROFILES_ACTIVE
+    value: "dev"
+  - name: JAVA_TOOL_OPTIONS
+    value: "-Xms256m -Xmx512m"
+
+envFrom:
+  - secretRef:
+      name: goti-ticketing-dev-secrets
+
+externalSecret:
+  enabled: true
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: aws-parameter-store
+    kind: ClusterSecretStore
+  remoteRef:
+    path: /dev/server
+    overridePath: /dev/kind/server

--- a/environments/dev/goti-ticketing/values.yaml
+++ b/environments/dev/goti-ticketing/values.yaml
@@ -40,7 +40,7 @@ env:
   - name: SPRING_PROFILES_ACTIVE
     value: "dev"
   - name: JAVA_TOOL_OPTIONS
-    value: "-Xms256m -Xmx512m"
+    value: "-XX:MaxRAMPercentage=60.0"
 
 envFrom:
   - secretRef:
@@ -53,5 +53,5 @@ externalSecret:
     name: aws-parameter-store
     kind: ClusterSecretStore
   remoteRef:
-    path: /dev/server
+    path: /dev/server  # TODO: 서비스별 경로 분리 예정 (/dev/ticketing 등)
     overridePath: /dev/kind/server

--- a/environments/dev/goti-user/values.yaml
+++ b/environments/dev/goti-user/values.yaml
@@ -40,7 +40,7 @@ env:
   - name: SPRING_PROFILES_ACTIVE
     value: "dev"
   - name: JAVA_TOOL_OPTIONS
-    value: "-Xms256m -Xmx512m"
+    value: "-XX:MaxRAMPercentage=60.0"
 
 envFrom:
   - secretRef:
@@ -53,5 +53,5 @@ externalSecret:
     name: aws-parameter-store
     kind: ClusterSecretStore
   remoteRef:
-    path: /dev/server
+    path: /dev/server  # TODO: 서비스별 경로 분리 예정 (/dev/user 등)
     overridePath: /dev/kind/server

--- a/environments/dev/goti-user/values.yaml
+++ b/environments/dev/goti-user/values.yaml
@@ -1,0 +1,57 @@
+nameOverride: goti-user
+
+image:
+  repository: "707925622666.dkr.ecr.ap-northeast-2.amazonaws.com/goti-user"
+  tag: "latest"
+  pullPolicy: Always
+
+imagePullSecrets:
+  - name: ecr-creds
+
+podAnnotations:
+  instrumentation.opentelemetry.io/inject-java: "goti/goti-java"
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 384Mi
+  limits:
+    cpu: 500m
+    memory: 768Mi
+
+gateway:
+  enabled: false
+
+probes:
+  liveness:
+    httpGet:
+      path: /actuator/health/liveness
+      port: http
+    initialDelaySeconds: 60
+    periodSeconds: 10
+  readiness:
+    httpGet:
+      path: /actuator/health/readiness
+      port: http
+    initialDelaySeconds: 30
+    periodSeconds: 5
+
+env:
+  - name: SPRING_PROFILES_ACTIVE
+    value: "dev"
+  - name: JAVA_TOOL_OPTIONS
+    value: "-Xms256m -Xmx512m"
+
+envFrom:
+  - secretRef:
+      name: goti-user-dev-secrets
+
+externalSecret:
+  enabled: true
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: aws-parameter-store
+    kind: ClusterSecretStore
+  remoteRef:
+    path: /dev/server
+    overridePath: /dev/kind/server

--- a/gitops/applicationsets/goti-msa-appset.yaml
+++ b/gitops/applicationsets/goti-msa-appset.yaml
@@ -26,20 +26,20 @@ spec:
     metadata:
       name: "goti-{{service}}-dev"
       annotations:
-        argocd-image-updater.argoproj.io/image-list: "app=707925622666.dkr.ecr.ap-northeast-2.amazonaws.com/goti-{{service}}"
-        argocd-image-updater.argoproj.io/app.update-strategy: latest
-        argocd-image-updater.argoproj.io/app.allow-tags: "regexp:^dev-"
+        argocd-image-updater.argoproj.io/image-list: "{{service}}=707925622666.dkr.ecr.ap-northeast-2.amazonaws.com/goti-{{service}}"
+        argocd-image-updater.argoproj.io/{{service}}.update-strategy: latest
+        argocd-image-updater.argoproj.io/{{service}}.allow-tags: "regexp:^dev-"
         argocd-image-updater.argoproj.io/write-back-method: git
         argocd-image-updater.argoproj.io/git-branch: main
         argocd-image-updater.argoproj.io/git-repository: "https://github.com/Team-Ikujo/Goti-k8s.git"
         argocd-image-updater.argoproj.io/write-back-target: "helmvalues:/{{valuesFile}}"
-        argocd-image-updater.argoproj.io/app.helm.image-name: image.repository
-        argocd-image-updater.argoproj.io/app.helm.image-tag: image.tag
+        argocd-image-updater.argoproj.io/{{service}}.helm.image-name: image.repository
+        argocd-image-updater.argoproj.io/{{service}}.helm.image-tag: image.tag
     spec:
       project: goti
       source:
         repoURL: "https://github.com/Team-Ikujo/Goti-k8s.git"
-        targetRevision: main
+        targetRevision: main  # dev only: HEAD tracking — prod는 반드시 semver tag 고정
         path: "charts/goti-server"
         helm:
           valueFiles:

--- a/gitops/applicationsets/goti-msa-appset.yaml
+++ b/gitops/applicationsets/goti-msa-appset.yaml
@@ -1,0 +1,67 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: goti-msa
+  namespace: argocd
+spec:
+  generators:
+    - list:
+        elements:
+          - service: user
+            namespace: goti
+            valuesFile: environments/dev/goti-user/values.yaml
+          - service: stadium
+            namespace: goti
+            valuesFile: environments/dev/goti-stadium/values.yaml
+          - service: ticketing
+            namespace: goti
+            valuesFile: environments/dev/goti-ticketing/values.yaml
+          - service: payment
+            namespace: goti
+            valuesFile: environments/dev/goti-payment/values.yaml
+          - service: resale
+            namespace: goti
+            valuesFile: environments/dev/goti-resale/values.yaml
+  template:
+    metadata:
+      name: "goti-{{service}}-dev"
+      annotations:
+        argocd-image-updater.argoproj.io/image-list: "app=707925622666.dkr.ecr.ap-northeast-2.amazonaws.com/goti-{{service}}"
+        argocd-image-updater.argoproj.io/app.update-strategy: latest
+        argocd-image-updater.argoproj.io/app.allow-tags: "regexp:^dev-"
+        argocd-image-updater.argoproj.io/write-back-method: git
+        argocd-image-updater.argoproj.io/git-branch: main
+        argocd-image-updater.argoproj.io/git-repository: "https://github.com/Team-Ikujo/Goti-k8s.git"
+        argocd-image-updater.argoproj.io/write-back-target: "helmvalues:/{{valuesFile}}"
+        argocd-image-updater.argoproj.io/app.helm.image-name: image.repository
+        argocd-image-updater.argoproj.io/app.helm.image-tag: image.tag
+    spec:
+      project: goti
+      source:
+        repoURL: "https://github.com/Team-Ikujo/Goti-k8s.git"
+        targetRevision: main
+        path: "charts/goti-server"
+        helm:
+          valueFiles:
+            - "../../{{valuesFile}}"
+      destination:
+        server: "https://kubernetes.default.svc"
+        namespace: "{{namespace}}"
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        retry:
+          limit: 5
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m
+        syncOptions:
+          - CreateNamespace=true
+          - ServerSideApply=true
+      ignoreDifferences:
+        - group: apps
+          kind: Deployment
+          jsonPointers:
+            - /spec/replicas


### PR DESCRIPTION
## Summary
- MSA 5개 서비스(user, stadium, ticketing, payment, resale)의 ApplicationSet + 환경별 values.yaml 생성
- goti-server chart 재활용, `nameOverride`로 서비스별 fullname 정합성 보장 (ExternalSecret ↔ envFrom)
- ArgoCD Image Updater 연동 — ECR `dev-*` 태그 자동 감지 → values.yaml 업데이트 → sync

## Test plan
- [ ] Helm template 렌더링 검증 (5개 서비스 전체 OK 확인 완료)
- [ ] ExternalSecret name ↔ envFrom secretRef 정합성 확인 완료
- [ ] ECR 이미지 push 후 ArgoCD Application 생성 확인
- [ ] Image Updater 태그 감지 → 자동 sync 확인

Closes #40