### PR TITLE
[FEAT] K8s + 네트워크 보안 하드닝 (#52)

### DIFF
--- a/charts/goti-common/templates/_deployment.tpl
+++ b/charts/goti-common/templates/_deployment.tpl
@@ -31,18 +31,11 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        fsGroup: 1000
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
-            seccompProfile:
-              type: RuntimeDefault
+            {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
@@ -72,9 +65,16 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
       volumes:
         - name: tmp
-          emptyDir: {}
+          emptyDir:
+            sizeLimit: 100Mi
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/goti-common/templates/_deployment.tpl
+++ b/charts/goti-common/templates/_deployment.tpl
@@ -25,12 +25,24 @@ spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ default (include "goti-common.fullname" .) .Values.serviceAccount.name }}
       {{- end }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken | default false }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
       containers:
         - name: {{ .Chart.Name }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
@@ -57,6 +69,12 @@ spec:
           envFrom:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/goti-common/templates/_serviceaccount.tpl
+++ b/charts/goti-common/templates/_serviceaccount.tpl
@@ -10,5 +10,6 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken | default false }}
 {{- end }}
 {{- end }}

--- a/charts/goti-server/values.yaml
+++ b/charts/goti-server/values.yaml
@@ -11,6 +11,7 @@ serviceAccount:
   create: true
   name: ""
   annotations: {}
+  automountServiceAccountToken: false
 
 service:
   type: ClusterIP

--- a/charts/goti-server/values.yaml
+++ b/charts/goti-server/values.yaml
@@ -76,6 +76,22 @@ externalSecret:
   remoteRef:
     path: ""
 
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  fsGroup: 1000
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop: ["ALL"]
+  seccompProfile:
+    type: RuntimeDefault
+
+extraVolumeMounts: []
+extraVolumes: []
+
 podAnnotations: {}
 nodeSelector: {}
 tolerations: []

--- a/environments/dev/goti-payment/values.yaml
+++ b/environments/dev/goti-payment/values.yaml
@@ -117,3 +117,13 @@ istioPolicy:
   # Phase 2: Resilience (공통 설정은 goti-server/values.yaml 기본값 사용)
   destinationRule:
     enabled: true
+
+  # Phase 2: Sidecar egress 제한
+  sidecar:
+    enabled: true
+    egress:
+      - hosts:
+          - "istio-system/*"
+          - "./*"
+          - "monitoring/alloy-dev.monitoring.svc.cluster.local"
+          - "~/*.amazonaws.com"

--- a/environments/dev/goti-payment/values.yaml
+++ b/environments/dev/goti-payment/values.yaml
@@ -126,4 +126,5 @@ istioPolicy:
           - "istio-system/*"
           - "./*"
           - "monitoring/alloy-dev.monitoring.svc.cluster.local"
+          - "kafka/*"
           - "~/*.amazonaws.com"

--- a/environments/dev/goti-resale/values.yaml
+++ b/environments/dev/goti-resale/values.yaml
@@ -117,3 +117,13 @@ istioPolicy:
   # Phase 2: Resilience (공통 설정은 goti-server/values.yaml 기본값 사용)
   destinationRule:
     enabled: true
+
+  # Phase 2: Sidecar egress 제한
+  sidecar:
+    enabled: true
+    egress:
+      - hosts:
+          - "istio-system/*"
+          - "./*"
+          - "monitoring/alloy-dev.monitoring.svc.cluster.local"
+          - "~/*.amazonaws.com"

--- a/environments/dev/goti-resale/values.yaml
+++ b/environments/dev/goti-resale/values.yaml
@@ -126,4 +126,5 @@ istioPolicy:
           - "istio-system/*"
           - "./*"
           - "monitoring/alloy-dev.monitoring.svc.cluster.local"
+          - "kafka/*"
           - "~/*.amazonaws.com"

