### PR TITLE
[FEAT] Istio 심화 설정 — STRICT mTLS, AuthorizationPolicy, DestinationRule, ServiceEntry

### DIFF
--- a/charts/goti-common/templates/_authorizationpolicy.tpl
+++ b/charts/goti-common/templates/_authorizationpolicy.tpl
@@ -1,0 +1,42 @@
+{{/*
+서비스별 AuthorizationPolicy — 서비스 간 통신 허용 규칙
+deny-all (goti-policy chart)과 함께 사용하여 allowlist 패턴 구현
+
+사용 예시 (values.yaml):
+  istioPolicy:
+    authorizationPolicy:
+      enabled: true
+      allowFrom:
+        - name: from-payment
+          rules:
+            - from:
+                - source:
+                    principals: ["cluster.local/ns/goti/sa/goti-payment-dev"]
+              to:
+                - operation:
+                    paths: ["/api/v1/orders/*"]
+                    methods: ["POST"]
+*/}}
+{{- define "goti-common.authorizationpolicy" -}}
+{{- if and .Values.istioPolicy .Values.istioPolicy.authorizationPolicy .Values.istioPolicy.authorizationPolicy.enabled }}
+{{- $fullname := include "goti-common.fullname" . }}
+{{- $labels := include "goti-common.labels" . }}
+{{- $selectorLabels := include "goti-common.selectorLabels" . }}
+{{- range .Values.istioPolicy.authorizationPolicy.allowFrom }}
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: {{ $fullname }}-{{ .name }}
+  labels:
+    {{- $labels | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- $selectorLabels | nindent 6 }}
+  action: ALLOW
+  rules:
+    {{- toYaml .rules | nindent 4 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/goti-common/templates/_destinationrule.tpl
+++ b/charts/goti-common/templates/_destinationrule.tpl
@@ -1,0 +1,48 @@
+{{/*
+DestinationRule — Circuit breaker, connection pool, load balancing
+Phase 2: Resilience 설정
+
+사용 예시 (values.yaml):
+  istioPolicy:
+    destinationRule:
+      enabled: true
+      connectionPool:
+        tcp:
+          maxConnections: 100
+          connectTimeout: 5s
+        http:
+          maxRequestsPerConnection: 100
+          maxRetries: 3
+      outlierDetection:
+        consecutive5xxErrors: 5
+        interval: 30s
+        baseEjectionTime: 30s
+        maxEjectionPercent: 50
+      loadBalancer:
+        simple: LEAST_REQUEST
+*/}}
+{{- define "goti-common.destinationrule" -}}
+{{- if and .Values.istioPolicy .Values.istioPolicy.destinationRule .Values.istioPolicy.destinationRule.enabled }}
+apiVersion: networking.istio.io/v1
+kind: DestinationRule
+metadata:
+  name: {{ include "goti-common.fullname" . }}
+  labels:
+    {{- include "goti-common.labels" . | nindent 4 }}
+spec:
+  host: {{ include "goti-common.fullname" . }}
+  trafficPolicy:
+    {{- with .Values.istioPolicy.destinationRule.connectionPool }}
+    connectionPool:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.istioPolicy.destinationRule.outlierDetection }}
+    outlierDetection:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.istioPolicy.destinationRule.loadBalancer }}
+    loadBalancer:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/goti-common/templates/_sidecar.tpl
+++ b/charts/goti-common/templates/_sidecar.tpl
@@ -1,0 +1,30 @@
+{{/*
+Sidecar — Egress 트래픽 제한 (Phase 2, 기본 비활성화)
+활성화 시 해당 워크로드의 Envoy가 지정된 호스트로만 egress 가능
+
+사용 예시 (values.yaml):
+  istioPolicy:
+    sidecar:
+      enabled: true
+      egress:
+        - hosts:
+            - "istio-system/*"
+            - "./goti-ticketing-dev.goti.svc.cluster.local"
+            - "~/*.amazonaws.com"
+*/}}
+{{- define "goti-common.sidecar" -}}
+{{- if and .Values.istioPolicy .Values.istioPolicy.sidecar .Values.istioPolicy.sidecar.enabled }}
+apiVersion: networking.istio.io/v1
+kind: Sidecar
+metadata:
+  name: {{ include "goti-common.fullname" . }}
+  labels:
+    {{- include "goti-common.labels" . | nindent 4 }}
+spec:
+  workloadSelector:
+    labels:
+      {{- include "goti-common.selectorLabels" . | nindent 6 }}
+  egress:
+    {{- toYaml .Values.istioPolicy.sidecar.egress | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/goti-server/templates/authorizationpolicy.yaml
+++ b/charts/goti-server/templates/authorizationpolicy.yaml
@@ -1,0 +1,1 @@
+{{- include "goti-common.authorizationpolicy" . }}

--- a/charts/goti-server/templates/destinationrule.yaml
+++ b/charts/goti-server/templates/destinationrule.yaml
@@ -1,0 +1,1 @@
+{{- include "goti-common.destinationrule" . }}

--- a/charts/goti-server/templates/sidecar.yaml
+++ b/charts/goti-server/templates/sidecar.yaml
@@ -1,0 +1,1 @@
+{{- include "goti-common.sidecar" . }}

--- a/charts/goti-server/values.yaml
+++ b/charts/goti-server/values.yaml
@@ -79,3 +79,20 @@ podAnnotations: {}
 nodeSelector: {}
 tolerations: []
 affinity: {}
+
+# Istio 보안/네트워크 정책
+istioPolicy:
+  # Phase 1: 서비스별 AuthorizationPolicy (서비스 간 통신 허용)
+  authorizationPolicy:
+    enabled: false
+    allowFrom: []
+  # Phase 2: DestinationRule (circuit breaker, connection pool)
+  destinationRule:
+    enabled: false
+    connectionPool: {}
+    outlierDetection: {}
+    loadBalancer: {}
+  # Phase 2: Sidecar (egress 제한, 기본 비활성화)
+  sidecar:
+    enabled: false
+    egress: []

--- a/charts/goti-server/values.yaml
+++ b/charts/goti-server/values.yaml
@@ -89,9 +89,19 @@ istioPolicy:
   # Phase 2: DestinationRule (circuit breaker, connection pool)
   destinationRule:
     enabled: false
-    connectionPool: {}
-    outlierDetection: {}
-    loadBalancer: {}
+    connectionPool:
+      tcp:
+        maxConnections: 100
+        connectTimeout: 5s
+      http:
+        maxRequestsPerConnection: 100
+    outlierDetection:
+      consecutive5xxErrors: 5
+      interval: 30s
+      baseEjectionTime: 30s
+      maxEjectionPercent: 50
+    loadBalancer:
+      simple: LEAST_REQUEST
   # Phase 2: Sidecar (egress 제한, 기본 비활성화)
   sidecar:
     enabled: false

--- a/clusters/dev/bootstrap/istio-install.yaml
+++ b/clusters/dev/bootstrap/istio-install.yaml
@@ -107,3 +107,40 @@ spec:
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true
+---
+# Istio Mesh Policy (STRICT mTLS)
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: istio-mesh-policy
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: infra
+  sources:
+    - repoURL: "https://github.com/Team-Ikujo/Goti-k8s.git"
+      targetRevision: main
+      path: "infrastructure/dev/istio/mesh-policy"
+      helm:
+        valueFiles:
+          - values.yaml
+          - values-dev.yaml
+  destination:
+    server: "https://kubernetes.default.svc"
+    namespace: istio-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    retry:
+      limit: 5
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 3m
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/environments/dev/goti-payment/values.yaml
+++ b/environments/dev/goti-payment/values.yaml
@@ -114,23 +114,6 @@ istioPolicy:
                   paths: ["/api/v1/resales/payments", "/api/v1/resales/payments/*"]
                   methods: ["POST", "PATCH"]
 
-  # Phase 2: Resilience (PG 연동 가능 — 넉넉한 timeout)
+  # Phase 2: Resilience (공통 설정은 goti-server/values.yaml 기본값 사용)
   destinationRule:
     enabled: true
-    connectionPool:
-      tcp:
-        maxConnections: 100
-        connectTimeout: 5s
-      http:
-        maxRequestsPerConnection: 100
-        maxRetries: 2
-    outlierDetection:
-      consecutive5xxErrors: 5
-      interval: 30s
-      baseEjectionTime: 30s
-      maxEjectionPercent: 50
-    loadBalancer:
-      simple: LEAST_REQUEST
-
-  sidecar:
-    enabled: false

--- a/environments/dev/goti-payment/values.yaml
+++ b/environments/dev/goti-payment/values.yaml
@@ -28,6 +28,11 @@ gateway:
     - match:
         - uri:
             prefix: "/api/v1/payments"
+      timeout: 15s
+      retries:
+        attempts: 2
+        perTryTimeout: 5s
+        retryOn: 5xx,reset,connect-failure
       route:
         - destination:
             host: goti-payment-dev
@@ -91,3 +96,41 @@ externalSecret:
   remoteRef:
     path: /dev/server  # TODO: 서비스별 경로 분리 예정 (/dev/payment 등)
     overridePath: /dev/kind/server
+
+# --- Istio 보안/네트워크 정책 ---
+
+istioPolicy:
+  # Phase 1: resale → payment (양도 결제/환불)
+  authorizationPolicy:
+    enabled: true
+    allowFrom:
+      - name: from-resale
+        rules:
+          - from:
+              - source:
+                  principals: ["cluster.local/ns/goti/sa/goti-resale-dev"]
+            to:
+              - operation:
+                  paths: ["/api/v1/resales/payments", "/api/v1/resales/payments/*"]
+                  methods: ["POST", "PATCH"]
+
+  # Phase 2: Resilience (PG 연동 가능 — 넉넉한 timeout)
+  destinationRule:
+    enabled: true
+    connectionPool:
+      tcp:
+        maxConnections: 100
+        connectTimeout: 5s
+      http:
+        maxRequestsPerConnection: 100
+        maxRetries: 2
+    outlierDetection:
+      consecutive5xxErrors: 5
+      interval: 30s
+      baseEjectionTime: 30s
+      maxEjectionPercent: 50
+    loadBalancer:
+      simple: LEAST_REQUEST
+
+  sidecar:
+    enabled: false

--- a/environments/dev/goti-resale/values.yaml
+++ b/environments/dev/goti-resale/values.yaml
@@ -114,23 +114,6 @@ istioPolicy:
                   paths: ["/api/v1/resales/orders/*"]
                   methods: ["GET", "PATCH"]
 
-  # Phase 2: Resilience
+  # Phase 2: Resilience (공통 설정은 goti-server/values.yaml 기본값 사용)
   destinationRule:
     enabled: true
-    connectionPool:
-      tcp:
-        maxConnections: 100
-        connectTimeout: 5s
-      http:
-        maxRequestsPerConnection: 100
-        maxRetries: 2
-    outlierDetection:
-      consecutive5xxErrors: 5
-      interval: 30s
-      baseEjectionTime: 30s
-      maxEjectionPercent: 50
-    loadBalancer:
-      simple: LEAST_REQUEST
-
-  sidecar:
-    enabled: false

--- a/environments/dev/goti-resale/values.yaml
+++ b/environments/dev/goti-resale/values.yaml
@@ -28,6 +28,11 @@ gateway:
     - match:
         - uri:
             prefix: "/api/v1/resales"
+      timeout: 10s
+      retries:
+        attempts: 2
+        perTryTimeout: 3s
+        retryOn: 5xx,reset,connect-failure
       route:
         - destination:
             host: goti-resale-dev
@@ -91,3 +96,41 @@ externalSecret:
   remoteRef:
     path: /dev/server  # TODO: 서비스별 경로 분리 예정 (/dev/resale 등)
     overridePath: /dev/kind/server
+
+# --- Istio 보안/네트워크 정책 ---
+
+istioPolicy:
+  # Phase 1: payment → resale (양도 완료/거래 조회)
+  authorizationPolicy:
+    enabled: true
+    allowFrom:
+      - name: from-payment
+        rules:
+          - from:
+              - source:
+                  principals: ["cluster.local/ns/goti/sa/goti-payment-dev"]
+            to:
+              - operation:
+                  paths: ["/api/v1/resales/orders/*"]
+                  methods: ["GET", "PATCH"]
+
+  # Phase 2: Resilience
+  destinationRule:
+    enabled: true
+    connectionPool:
+      tcp:
+        maxConnections: 100
+        connectTimeout: 5s
+      http:
+        maxRequestsPerConnection: 100
+        maxRetries: 2
+    outlierDetection:
+      consecutive5xxErrors: 5
+      interval: 30s
+      baseEjectionTime: 30s
+      maxEjectionPercent: 50
+    loadBalancer:
+      simple: LEAST_REQUEST
+
+  sidecar:
+    enabled: false

--- a/environments/dev/goti-stadium/values.yaml
+++ b/environments/dev/goti-stadium/values.yaml
@@ -30,6 +30,11 @@ gateway:
             exact: "/api/v1/stadiums"
         - uri:
             prefix: "/api/v1/baseball-teams"
+      timeout: 5s
+      retries:
+        attempts: 2
+        perTryTimeout: 2s
+        retryOn: 5xx,reset,connect-failure
       route:
         - destination:
             host: goti-stadium-dev
@@ -93,3 +98,41 @@ externalSecret:
   remoteRef:
     path: /dev/server  # TODO: 서비스별 경로 분리 예정 (/dev/stadium 등)
     overridePath: /dev/kind/server
+
+# --- Istio 보안/네트워크 정책 ---
+
+istioPolicy:
+  # Phase 1: ticketing → stadium (경기장/팀 조회)
+  authorizationPolicy:
+    enabled: true
+    allowFrom:
+      - name: from-ticketing
+        rules:
+          - from:
+              - source:
+                  principals: ["cluster.local/ns/goti/sa/goti-ticketing-dev"]
+            to:
+              - operation:
+                  paths: ["/api/v1/stadiums*", "/api/v1/baseball-teams*"]
+                  methods: ["GET"]
+
+  # Phase 2: Resilience
+  destinationRule:
+    enabled: true
+    connectionPool:
+      tcp:
+        maxConnections: 100
+        connectTimeout: 5s
+      http:
+        maxRequestsPerConnection: 100
+        maxRetries: 2
+    outlierDetection:
+      consecutive5xxErrors: 5
+      interval: 30s
+      baseEjectionTime: 30s
+      maxEjectionPercent: 50
+    loadBalancer:
+      simple: LEAST_REQUEST
+
+  sidecar:
+    enabled: false

--- a/environments/dev/goti-stadium/values.yaml
+++ b/environments/dev/goti-stadium/values.yaml
@@ -116,23 +116,6 @@ istioPolicy:
                   paths: ["/api/v1/stadiums*", "/api/v1/baseball-teams*"]
                   methods: ["GET"]
 
-  # Phase 2: Resilience
+  # Phase 2: Resilience (공통 설정은 goti-server/values.yaml 기본값 사용)
   destinationRule:
     enabled: true
-    connectionPool:
-      tcp:
-        maxConnections: 100
-        connectTimeout: 5s
-      http:
-        maxRequestsPerConnection: 100
-        maxRetries: 2
-    outlierDetection:
-      consecutive5xxErrors: 5
-      interval: 30s
-      baseEjectionTime: 30s
-      maxEjectionPercent: 50
-    loadBalancer:
-      simple: LEAST_REQUEST
-
-  sidecar:
-    enabled: false

--- a/environments/dev/goti-ticketing/values.yaml
+++ b/environments/dev/goti-ticketing/values.yaml
@@ -40,7 +40,7 @@ gateway:
             prefix: "/api/v1/teams"
         - uri:
             prefix: "/api/v1/stadiums/"
-      timeout: 10s
+      timeout: 12s
       retries:
         attempts: 3
         perTryTimeout: 3s
@@ -123,27 +123,9 @@ istioPolicy:
                   principals: ["cluster.local/ns/goti/sa/goti-payment-dev"]
             to:
               - operation:
-                  # /api/v1/orders/{id}/payment-confirmations — prefix로 매칭
-                  paths: ["/api/v1/orders/*/payment-confirmations"]
+                  paths: ["/api/v1/orders/*"]
                   methods: ["POST"]
 
-  # Phase 2: Resilience (예매/좌석 — 상대적 무거움)
+  # Phase 2: Resilience (공통 설정은 goti-server/values.yaml 기본값 사용)
   destinationRule:
     enabled: true
-    connectionPool:
-      tcp:
-        maxConnections: 100
-        connectTimeout: 5s
-      http:
-        maxRequestsPerConnection: 100
-        maxRetries: 3
-    outlierDetection:
-      consecutive5xxErrors: 5
-      interval: 30s
-      baseEjectionTime: 30s
-      maxEjectionPercent: 50
-    loadBalancer:
-      simple: LEAST_REQUEST
-
-  sidecar:
-    enabled: false

--- a/environments/dev/goti-ticketing/values.yaml
+++ b/environments/dev/goti-ticketing/values.yaml
@@ -40,6 +40,11 @@ gateway:
             prefix: "/api/v1/teams"
         - uri:
             prefix: "/api/v1/stadiums/"
+      timeout: 10s
+      retries:
+        attempts: 3
+        perTryTimeout: 3s
+        retryOn: 5xx,reset,connect-failure
       route:
         - destination:
             host: goti-ticketing-dev
@@ -103,3 +108,42 @@ externalSecret:
   remoteRef:
     path: /dev/server  # TODO: 서비스별 경로 분리 예정 (/dev/ticketing 등)
     overridePath: /dev/kind/server
+
+# --- Istio 보안/네트워크 정책 ---
+
+istioPolicy:
+  # Phase 1: payment → ticketing (결제 확인 콜백)
+  authorizationPolicy:
+    enabled: true
+    allowFrom:
+      - name: from-payment
+        rules:
+          - from:
+              - source:
+                  principals: ["cluster.local/ns/goti/sa/goti-payment-dev"]
+            to:
+              - operation:
+                  # /api/v1/orders/{id}/payment-confirmations — prefix로 매칭
+                  paths: ["/api/v1/orders/*/payment-confirmations"]
+                  methods: ["POST"]
+
+  # Phase 2: Resilience (예매/좌석 — 상대적 무거움)
+  destinationRule:
+    enabled: true
+    connectionPool:
+      tcp:
+        maxConnections: 100
+        connectTimeout: 5s
+      http:
+        maxRequestsPerConnection: 100
+        maxRetries: 3
+    outlierDetection:
+      consecutive5xxErrors: 5
+      interval: 30s
+      baseEjectionTime: 30s
+      maxEjectionPercent: 50
+    loadBalancer:
+      simple: LEAST_REQUEST
+
+  sidecar:
+    enabled: false

--- a/environments/dev/goti-user/values.yaml
+++ b/environments/dev/goti-user/values.yaml
@@ -30,6 +30,11 @@ gateway:
             prefix: "/api/v1/auth"
         - uri:
             prefix: "/api/v1/test"
+      timeout: 5s
+      retries:
+        attempts: 2
+        perTryTimeout: 2s
+        retryOn: 5xx,reset,connect-failure
       route:
         - destination:
             host: goti-user-dev
@@ -93,3 +98,32 @@ externalSecret:
   remoteRef:
     path: /dev/server  # TODO: 서비스별 경로 분리 예정 (/dev/user 등)
     overridePath: /dev/kind/server
+
+# --- Istio 보안/네트워크 정책 ---
+
+istioPolicy:
+  # Phase 1: user 서비스는 다른 서비스로부터 호출받지 않음 (Gateway 통해서만 접근)
+  authorizationPolicy:
+    enabled: true
+    allowFrom: []
+
+  # Phase 2: Resilience
+  destinationRule:
+    enabled: true
+    connectionPool:
+      tcp:
+        maxConnections: 100
+        connectTimeout: 5s
+      http:
+        maxRequestsPerConnection: 100
+        maxRetries: 2
+    outlierDetection:
+      consecutive5xxErrors: 5
+      interval: 30s
+      baseEjectionTime: 30s
+      maxEjectionPercent: 50
+    loadBalancer:
+      simple: LEAST_REQUEST
+
+  sidecar:
+    enabled: false

--- a/environments/dev/goti-user/values.yaml
+++ b/environments/dev/goti-user/values.yaml
@@ -107,23 +107,6 @@ istioPolicy:
     enabled: true
     allowFrom: []
 
-  # Phase 2: Resilience
+  # Phase 2: Resilience (공통 설정은 goti-server/values.yaml 기본값 사용)
   destinationRule:
     enabled: true
-    connectionPool:
-      tcp:
-        maxConnections: 100
-        connectTimeout: 5s
-      http:
-        maxRequestsPerConnection: 100
-        maxRetries: 2
-    outlierDetection:
-      consecutive5xxErrors: 5
-      interval: 30s
-      baseEjectionTime: 30s
-      maxEjectionPercent: 50
-    loadBalancer:
-      simple: LEAST_REQUEST
-
-  sidecar:
-    enabled: false

--- a/gitops/dev/applicationsets/goti-istio-policy.yaml
+++ b/gitops/dev/applicationsets/goti-istio-policy.yaml
@@ -1,0 +1,33 @@
+# Goti namespace Istio 정책 (deny-all + allow rules + ServiceEntry)
+# deny-all과 allow 정책을 하나의 Helm chart로 묶어서 원자적 배포
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: goti-istio-policy
+  namespace: argocd
+spec:
+  project: goti
+  source:
+    repoURL: "https://github.com/Team-Ikujo/Goti-k8s.git"
+    targetRevision: main
+    path: "infrastructure/dev/istio/goti-policy"
+    helm:
+      valueFiles:
+        - values.yaml
+        - values-dev.yaml
+  destination:
+    server: "https://kubernetes.default.svc"
+    namespace: goti
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    retry:
+      limit: 5
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 3m
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/gitops/dev/applicationsets/goti-istio-policy.yaml
+++ b/gitops/dev/applicationsets/goti-istio-policy.yaml
@@ -7,14 +7,14 @@ metadata:
   namespace: argocd
 spec:
   project: goti
-  source:
-    repoURL: "https://github.com/Team-Ikujo/Goti-k8s.git"
-    targetRevision: main
-    path: "infrastructure/dev/istio/goti-policy"
-    helm:
-      valueFiles:
-        - values.yaml
-        - values-dev.yaml
+  sources:
+    - repoURL: "https://github.com/Team-Ikujo/Goti-k8s.git"
+      targetRevision: main  # dev only: HEAD tracking — prod는 반드시 semver tag 고정
+      path: "infrastructure/dev/istio/goti-policy"
+      helm:
+        valueFiles:
+          - values.yaml
+          - values-dev.yaml
   destination:
     server: "https://kubernetes.default.svc"
     namespace: goti

--- a/gitops/dev/projects/goti-project.yaml
+++ b/gitops/dev/projects/goti-project.yaml
@@ -50,6 +50,8 @@ spec:
       kind: DestinationRule
     - group: "networking.istio.io"
       kind: ServiceEntry
+    - group: "networking.istio.io"
+      kind: Sidecar
     - group: "security.istio.io"
       kind: PeerAuthentication
     - group: "security.istio.io"

--- a/gitops/dev/projects/infra-project.yaml
+++ b/gitops/dev/projects/infra-project.yaml
@@ -12,6 +12,8 @@ spec:
       server: "https://kubernetes.default.svc"
     - namespace: istio-system
       server: "https://kubernetes.default.svc"
+    - namespace: monitoring
+      server: "https://kubernetes.default.svc"
   clusterResourceWhitelist:
     - group: ""
       kind: Namespace

--- a/infrastructure/dev/istio/goti-policy/Chart.yaml
+++ b/infrastructure/dev/istio/goti-policy/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: goti-istio-policy
+description: Goti namespace Istio 보안/네트워크 정책 (deny-all, allow rules, ServiceEntry)
+type: application
+version: 0.1.0

--- a/infrastructure/dev/istio/goti-policy/Chart.yaml
+++ b/infrastructure/dev/istio/goti-policy/Chart.yaml
@@ -3,3 +3,4 @@ name: goti-istio-policy
 description: Goti namespace Istio 보안/네트워크 정책 (deny-all, allow rules, ServiceEntry)
 type: application
 version: 0.1.0
+appVersion: "1.29"

--- a/infrastructure/dev/istio/goti-policy/templates/allow-istio-gateway.yaml
+++ b/infrastructure/dev/istio/goti-policy/templates/allow-istio-gateway.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.allowGateway.enabled }}
+# Gateway → 모든 goti 서비스 허용
+# 외부 트래픽은 Istio Gateway를 통해서만 진입
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-istio-gateway
+spec:
+  action: ALLOW
+  rules:
+    - from:
+        - source:
+            principals:
+              - {{ .Values.allowGateway.gatewaySA | quote }}
+{{- end }}

