### PR TITLE
fix(istio): monitoring scrape 호환 — goti ns PERMISSIVE + source 제약 제거

### DIFF
--- a/infrastructure/dev/istio/goti-policy/templates/allow-prometheus-scrape.yaml
+++ b/infrastructure/dev/istio/goti-policy/templates/allow-prometheus-scrape.yaml
@@ -12,9 +12,13 @@ metadata:
 spec:
   action: ALLOW
   rules:
+    # TODO(prod): monitoring에 sidecar 주입 후 source.namespaces 복원
+    # dev only: sidecar 미주입으로 source 식별 불가하여 from 절 생략
     - to:
         - operation:
             ports: ["15020", "15090"]
+            paths: ["/stats/prometheus"]
+            methods: ["GET"]
         - operation:
             ports: ["8080"]
             paths: ["/actuator/prometheus"]

--- a/infrastructure/dev/istio/goti-policy/templates/allow-prometheus-scrape.yaml
+++ b/infrastructure/dev/istio/goti-policy/templates/allow-prometheus-scrape.yaml
@@ -1,5 +1,7 @@
 {{- if .Values.allowPrometheus.enabled }}
-# Prometheus (monitoring namespace) → goti 서비스 메트릭 스크랩 허용
+# Prometheus/Alloy → goti 서비스 메트릭 스크랩 허용
+# monitoring namespace에 sidecar 미주입 → source.namespaces 식별 불가
+# port + path + method 제한으로 보호 (non-mesh 소스도 허용)
 # - 15020: Istio merged prometheus metrics
 # - 15090: Envoy admin stats
 # - 8080: /actuator/prometheus (Spring Boot)
@@ -10,11 +12,7 @@ metadata:
 spec:
   action: ALLOW
   rules:
-    - from:
-        - source:
-            namespaces:
-              - {{ .Values.allowPrometheus.sourceNamespace | quote }}
-      to:
+    - to:
         - operation:
             ports: ["15020", "15090"]
         - operation:

--- a/infrastructure/dev/istio/goti-policy/templates/peer-auth-prometheus-ports.yaml
+++ b/infrastructure/dev/istio/goti-policy/templates/peer-auth-prometheus-ports.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.allowPrometheus.enabled }}
+# goti namespace PERMISSIVE mTLS
+# monitoring namespace에 sidecar 미주입 → plaintext scrape 수신 허용
+# AuthorizationPolicy deny-all이 L7 접근 제어를 담당하므로 보안 유지
+# mesh 내부(sidecar → sidecar) 통신은 자동으로 mTLS 사용
+apiVersion: security.istio.io/v1
+kind: PeerAuthentication
+metadata:
+  name: default
+spec:
+  mtls:
+    mode: PERMISSIVE
+{{- end }}

--- a/infrastructure/dev/istio/goti-policy/templates/peer-auth-prometheus-ports.yaml
+++ b/infrastructure/dev/istio/goti-policy/templates/peer-auth-prometheus-ports.yaml
@@ -1,13 +1,21 @@
-{{- if .Values.allowPrometheus.enabled }}
-# goti namespace PERMISSIVE mTLS
+{{- if .Values.peerAuth.permissiveForScrape.enabled }}
+# goti namespace — scrape 포트만 PERMISSIVE mTLS (dev only)
 # monitoring namespace에 sidecar 미주입 → plaintext scrape 수신 허용
+# 기본 STRICT 유지, scrape 대상 포트만 PERMISSIVE로 범위 최소화
 # AuthorizationPolicy deny-all이 L7 접근 제어를 담당하므로 보안 유지
-# mesh 내부(sidecar → sidecar) 통신은 자동으로 mTLS 사용
+# TODO(prod): monitoring에 sidecar 주입 후 enabled: false 또는 이 파일 제거
 apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
-  name: default
+  name: goti-permissive-for-scrape
 spec:
   mtls:
-    mode: PERMISSIVE
+    mode: STRICT
+  portLevelMtls:
+    15020:
+      mode: PERMISSIVE  # Istio merged prometheus metrics
+    15090:
+      mode: PERMISSIVE  # Envoy admin stats
+    8080:
+      mode: PERMISSIVE  # Spring Boot actuator (/actuator/prometheus)
 {{- end }}

--- a/infrastructure/dev/istio/goti-policy/values.yaml
+++ b/infrastructure/dev/istio/goti-policy/values.yaml
@@ -11,7 +11,12 @@ allowGateway:
 
 allowPrometheus:
   enabled: true
-  sourceNamespace: "monitoring"
+
+# mTLS PERMISSIVE — scrape 포트만 plaintext 허용 (dev only)
+# prod: monitoring에 sidecar 주입 후 enabled: false
+peerAuth:
+  permissiveForScrape:
+    enabled: true
 
 allowKubeletProbes:
   enabled: true


### PR DESCRIPTION
## 관련 이슈
- monitoring namespace에서 goti 서비스 메트릭 스크랩 실패

## 개요
monitoring namespace에 Istio sidecar가 주입되지 않아 `source.namespaces` 기반 AuthorizationPolicy가 동작하지 않는 문제 수정. goti namespace를 PERMISSIVE mTLS로 전환하고, scrape 정책에서 source 제약을 제거하여 non-mesh 소스(Prometheus/Alloy)도 허용.

## 작업 내용
- [x] `allow-prometheus-scrape.yaml`: `source.namespaces` 제거 → port + path + method 제한으로 보호
- [x] `peer-auth-prometheus-ports.yaml` 신규: goti ns PERMISSIVE PeerAuthentication 추가
  - mesh 내부 통신은 자동 mTLS 유지, deny-all AuthorizationPolicy가 L7 접근 제어 담당

## 테스트
- [x] `helm lint` 통과
- [x] `helm template` 렌더링 검증
- [x] Kind 로컬 클러스터 배포 검증
- [x] ArgoCD sync 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)