--- a/environments/dev/goti-stadium/values.yaml
+++ b/environments/dev/goti-stadium/values.yaml
@@ -128,4 +128,5 @@ istioPolicy:
           - "istio-system/*"
           - "./*"
           - "monitoring/alloy-dev.monitoring.svc.cluster.local"
+          - "kafka/*"
           - "~/*.amazonaws.com"

--- a/environments/dev/goti-stadium/values.yaml
+++ b/environments/dev/goti-stadium/values.yaml
@@ -119,3 +119,13 @@ istioPolicy:
   # Phase 2: Resilience (공통 설정은 goti-server/values.yaml 기본값 사용)
   destinationRule:
     enabled: true
+
+  # Phase 2: Sidecar egress 제한
+  sidecar:
+    enabled: true
+    egress:
+      - hosts:
+          - "istio-system/*"
+          - "./*"
+          - "monitoring/alloy-dev.monitoring.svc.cluster.local"
+          - "~/*.amazonaws.com"

--- a/environments/dev/goti-ticketing/values.yaml
+++ b/environments/dev/goti-ticketing/values.yaml
@@ -129,3 +129,13 @@ istioPolicy:
   # Phase 2: Resilience (공통 설정은 goti-server/values.yaml 기본값 사용)
   destinationRule:
     enabled: true
+
+  # Phase 2: Sidecar egress 제한
+  sidecar:
+    enabled: true
+    egress:
+      - hosts:
+          - "istio-system/*"
+          - "./*"
+          - "monitoring/alloy-dev.monitoring.svc.cluster.local"
+          - "~/*.amazonaws.com"

--- a/environments/dev/goti-ticketing/values.yaml
+++ b/environments/dev/goti-ticketing/values.yaml
@@ -138,4 +138,5 @@ istioPolicy:
           - "istio-system/*"
           - "./*"
           - "monitoring/alloy-dev.monitoring.svc.cluster.local"
+          - "kafka/*"
           - "~/*.amazonaws.com"

--- a/environments/dev/goti-user/values.yaml
+++ b/environments/dev/goti-user/values.yaml
@@ -119,8 +119,12 @@ istioPolicy:
           - "istio-system/*"
           - "./*"
           - "monitoring/alloy-dev.monitoring.svc.cluster.local"
+          - "kafka/*"
+          # OAuth 소셜 로그인 (Google, Naver, Kakao)
           - "~/*.googleapis.com"
           - "~/*.naver.com"
           - "~/*.kakao.com"
+          # SMS 발송 (Nurigo/CoolSMS)
           - "~/*.nurigo.com"
+          # AWS (SSM Parameter Store, STS)
           - "~/*.amazonaws.com"

--- a/environments/dev/goti-user/values.yaml
+++ b/environments/dev/goti-user/values.yaml
@@ -110,3 +110,17 @@ istioPolicy:
   # Phase 2: Resilience (공통 설정은 goti-server/values.yaml 기본값 사용)
   destinationRule:
     enabled: true
+
+  # Phase 2: Sidecar egress 제한
+  sidecar:
+    enabled: true
+    egress:
+      - hosts:
+          - "istio-system/*"
+          - "./*"
+          - "monitoring/alloy-dev.monitoring.svc.cluster.local"
+          - "~/*.googleapis.com"
+          - "~/*.naver.com"
+          - "~/*.kakao.com"
+          - "~/*.nurigo.com"
+          - "~/*.amazonaws.com"

--- a/gitops/dev/projects/infra-project.yaml
+++ b/gitops/dev/projects/infra-project.yaml
@@ -27,6 +27,9 @@ spec:
       kind: MutatingWebhookConfiguration
     - group: "admissionregistration.k8s.io"
       kind: ValidatingWebhookConfiguration
+    # External Secrets (cluster-scoped)
+    - group: "external-secrets.io"
+      kind: ClusterSecretStore
   namespaceResourceWhitelist:
     # Core
     - group: ""
@@ -100,8 +103,6 @@ spec:
     - group: "kafka.strimzi.io"
       kind: KafkaUser
     # External Secrets