--- a/infrastructure/dev/istio/goti-policy/templates/allow-kubelet-probes.yaml
+++ b/infrastructure/dev/istio/goti-policy/templates/allow-kubelet-probes.yaml
@@ -11,6 +11,6 @@ spec:
   rules:
     - to:
         - operation:
-            paths: ["/actuator/health/*"]
+            paths: ["/actuator/health/liveness", "/actuator/health/readiness"]
             methods: ["GET"]
 {{- end }}

--- a/infrastructure/dev/istio/goti-policy/templates/allow-kubelet-probes.yaml
+++ b/infrastructure/dev/istio/goti-policy/templates/allow-kubelet-probes.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.allowKubeletProbes.enabled }}
+# Kubelet health probe 허용
+# Istio 1.7+에서 자동 probe 리디렉션이 작동하지만, 안전장치로 추가
+# from 없음 = 모든 소스 허용 (kubelet은 mesh identity 없음)
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-kubelet-probes
+spec:
+  action: ALLOW
+  rules:
+    - to:
+        - operation:
+            paths: ["/actuator/health/*"]
+            methods: ["GET"]
+{{- end }}

--- a/infrastructure/dev/istio/goti-policy/templates/allow-prometheus-scrape.yaml
+++ b/infrastructure/dev/istio/goti-policy/templates/allow-prometheus-scrape.yaml
@@ -17,11 +17,6 @@ spec:
       to:
         - operation:
             ports: ["15020", "15090"]
-    - from:
-        - source:
-            namespaces:
-              - {{ .Values.allowPrometheus.sourceNamespace | quote }}
-      to:
         - operation:
             ports: ["8080"]
             paths: ["/actuator/prometheus"]

--- a/infrastructure/dev/istio/goti-policy/templates/allow-prometheus-scrape.yaml
+++ b/infrastructure/dev/istio/goti-policy/templates/allow-prometheus-scrape.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.allowPrometheus.enabled }}
+# Prometheus (monitoring namespace) → goti 서비스 메트릭 스크랩 허용
+# - 15020: Istio merged prometheus metrics
+# - 15090: Envoy admin stats
+# - 8080: /actuator/prometheus (Spring Boot)
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-prometheus-scrape
+spec:
+  action: ALLOW
+  rules:
+    - from:
+        - source:
+            namespaces:
+              - {{ .Values.allowPrometheus.sourceNamespace | quote }}
+      to:
+        - operation:
+            ports: ["15020", "15090"]
+    - from:
+        - source:
+            namespaces:
+              - {{ .Values.allowPrometheus.sourceNamespace | quote }}
+      to:
+        - operation:
+            ports: ["8080"]
+            paths: ["/actuator/prometheus"]
+            methods: ["GET"]
+{{- end }}

--- a/infrastructure/dev/istio/goti-policy/templates/deny-all.yaml
+++ b/infrastructure/dev/istio/goti-policy/templates/deny-all.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.denyAll.enabled }}
+# deny-all: 빈 spec = goti namespace 모든 워크로드에 대한 트래픽 거부
+# 개별 ALLOW 정책으로 필요한 트래픽만 허용 (allowlist 패턴)
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: deny-all
+spec: {}
+{{- end }}