-    - group: "external-secrets.io"
-      kind: ClusterSecretStore
     - group: "external-secrets.io"
       kind: ExternalSecret
     # Batch

--- a/gitops/dev/projects/infra-project.yaml
+++ b/gitops/dev/projects/infra-project.yaml
@@ -27,7 +27,91 @@ spec:
       kind: MutatingWebhookConfiguration
     - group: "admissionregistration.k8s.io"
       kind: ValidatingWebhookConfiguration
-  # Istio, ArgoCD 리소스 타입이 다양하므로 namespace 경계로 격리
   namespaceResourceWhitelist:
-    - group: "*"
-      kind: "*"
+    # Core
+    - group: ""
+      kind: Service
+    - group: ""
+      kind: ConfigMap
+    - group: ""
+      kind: Secret
+    - group: ""
+      kind: ServiceAccount
+    - group: ""
+      kind: Endpoints
+    # Apps
+    - group: "apps"
+      kind: Deployment
+    - group: "apps"
+      kind: DaemonSet
+    - group: "apps"
+      kind: StatefulSet
+    # RBAC
+    - group: "rbac.authorization.k8s.io"
+      kind: Role
+    - group: "rbac.authorization.k8s.io"
+      kind: RoleBinding
+    # Istio
+    - group: "networking.istio.io"
+      kind: Gateway
+    - group: "networking.istio.io"
+      kind: VirtualService
+    - group: "networking.istio.io"
+      kind: DestinationRule
+    - group: "networking.istio.io"
+      kind: EnvoyFilter
+    - group: "networking.istio.io"
+      kind: ServiceEntry
+    - group: "networking.istio.io"
+      kind: Sidecar
+    - group: "security.istio.io"
+      kind: PeerAuthentication
+    - group: "security.istio.io"
+      kind: AuthorizationPolicy
+    - group: "security.istio.io"
+      kind: RequestAuthentication
+    # Monitoring
+    - group: "monitoring.coreos.com"
+      kind: ServiceMonitor
+    - group: "monitoring.coreos.com"
+      kind: PodMonitor
+    - group: "monitoring.coreos.com"
+      kind: PrometheusRule
+    # ArgoCD
+    - group: "argoproj.io"
+      kind: Application
+    - group: "argoproj.io"
+      kind: ApplicationSet
+    - group: "argoproj.io"
+      kind: AppProject
+    # NetworkPolicy
+    - group: "networking.k8s.io"
+      kind: NetworkPolicy
+    # OTel
+    - group: "opentelemetry.io"
+      kind: Instrumentation
+    - group: "opentelemetry.io"
+      kind: OpenTelemetryCollector
+    # Strimzi Kafka
+    - group: "kafka.strimzi.io"
+      kind: Kafka
+    - group: "kafka.strimzi.io"
+      kind: KafkaTopic
+    - group: "kafka.strimzi.io"
+      kind: KafkaUser
+    # External Secrets
+    - group: "external-secrets.io"
+      kind: ClusterSecretStore
+    - group: "external-secrets.io"
+      kind: ExternalSecret
+    # Batch
+    - group: "batch"
+      kind: CronJob
+    - group: "batch"
+      kind: Job
+    # Policy
+    - group: "policy"
+      kind: PodDisruptionBudget
+    # Autoscaling
+    - group: "autoscaling"
+      kind: HorizontalPodAutoscaler

--- a/infrastructure/dev/network-policies/argocd-netpol.yaml
+++ b/infrastructure/dev/network-policies/argocd-netpol.yaml
@@ -1,0 +1,40 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: argocd
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+# ArgoCD server: NodePort 외부 접근 허용
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-argocd-server
+  namespace: argocd
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: argocd-server
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - port: 8080
+          protocol: TCP
+---
+# ArgoCD 내부 컴포넌트 간 통신
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-argocd-internal
+  namespace: argocd
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector: {}