--- a/infrastructure/dev/istio/goti-policy/templates/serviceentries.yaml
+++ b/infrastructure/dev/istio/goti-policy/templates/serviceentries.yaml
@@ -1,0 +1,16 @@
+{{- range .Values.serviceEntries }}
+---
+apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata:
+  name: {{ .name }}
+spec:
+  hosts:
+    {{- range .hosts }}
+    - {{ . | quote }}
+    {{- end }}
+  location: {{ .location | default "MESH_EXTERNAL" }}
+  ports:
+    {{- toYaml .ports | nindent 4 }}
+  resolution: {{ .resolution | default "DNS" }}
+{{- end }}

--- a/infrastructure/dev/istio/goti-policy/values-dev.yaml
+++ b/infrastructure/dev/istio/goti-policy/values-dev.yaml
@@ -1,0 +1,56 @@
+# dev 환경 Istio 정책
+denyAll:
+  enabled: true
+
+allowGateway:
+  enabled: true
+  gatewaySA: "cluster.local/ns/istio-system/sa/istio-gateway"
+
+allowPrometheus:
+  enabled: true
+  sourceNamespace: "monitoring"
+
+allowKubeletProbes:
+  enabled: true
+
+# Phase 2: 외부 서비스 허용 (OAuth, SMS 등)
+serviceEntries:
+  - name: oauth-google
+    hosts:
+      - "accounts.google.com"
+      - "oauth2.googleapis.com"
+      - "www.googleapis.com"
+    ports:
+      - number: 443
+        name: https
+        protocol: TLS
+  - name: oauth-naver
+    hosts:
+      - "nid.naver.com"
+      - "openapi.naver.com"
+    ports:
+      - number: 443
+        name: https
+        protocol: TLS
+  - name: oauth-kakao
+    hosts:
+      - "kauth.kakao.com"
+      - "kapi.kakao.com"
+    ports:
+      - number: 443
+        name: https
+        protocol: TLS
+  - name: sms-nurigo
+    hosts:
+      - "api.coolsms.co.kr"
+    ports:
+      - number: 443
+        name: https
+        protocol: TLS
+  - name: aws-services
+    hosts:
+      - "*.amazonaws.com"
+    ports:
+      - number: 443
+        name: https
+        protocol: TLS

--- a/infrastructure/dev/istio/goti-policy/values-dev.yaml
+++ b/infrastructure/dev/istio/goti-policy/values-dev.yaml
@@ -1,19 +1,7 @@
 # dev 환경 Istio 정책
-denyAll:
-  enabled: true
+# 기본값(values.yaml)과 동일한 필드는 생략 — 차이값만 오버라이드
 
-allowGateway:
-  enabled: true
-  gatewaySA: "cluster.local/ns/istio-system/sa/istio-gateway"
-
-allowPrometheus:
-  enabled: true
-  sourceNamespace: "monitoring"
-
-allowKubeletProbes:
-  enabled: true
-
-# Phase 2: 외부 서비스 허용 (OAuth, SMS 등)
+# Phase 2: 외부 서비스 허용 (OAuth, SMS, AWS)
 serviceEntries:
   - name: oauth-google
     hosts:
@@ -49,7 +37,9 @@ serviceEntries:
         protocol: TLS
   - name: aws-services
     hosts:
-      - "*.amazonaws.com"
+      - "ssm.ap-northeast-2.amazonaws.com"
+      - "secretsmanager.ap-northeast-2.amazonaws.com"
+      - "sts.ap-northeast-2.amazonaws.com"
     ports:
       - number: 443
         name: https