--- a/infrastructure/dev/network-policies/argocd-netpol.yaml
+++ b/infrastructure/dev/network-policies/argocd-netpol.yaml
@@ -1,14 +1,16 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: default-deny-ingress
+  name: default-deny-all
   namespace: argocd
 spec:
   podSelector: {}
   policyTypes:
     - Ingress
+    - Egress
 ---
 # ArgoCD server: NodePort 외부 접근 허용
+# dev only: NodePort 외부 접근을 위해 from 미제한. prod에서는 ingress controller namespace만 허용
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -35,6 +37,58 @@ spec:
   podSelector: {}
   policyTypes:
     - Ingress
+    - Egress
   ingress:
     - from:
         - podSelector: {}
+  egress:
+    - to:
+        - podSelector: {}
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+        podSelector:
+          matchLabels:
+            k8s-app: kube-dns
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+---
+# repo-server: GitHub HTTPS egress (Git clone)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-repo-server-egress
+  namespace: argocd
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: argocd-repo-server
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+---
+# application-controller: K8s API server egress
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-controller-k8s-api
+  namespace: argocd
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: argocd-application-controller
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP

--- a/infrastructure/dev/network-policies/goti-netpol.yaml
+++ b/infrastructure/dev/network-policies/goti-netpol.yaml
@@ -1,24 +1,23 @@
+# goti namespace: defense-in-depth (Istio AuthorizationPolicy L7 + NetworkPolicy L3/L4)
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: default-deny-all
-  namespace: monitoring
+  namespace: goti
 spec:
   podSelector: {}
   policyTypes:
     - Ingress
     - Egress
 ---
-# Grafana: Istio Gateway에서 접근 허용
+# Istio Gateway에서의 ingress 허용
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: allow-grafana-ingress
-  namespace: monitoring
+  name: allow-from-istio-gateway
+  namespace: goti
 spec:
-  podSelector:
-    matchLabels:
-      app.kubernetes.io/name: grafana
+  podSelector: {}
   policyTypes:
     - Ingress
   ingress:
@@ -26,16 +25,13 @@ spec:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: istio-system
-      ports:
-        - port: 3000
-          protocol: TCP
 ---
-# monitoring 내부 통신 허용 (Alloy→Mimir, Alloy→Loki, Alloy→Tempo 등)
+# goti namespace 내부 서비스 간 통신
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: allow-monitoring-internal
-  namespace: monitoring
+  name: allow-goti-internal
+  namespace: goti
 spec:
   podSelector: {}
   policyTypes:
@@ -47,59 +43,22 @@ spec:
   egress:
     - to:
         - podSelector: {}
-    - to:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: kube-system
-        podSelector:
-          matchLabels:
-            k8s-app: kube-dns
-      ports:
-        - port: 53
-          protocol: UDP
-        - port: 53
-          protocol: TCP
 ---
-# Alloy: goti namespace에서 OTLP 수신
+# monitoring에서의 scrape 허용 (Alloy metrics + Istio sidecar)
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: allow-alloy-ingress
-  namespace: monitoring
+  name: allow-monitoring-scrape
+  namespace: goti
 spec:
-  podSelector:
-    matchLabels:
-      app.kubernetes.io/name: alloy
+  podSelector: {}
   policyTypes:
     - Ingress
   ingress:
     - from:
         - namespaceSelector:
             matchLabels:
-              kubernetes.io/metadata.name: goti
-      ports:
-        - port: 4317
-          protocol: TCP
-        - port: 4318
-          protocol: TCP
----
-# Alloy: goti namespace scrape egress + kube-system metrics
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: allow-alloy-scrape-egress
-  namespace: monitoring
-spec:
-  podSelector:
-    matchLabels:
-      app.kubernetes.io/name: alloy
-  policyTypes:
-    - Egress
-  egress:
-    - to:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: goti
+              kubernetes.io/metadata.name: monitoring
       ports:
         - port: 8080
           protocol: TCP
@@ -107,13 +66,49 @@ spec:
           protocol: TCP
         - port: 15090
           protocol: TCP