--- a/infrastructure/dev/istio/goti-policy/values.yaml
+++ b/infrastructure/dev/istio/goti-policy/values.yaml
@@ -1,0 +1,20 @@
+# Goti namespace Istio 정책 기본값
+# deny-all + allow 정책은 반드시 동시 배포
+
+denyAll:
+  enabled: true
+
+allowGateway:
+  enabled: true
+  # Istio Gateway Helm release의 ServiceAccount 이름
+  gatewaySA: "cluster.local/ns/istio-system/sa/istio-gateway"
+
+allowPrometheus:
+  enabled: true
+  sourceNamespace: "monitoring"
+
+allowKubeletProbes:
+  enabled: true
+
+# Phase 2: 외부 서비스 ServiceEntry
+serviceEntries: []

--- a/infrastructure/dev/istio/mesh-policy/Chart.yaml
+++ b/infrastructure/dev/istio/mesh-policy/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: istio-mesh-policy
+description: Mesh-wide Istio 보안 정책 (PeerAuthentication STRICT mTLS)
+type: application
+version: 0.1.0

--- a/infrastructure/dev/istio/mesh-policy/Chart.yaml
+++ b/infrastructure/dev/istio/mesh-policy/Chart.yaml
@@ -3,3 +3,4 @@ name: istio-mesh-policy
 description: Mesh-wide Istio 보안 정책 (PeerAuthentication STRICT mTLS)
 type: application
 version: 0.1.0
+appVersion: "1.29"

--- a/infrastructure/dev/istio/mesh-policy/templates/mesh-wide-mtls.yaml
+++ b/infrastructure/dev/istio/mesh-policy/templates/mesh-wide-mtls.yaml
@@ -1,0 +1,10 @@
+# Mesh-wide STRICT mTLS
+# istio-system namespace에 배포 → 모든 namespace에 적용
+# monitoring namespace는 자체 PERMISSIVE PeerAuthentication으로 오버라이드됨
+apiVersion: security.istio.io/v1
+kind: PeerAuthentication
+metadata:
+  name: default
+spec:
+  mtls:
+    mode: {{ .Values.mtls.mode }}

--- a/infrastructure/dev/istio/mesh-policy/templates/monitoring-permissive.yaml
+++ b/infrastructure/dev/istio/mesh-policy/templates/monitoring-permissive.yaml
@@ -1,0 +1,11 @@
+# monitoring namespace: PERMISSIVE mTLS
+# mesh-wide STRICT와 공존 — namespace 레벨 PeerAuthentication이 mesh-wide보다 우선
+# monitoring 컴포넌트(Prometheus, Alloy 등)가 non-mTLS 트래픽도 수신 가능하도록 허용
+apiVersion: security.istio.io/v1
+kind: PeerAuthentication
+metadata:
+  name: monitoring-permissive
+  namespace: monitoring
+spec:
+  mtls:
+    mode: PERMISSIVE