+---
+# egress: monitoring (OTLP), kafka, DNS, Istio control plane
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-goti-egress
+  namespace: goti
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    # monitoring: Alloy OTLP
     - to:
         - namespaceSelector:
             matchLabels:
-              kubernetes.io/metadata.name: kube-system
+              kubernetes.io/metadata.name: monitoring
       ports:
-        - port: 8080
+        - port: 4317
           protocol: TCP
+        - port: 4318
+          protocol: TCP
+    # kafka: 브로커 접근
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kafka
+      ports:
+        - port: 9092
+          protocol: TCP
+        - port: 9093
+          protocol: TCP
+    # istio-system: Istiod xDS, CA
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: istio-system
+      ports:
+        - port: 15012
+          protocol: TCP
+        - port: 15014
+          protocol: TCP
+    # DNS
     - to:
         - namespaceSelector:
             matchLabels:
@@ -125,4 +120,8 @@ spec:
         - port: 53
           protocol: UDP
         - port: 53
+          protocol: TCP
+    # 외부 HTTPS (AWS SSM, OAuth 등 — Sidecar에서 L7 세분화)
+    - ports:
+        - port: 443
           protocol: TCP

--- a/infrastructure/dev/network-policies/kafka-netpol.yaml
+++ b/infrastructure/dev/network-policies/kafka-netpol.yaml
@@ -56,10 +56,54 @@ spec:
             matchLabels:
               strimzi.io/cluster: goti-kafka
     - to:
-        - namespaceSelector: {}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+        podSelector:
+          matchLabels:
+            k8s-app: kube-dns
       ports:
         - port: 53
           protocol: UDP
+        - port: 53
+          protocol: TCP
+---
+# Strimzi Operator: Kafka 브로커 관리 + K8s API 통신
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-strimzi-operator
+  namespace: kafka
+spec:
+  podSelector:
+    matchLabels:
+      strimzi.io/kind: cluster-operator
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector: {}
+  egress:
+    - to:
+        - podSelector: {}
+    - ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+        podSelector:
+          matchLabels:
+            k8s-app: kube-dns
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
 ---
 # monitoring에서 Kafka 메트릭 scrape 허용
 apiVersion: networking.k8s.io/v1

--- a/infrastructure/dev/network-policies/kafka-netpol.yaml
+++ b/infrastructure/dev/network-policies/kafka-netpol.yaml
@@ -1,0 +1,83 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+  namespace: kafka
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+---
+# goti namespace에서만 Kafka 접근 허용
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-kafka-from-goti
+  namespace: kafka
+spec:
+  podSelector:
+    matchLabels:
+      strimzi.io/cluster: goti-kafka
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: goti
+      ports:
+        - port: 9092
+          protocol: TCP
+        - port: 9093
+          protocol: TCP
+---
+# Kafka 브로커 간 내부 통신
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-kafka-internal
+  namespace: kafka
+spec:
+  podSelector:
+    matchLabels:
+      strimzi.io/cluster: goti-kafka
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              strimzi.io/cluster: goti-kafka
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              strimzi.io/cluster: goti-kafka
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - port: 53
+          protocol: UDP
+---
+# monitoring에서 Kafka 메트릭 scrape 허용
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-kafka-metrics-scrape
+  namespace: kafka
+spec:
+  podSelector:
+    matchLabels:
+      strimzi.io/cluster: goti-kafka
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+      ports:
+        - port: 9404
+          protocol: TCP