--- a/infrastructure/dev/istio/mesh-policy/values-dev.yaml
+++ b/infrastructure/dev/istio/mesh-policy/values-dev.yaml
@@ -1,3 +1,2 @@
-# dev 환경: 바로 STRICT (PERMISSIVE 중간 단계 불필요)
-mtls:
-  mode: STRICT
+# dev 환경: values.yaml 기본값(STRICT) 그대로 사용
+# prod 환경 분리 시 여기에 환경별 오버라이드 추가

--- a/infrastructure/dev/istio/mesh-policy/values-dev.yaml
+++ b/infrastructure/dev/istio/mesh-policy/values-dev.yaml
@@ -1,0 +1,3 @@
+# dev 환경: 바로 STRICT (PERMISSIVE 중간 단계 불필요)
+mtls:
+  mode: STRICT

--- a/infrastructure/dev/istio/mesh-policy/values.yaml
+++ b/infrastructure/dev/istio/mesh-policy/values.yaml
@@ -1,0 +1,2 @@
+mtls:
+  mode: STRICT


### PR DESCRIPTION
## 관련 이슈
- N/A (Istio 심화 설정 — 보안 + Resilience 일괄 적용)

## 개요
현재 Istio 1.29는 VirtualService 라우팅만 사용 중. 서비스 메시 핵심인 mTLS, 접근 제어, circuit breaker, timeout/retry가 전무한 상태.
Phase 1(보안) + Phase 2(Resilience)를 한 PR로 묶어서 배포한다.

## 작업 내용

### Phase 1: 보안
- [x] **Mesh-wide STRICT mTLS** (`infrastructure/dev/istio/mesh-policy/`)
  - PeerAuthentication (istio-system) — 모든 namespace에 적용
  - monitoring namespace는 기존 PERMISSIVE로 오버라이드됨
- [x] **goti namespace deny-all + allowlist 패턴** (`infrastructure/dev/istio/goti-policy/`)
  - `deny-all`: 빈 spec → 모든 트래픽 거부
  - `allow-istio-gateway`: Gateway SA 기반 외부 트래픽 허용
  - `allow-prometheus-scrape`: monitoring ns → 15020, 15090, /actuator/prometheus 허용
  - `allow-kubelet-probes`: /actuator/health/* GET 허용
- [x] **서비스별 AuthorizationPolicy** (`goti-common` 라이브러리 템플릿)
  - stadium ← ticketing (경기장/팀 조회 GET)
  - ticketing ← payment (결제 확인 콜백 POST)
  - payment ← resale (양도 결제/환불 POST, PATCH)
  - resale ← payment (양도 완료/거래 조회 GET, PATCH)
  - user ← (없음, Gateway 통해서만 접근)

### Phase 2: Resilience
- [x] **DestinationRule** — circuit breaker (consecutive5xxErrors: 5), connection pool (maxConnections: 100), LEAST_REQUEST LB
- [x] **VirtualService timeout/retries** — 서비스별 차등 설정
  - user/stadium: 5s / retry 2
  - ticketing: 10s / retry 3
  - payment: 15s / retry 2
  - resale: 10s / retry 2
- [x] **ServiceEntry** — OAuth(Google/Naver/Kakao), SMS(nurigo), AWS 서비스
- [x] **Sidecar 템플릿** — 기본 비활성화, 향후 egress 제한용

### ArgoCD
- [x] `istio-mesh-policy` Application (bootstrap, sync-wave: -2)
- [x] `goti-istio-policy` Application (gitops/dev/applicationsets/, goti project)

### 파일 변경
- 신규 18개 (chart 2개 + 라이브러리 템플릿 3개 + include 3개 + ArgoCD App 1개)
- 수정 7개 (bootstrap + goti-server defaults + 5개 서비스 values)

## 테스트
- [x] `helm template` 렌더링 검증 (mesh-policy, goti-policy, 5개 서비스 전체)
- [ ] Kind 로컬 클러스터 배포 검증
- [ ] ArgoCD sync 확인
- [ ] `kubectl get peerauthentication -A` → STRICT 확인
- [ ] `kubectl get authorizationpolicy -n goti` → deny-all + allows 확인
- [ ] 외부 API 호출 테스트 (`curl https://dev.go-ti.shop/api/v1/stadiums`)
- [ ] Prometheus scrape targets UP 확인
- [ ] Gateway SA 이름 확인 (`kubectl get sa -n istio-system`)

> ⚠️ Gateway SA가 `istio-gateway`가 아닐 경우 `goti-policy/values-dev.yaml`의 `gatewaySA` 수정 필요