--- a/infrastructure/dev/network-policies/monitoring-netpol.yaml
+++ b/infrastructure/dev/network-policies/monitoring-netpol.yaml
@@ -1,0 +1,116 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+  namespace: monitoring
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+---
+# Grafana: Istio Gateway에서 접근 허용
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-grafana-ingress
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: grafana
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: istio-system
+      ports:
+        - port: 3000
+          protocol: TCP
+---
+# monitoring 내부 통신 허용 (Alloy→Mimir, Alloy→Loki, Alloy→Tempo 등)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-monitoring-internal
+  namespace: monitoring
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector: {}
+  egress:
+    - to:
+        - podSelector: {}
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+---
+# Alloy: goti namespace에서 OTLP 수신
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-alloy-ingress
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: alloy
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: goti
+      ports:
+        - port: 4317
+          protocol: TCP
+        - port: 4318
+          protocol: TCP
+---
+# Alloy: goti namespace scrape egress + kube-system metrics
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-alloy-scrape-egress
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: alloy
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: goti
+      ports:
+        - port: 8080
+          protocol: TCP
+        - port: 15020
+          protocol: TCP
+        - port: 15090
+          protocol: TCP
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - port: 8080
+          protocol: TCP
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - port: 53
+          protocol: UDP


### PR DESCRIPTION
## 관련 이슈
- Closes #52

## 개요
보안팀 Red Team 대비를 위한 K8s Security + Network Security 하드닝.
보안 리뷰에서 식별된 P0~P1 항목 7건 중 코드 수정 대상 6건을 반영한다.
(PSA labels는 ArgoCD sync 후 kubectl로 별도 적용)

## 작업 내용

### C-01: goti-common securityContext 추가
- Pod-level: `runAsNonRoot: true`, `runAsUser: 1000`, `fsGroup: 1000`
- Container-level: `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`, `drop: ["ALL"]`, `seccompProfile: RuntimeDefault`
- `/tmp` emptyDir 마운트 (Spring Boot Tomcat work dir 필수)

### H-01: automountServiceAccountToken: false
- `_serviceaccount.tpl`: ServiceAccount 리소스에 직접 설정
- `_deployment.tpl`: Pod spec에 values 기반 설정 반영
- `goti-server/values.yaml`: 기본값 `false` 추가

### NS-001: NetworkPolicy default-deny (3개 namespace)
- **monitoring**: default-deny + Grafana ingress(istio-system) + 내부 통신 + Alloy OTLP 수신/scrape egress
- **kafka**: default-deny + goti→Kafka(9092/9093) + 브로커 간 통신 + monitoring metrics scrape(9404)
- **argocd**: default-deny-ingress + server NodePort(8080) + 내부 컴포넌트 통신

### H-04: infra AppProject 와일드카드 제거
- `group:"*"/kind:"*"` → 실제 사용하는 리소스만 명시적 whitelist
- Core, Apps, RBAC, Istio, Monitoring, ArgoCD, NetworkPolicy, OTel, Strimzi, ExternalSecrets, Batch, Policy, Autoscaling

### NS-006: Sidecar egress 제한 활성화 (5개 서비스)
- 공통: `istio-system/*` + `./*` + `monitoring/alloy-dev` + `~/*.amazonaws.com`
- goti-user 추가: `~/*.googleapis.com`, `~/*.naver.com`, `~/*.kakao.com`, `~/*.nurigo.com` (OAuth + SMS)

### M-04: PSA labels (후속 작업)
- goti: `restricted`, monitoring/kafka/argocd: `baseline`
- Step 1 securityContext 적용 확인 후 kubectl로 별도 적용

## 테스트
- [ ] `helm template` 렌더링 검증 (securityContext, automountServiceAccountToken, volumeMounts 포함 확인)
- [ ] Kind 로컬 클러스터 배포 검증
- [ ] ArgoCD sync 확인
- [ ] Pod 정상 기동 확인 (`readOnlyRootFilesystem` + `/tmp` emptyDir 동작)
- [ ] SA 토큰 미마운트 확인 (`ls /var/run/secrets/kubernetes.io/serviceaccount/` → No such file)
- [ ] NetworkPolicy 적용 확인 (`kubectl get networkpolicy -A`)
- [ ] Lateral movement 차단 테스트 (monitoring → kafka)
- [ ] Sidecar egress 확인 (`kubectl get sidecar -n goti`)
- [ ] 서비스 정상 동작 확인 (`curl /api/v1/auth/health`)