### PR TITLE
[FEAT] JWT RS256 Istio RequestAuthentication + 헤더 위조 방지

### DIFF
--- a/charts/goti-common/templates/_authorizationpolicy-jwt.tpl
+++ b/charts/goti-common/templates/_authorizationpolicy-jwt.tpl
@@ -1,0 +1,52 @@
+{{/*
+JWT 필수 강제 AuthorizationPolicy — JWT 없는 요청을 DENY
+
+RequestAuthentication은 JWT가 있으면 검증하지만, 없는 요청은 통과시킨다.
+이 AuthorizationPolicy가 인증 필요 경로에 JWT를 필수로 강제한다.
+공개 API 경로는 excludePaths로 제외한다.
+
+사용 예시 (values.yaml):
+  istioPolicy:
+    jwtAuthorizationPolicy:
+      enabled: true
+      excludePaths:
+        - "/api/v1/auth/*"
+        - "/api/v1/stadiums/*"
+        - "/api/v1/games/*"
+        - "/actuator/*"
+        - "/swagger-ui/*"
+        - "/v3/api-docs/*"
+        - "/.well-known/*"
+*/}}
+{{- define "goti-common.authorizationpolicy-jwt" -}}
+{{- if and .Values.istioPolicy .Values.istioPolicy.jwtAuthorizationPolicy .Values.istioPolicy.jwtAuthorizationPolicy.enabled }}
+{{- $fullname := include "goti-common.fullname" . }}
+{{- $labels := include "goti-common.labels" . }}
+{{- $selectorLabels := include "goti-common.selectorLabels" . }}
+{{- $policy := .Values.istioPolicy.jwtAuthorizationPolicy }}
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: {{ $fullname }}-require-jwt
+  labels:
+    {{- $labels | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- $selectorLabels | nindent 6 }}
+  action: DENY
+  rules:
+    - from:
+        - source:
+            notRequestPrincipals: ["*"]
+      to:
+        - operation:
+            {{- if $policy.excludePaths }}
+            notPaths:
+              {{- range $policy.excludePaths }}
+              - {{ . | quote }}
+              {{- end }}
+            {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/goti-common/templates/_requestauthentication.tpl
+++ b/charts/goti-common/templates/_requestauthentication.tpl
@@ -1,0 +1,49 @@
+{{/*
+서비스별 Istio RequestAuthentication — JWT 검증을 서비스 메시 레벨에서 수행
+
+Istio sidecar가 JWT를 검증하고 claim을 헤더로 변환한다.
+forwardOriginalToken: true → Spring Boot에서도 원본 토큰 접근 가능
+outputClaimToHeaders → sub→X-User-Id, role→X-User-Role 변환
+
+사용 예시 (values.yaml):
+  istioPolicy:
+    requestAuthentication:
+      enabled: true
+      issuer: "goti-user-service"
+      jwksUri: "http://goti-user-dev.goti.svc.cluster.local:8080/.well-known/jwks.json"
+      outputClaimToHeaders:
+        - header: "X-User-Id"
+          claim: "sub"
+        - header: "X-User-Role"
+          claim: "role"
+*/}}
+{{- define "goti-common.requestauthentication" -}}
+{{- if and .Values.istioPolicy .Values.istioPolicy.requestAuthentication .Values.istioPolicy.requestAuthentication.enabled }}
+{{- $fullname := include "goti-common.fullname" . }}
+{{- $labels := include "goti-common.labels" . }}
+{{- $selectorLabels := include "goti-common.selectorLabels" . }}
+{{- $ra := .Values.istioPolicy.requestAuthentication }}
+---
+apiVersion: security.istio.io/v1
+kind: RequestAuthentication
+metadata:
+  name: {{ $fullname }}-jwt
+  labels:
+    {{- $labels | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- $selectorLabels | nindent 6 }}
+  jwtRules:
+    - issuer: {{ $ra.issuer | quote }}
+      jwksUri: {{ $ra.jwksUri | quote }}
+      forwardOriginalToken: {{ $ra.forwardOriginalToken | default true }}
+      {{- if $ra.outputClaimToHeaders }}
+      outputClaimToHeaders:
+        {{- range $ra.outputClaimToHeaders }}
+        - header: {{ .header | quote }}
+          claim: {{ .claim | quote }}
+        {{- end }}
+      {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/goti-server/templates/authorizationpolicy-jwt.yaml
+++ b/charts/goti-server/templates/authorizationpolicy-jwt.yaml
@@ -1,0 +1,1 @@
+{{- include "goti-common.authorizationpolicy-jwt" . }}

--- a/charts/goti-server/templates/externalsecret.yaml
+++ b/charts/goti-server/templates/externalsecret.yaml
@@ -34,4 +34,14 @@ spec:
             source: "^{{ .Values.externalSecret.remoteRef.overridePath }}/(.*)$"
             target: "$1"
     {{- end }}
+    {{- range .Values.externalSecret.additionalPaths }}
+    - find:
+        path: {{ .path }}
+        name:
+          regexp: ".*"
+      rewrite:
+        - regexp:
+            source: "^{{ .path }}/(.*)$"
+            target: "$1"
+    {{- end }}
 {{- end }}

--- a/charts/goti-server/templates/requestauthentication.yaml
+++ b/charts/goti-server/templates/requestauthentication.yaml
@@ -1,0 +1,1 @@
+{{- include "goti-common.requestauthentication" . }}

--- a/charts/goti-server/values.yaml
+++ b/charts/goti-server/values.yaml
@@ -75,6 +75,7 @@ externalSecret:
     kind: ClusterSecretStore
   remoteRef:
     path: ""
+  additionalPaths: []  # 추가 Parameter Store 경로 (서비스별 시크릿 분리용)
 
 podSecurityContext:
   runAsNonRoot: true
@@ -119,6 +120,21 @@ istioPolicy:
       maxEjectionPercent: 50
     loadBalancer:
       simple: LEAST_REQUEST
+  # JWT 검증: Istio RequestAuthentication (기본 비활성화)
+  requestAuthentication:
+    enabled: false
+    issuer: "goti-user-service"
+    jwksUri: ""
+    forwardOriginalToken: true
+    outputClaimToHeaders:
+      - header: "X-User-Id"
+        claim: "sub"
+      - header: "X-User-Role"
+        claim: "role"
+  # JWT 필수 강제: 공개 API 외 경로에 JWT 없으면 403 (기본 비활성화)
+  jwtAuthorizationPolicy:
+    enabled: false
+    excludePaths: []
   # Phase 2: Sidecar (egress 제한, 기본 비활성화)
   sidecar:
     enabled: false

--- a/environments/dev/goti-payment/values.yaml
+++ b/environments/dev/goti-payment/values.yaml
@@ -117,24 +117,20 @@ istioPolicy:
                   paths: ["/api/v1/resales/payments", "/api/v1/resales/payments/*"]
                   methods: ["POST", "PATCH"]
 
-  # JWT 검증: Istio sidecar가 RS256 JWT를 검증하고 claim을 헤더로 변환
+  # JWT 검증: issuer/outputClaimToHeaders는 base values 상속
   requestAuthentication:
     enabled: true
-    issuer: "goti-user-service"
     jwksUri: "http://goti-user-dev.goti.svc.cluster.local:8080/.well-known/jwks.json"
-    forwardOriginalToken: true
-    outputClaimToHeaders:
-      - header: "X-User-Id"
-        claim: "sub"
-      - header: "X-User-Role"
-        claim: "role"
 
   # JWT 필수 강제: 모든 payment API는 인증 필수
   jwtAuthorizationPolicy:
     enabled: true
     excludePaths:
+      - "/actuator"
       - "/actuator/*"
+      - "/swagger-ui"
       - "/swagger-ui/*"
+      - "/v3/api-docs"
       - "/v3/api-docs/*"
 
   # Phase 2: Resilience (공통 설정은 goti-server/values.yaml 기본값 사용)

--- a/environments/dev/goti-payment/values.yaml
+++ b/environments/dev/goti-payment/values.yaml
@@ -117,6 +117,26 @@ istioPolicy:
                   paths: ["/api/v1/resales/payments", "/api/v1/resales/payments/*"]
                   methods: ["POST", "PATCH"]
 
+  # JWT 검증: Istio sidecar가 RS256 JWT를 검증하고 claim을 헤더로 변환
+  requestAuthentication:
+    enabled: true
+    issuer: "goti-user-service"
+    jwksUri: "http://goti-user-dev.goti.svc.cluster.local:8080/.well-known/jwks.json"
+    forwardOriginalToken: true
+    outputClaimToHeaders:
+      - header: "X-User-Id"
+        claim: "sub"
+      - header: "X-User-Role"
+        claim: "role"
+
+  # JWT 필수 강제: 모든 payment API는 인증 필수
+  jwtAuthorizationPolicy:
+    enabled: true
+    excludePaths:
+      - "/actuator/*"
+      - "/swagger-ui/*"
+      - "/v3/api-docs/*"
+
   # Phase 2: Resilience (공통 설정은 goti-server/values.yaml 기본값 사용)
   destinationRule:
     enabled: true

--- a/environments/dev/goti-resale/values.yaml
+++ b/environments/dev/goti-resale/values.yaml
@@ -117,25 +117,22 @@ istioPolicy:
                   paths: ["/api/v1/resales/orders/*"]
                   methods: ["GET", "PATCH"]
 
-  # JWT 검증: Istio sidecar가 RS256 JWT를 검증하고 claim을 헤더로 변환
+  # JWT 검증: issuer/outputClaimToHeaders는 base values 상속
   requestAuthentication:
     enabled: true
-    issuer: "goti-user-service"
     jwksUri: "http://goti-user-dev.goti.svc.cluster.local:8080/.well-known/jwks.json"
-    forwardOriginalToken: true
-    outputClaimToHeaders:
-      - header: "X-User-Id"
-        claim: "sub"
-      - header: "X-User-Role"
-        claim: "role"
 
   # JWT 필수 강제: histories는 공개, 나머지는 인증 필수
   jwtAuthorizationPolicy:
     enabled: true
     excludePaths:
+      - "/api/v1/resales/histories"
       - "/api/v1/resales/histories/*"
+      - "/actuator"
       - "/actuator/*"
+      - "/swagger-ui"
       - "/swagger-ui/*"
+      - "/v3/api-docs"
       - "/v3/api-docs/*"
 
   # Phase 2: Resilience (공통 설정은 goti-server/values.yaml 기본값 사용)

--- a/environments/dev/goti-resale/values.yaml
+++ b/environments/dev/goti-resale/values.yaml
@@ -117,6 +117,27 @@ istioPolicy:
                   paths: ["/api/v1/resales/orders/*"]
                   methods: ["GET", "PATCH"]
 
+  # JWT 검증: Istio sidecar가 RS256 JWT를 검증하고 claim을 헤더로 변환
+  requestAuthentication:
+    enabled: true
+    issuer: "goti-user-service"
+    jwksUri: "http://goti-user-dev.goti.svc.cluster.local:8080/.well-known/jwks.json"
+    forwardOriginalToken: true
+    outputClaimToHeaders:
+      - header: "X-User-Id"
+        claim: "sub"
+      - header: "X-User-Role"
+        claim: "role"
+
+  # JWT 필수 강제: histories는 공개, 나머지는 인증 필수
+  jwtAuthorizationPolicy:
+    enabled: true
+    excludePaths:
+      - "/api/v1/resales/histories/*"
+      - "/actuator/*"
+      - "/swagger-ui/*"
+      - "/v3/api-docs/*"
+
   # Phase 2: Resilience (공통 설정은 goti-server/values.yaml 기본값 사용)
   destinationRule:
     enabled: true

--- a/environments/dev/goti-stadium/values.yaml
+++ b/environments/dev/goti-stadium/values.yaml
@@ -119,26 +119,24 @@ istioPolicy:
                   paths: ["/api/v1/stadiums*", "/api/v1/baseball-teams*"]
                   methods: ["GET"]
 
-  # JWT 검증: Istio sidecar가 RS256 JWT를 검증하고 claim을 헤더로 변환
+  # JWT 검증: issuer/outputClaimToHeaders는 base values 상속
   requestAuthentication:
     enabled: true
-    issuer: "goti-user-service"
     jwksUri: "http://goti-user-dev.goti.svc.cluster.local:8080/.well-known/jwks.json"
-    forwardOriginalToken: true
-    outputClaimToHeaders:
-      - header: "X-User-Id"
-        claim: "sub"
-      - header: "X-User-Role"
-        claim: "role"
 
   # JWT 필수 강제: stadiums/baseball-teams는 공개, 나머지는 인증 필수
   jwtAuthorizationPolicy:
     enabled: true
     excludePaths:
+      - "/api/v1/stadiums"
       - "/api/v1/stadiums/*"
+      - "/api/v1/baseball-teams"
       - "/api/v1/baseball-teams/*"
+      - "/actuator"
       - "/actuator/*"
+      - "/swagger-ui"
       - "/swagger-ui/*"
+      - "/v3/api-docs"
       - "/v3/api-docs/*"
 
   # Phase 2: Resilience (공통 설정은 goti-server/values.yaml 기본값 사용)

--- a/environments/dev/goti-stadium/values.yaml
+++ b/environments/dev/goti-stadium/values.yaml
@@ -119,6 +119,28 @@ istioPolicy:
                   paths: ["/api/v1/stadiums*", "/api/v1/baseball-teams*"]
                   methods: ["GET"]
 
+  # JWT 검증: Istio sidecar가 RS256 JWT를 검증하고 claim을 헤더로 변환
+  requestAuthentication:
+    enabled: true
+    issuer: "goti-user-service"
+    jwksUri: "http://goti-user-dev.goti.svc.cluster.local:8080/.well-known/jwks.json"
+    forwardOriginalToken: true
+    outputClaimToHeaders:
+      - header: "X-User-Id"
+        claim: "sub"
+      - header: "X-User-Role"
+        claim: "role"
+
+  # JWT 필수 강제: stadiums/baseball-teams는 공개, 나머지는 인증 필수
+  jwtAuthorizationPolicy:
+    enabled: true
+    excludePaths:
+      - "/api/v1/stadiums/*"
+      - "/api/v1/baseball-teams/*"
+      - "/actuator/*"
+      - "/swagger-ui/*"
+      - "/v3/api-docs/*"
+
   # Phase 2: Resilience (공통 설정은 goti-server/values.yaml 기본값 사용)
   destinationRule:
     enabled: true

--- a/environments/dev/goti-ticketing/values.yaml
+++ b/environments/dev/goti-ticketing/values.yaml
@@ -131,6 +131,28 @@ istioPolicy:
                   paths: ["/api/v1/orders/*"]
                   methods: ["POST"]
 
+  # JWT 검증: Istio sidecar가 RS256 JWT를 검증하고 claim을 헤더로 변환
+  requestAuthentication:
+    enabled: true
+    issuer: "goti-user-service"
+    jwksUri: "http://goti-user-dev.goti.svc.cluster.local:8080/.well-known/jwks.json"
+    forwardOriginalToken: true
+    outputClaimToHeaders:
+      - header: "X-User-Id"
+        claim: "sub"
+      - header: "X-User-Role"
+        claim: "role"
+
+  # JWT 필수 강제: 공개 API 외 경로에 JWT 없으면 403
+  jwtAuthorizationPolicy:
+    enabled: true
+    excludePaths:
+      - "/api/v1/games/*"
+      - "/api/v1/stadiums/*"
+      - "/actuator/*"
+      - "/swagger-ui/*"
+      - "/v3/api-docs/*"
+
   # Phase 2: Resilience (공통 설정은 goti-server/values.yaml 기본값 사용)
   destinationRule:
     enabled: true

--- a/environments/dev/goti-ticketing/values.yaml
+++ b/environments/dev/goti-ticketing/values.yaml
@@ -131,26 +131,24 @@ istioPolicy:
                   paths: ["/api/v1/orders/*"]
                   methods: ["POST"]
 
-  # JWT 검증: Istio sidecar가 RS256 JWT를 검증하고 claim을 헤더로 변환
+  # JWT 검증: issuer/outputClaimToHeaders는 base values 상속
   requestAuthentication:
     enabled: true
-    issuer: "goti-user-service"
     jwksUri: "http://goti-user-dev.goti.svc.cluster.local:8080/.well-known/jwks.json"
-    forwardOriginalToken: true
-    outputClaimToHeaders:
-      - header: "X-User-Id"
-        claim: "sub"
-      - header: "X-User-Role"
-        claim: "role"
 
   # JWT 필수 강제: 공개 API 외 경로에 JWT 없으면 403
   jwtAuthorizationPolicy:
     enabled: true
     excludePaths:
+      - "/api/v1/games"
       - "/api/v1/games/*"
+      - "/api/v1/stadiums"
       - "/api/v1/stadiums/*"
+      - "/actuator"
       - "/actuator/*"
+      - "/swagger-ui"
       - "/swagger-ui/*"
+      - "/v3/api-docs"
       - "/v3/api-docs/*"
 
   # Phase 2: Resilience (공통 설정은 goti-server/values.yaml 기본값 사용)

--- a/environments/dev/goti-user/values.yaml
+++ b/environments/dev/goti-user/values.yaml
@@ -102,6 +102,7 @@ externalSecret:
   remoteRef:
     path: /dev/server  # 공통 (DB, Redis, JWT_RSA_PUBLIC_KEY 등)
     overridePath: /dev/kind/server
+  # 동일 key는 마지막 path 값으로 덮어씀 (Kind override용)
   additionalPaths:
     - path: /dev/user       # user 전용 (JWT_RSA_PRIVATE_KEY)
     - path: /dev/kind/user  # Kind 환경 override
@@ -114,26 +115,24 @@ istioPolicy:
     enabled: true
     allowFrom: []
 
-  # JWT 검증: Istio sidecar가 RS256 JWT를 검증하고 claim을 헤더로 변환
+  # JWT 검증: issuer/outputClaimToHeaders는 base values 상속
   requestAuthentication:
     enabled: true
-    issuer: "goti-user-service"
     jwksUri: "http://goti-user-dev.goti.svc.cluster.local:8080/.well-known/jwks.json"
-    forwardOriginalToken: true
-    outputClaimToHeaders:
-      - header: "X-User-Id"
-        claim: "sub"
-      - header: "X-User-Role"
-        claim: "role"
 
   # JWT 필수 강제: 공개 API 외 경로에 JWT 없으면 403
   jwtAuthorizationPolicy:
     enabled: true
     excludePaths:
+      - "/api/v1/auth"
       - "/api/v1/auth/*"
+      - "/actuator"
       - "/actuator/*"
+      - "/swagger-ui"
       - "/swagger-ui/*"
+      - "/v3/api-docs"
       - "/v3/api-docs/*"
+      - "/.well-known"
       - "/.well-known/*"
 
   # Phase 2: Resilience (공통 설정은 goti-server/values.yaml 기본값 사용)

--- a/environments/dev/goti-user/values.yaml
+++ b/environments/dev/goti-user/values.yaml
@@ -100,8 +100,11 @@ externalSecret:
     name: aws-parameter-store
     kind: ClusterSecretStore
   remoteRef:
-    path: /dev/server  # TODO: 서비스별 경로 분리 예정 (/dev/user 등)
+    path: /dev/server  # 공통 (DB, Redis, JWT_RSA_PUBLIC_KEY 등)
     overridePath: /dev/kind/server
+  additionalPaths:
+    - path: /dev/user       # user 전용 (JWT_RSA_PRIVATE_KEY)
+    - path: /dev/kind/user  # Kind 환경 override
 
 # --- Istio 보안/네트워크 정책 ---
 
@@ -110,6 +113,28 @@ istioPolicy:
   authorizationPolicy:
     enabled: true
     allowFrom: []
+
+  # JWT 검증: Istio sidecar가 RS256 JWT를 검증하고 claim을 헤더로 변환
+  requestAuthentication:
+    enabled: true
+    issuer: "goti-user-service"
+    jwksUri: "http://goti-user-dev.goti.svc.cluster.local:8080/.well-known/jwks.json"
+    forwardOriginalToken: true
+    outputClaimToHeaders:
+      - header: "X-User-Id"
+        claim: "sub"
+      - header: "X-User-Role"
+        claim: "role"
+
+  # JWT 필수 강제: 공개 API 외 경로에 JWT 없으면 403
+  jwtAuthorizationPolicy:
+    enabled: true
+    excludePaths:
+      - "/api/v1/auth/*"
+      - "/actuator/*"
+      - "/swagger-ui/*"
+      - "/v3/api-docs/*"
+      - "/.well-known/*"
 
   # Phase 2: Resilience (공통 설정은 goti-server/values.yaml 기본값 사용)
   destinationRule:

--- a/infrastructure/dev/istio/gateway/templates/strip-internal-headers.yaml
+++ b/infrastructure/dev/istio/gateway/templates/strip-internal-headers.yaml
@@ -2,11 +2,11 @@
 # 외부에서 유입되는 X-User-Id / X-User-Role 헤더를 Gateway에서 제거
 # Istio outputClaimToHeaders가 JWT claim에서 새로 설정하므로
 # 클라이언트가 이 헤더를 위조해도 무시된다
+# EnvoyFilter는 Istio 1.29 기준 v1alpha3만 지원 (v1 GA 미승격)
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: strip-internal-headers
-  namespace: istio-system
 spec:
   workloadSelector:
     labels:

--- a/infrastructure/dev/istio/gateway/values.yaml
+++ b/infrastructure/dev/istio/gateway/values.yaml
@@ -16,3 +16,7 @@ gateway:
 sharedGateway:
   hosts:
     - "goti.local"
+
+# JWT 헤더 위조 방지: Gateway에서 X-User-Id/X-User-Role strip
+stripInternalHeaders:
+  enabled: true

--- a/infrastructure/dev/istio/goti-policy/templates/allow-istiod-jwks.yaml
+++ b/infrastructure/dev/istio/goti-policy/templates/allow-istiod-jwks.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: goti-user
+      {{- toYaml .Values.allowIstiodJwks.targetSelector | nindent 6 }}
   action: ALLOW
   rules:
     - from:

--- a/infrastructure/dev/istio/goti-policy/templates/allow-istiod-jwks.yaml
+++ b/infrastructure/dev/istio/goti-policy/templates/allow-istiod-jwks.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.allowIstiodJwks.enabled }}
+# istiod → user 서비스 JWKS 엔드포인트 접근 허용
+# RequestAuthentication의 jwksUri를 istiod가 주기적으로 fetch한다
+# deny-all 하에서 이 접근을 명시적으로 허용해야 한다
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-istiod-jwks
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: goti-user
+  action: ALLOW
+  rules:
+    - from:
+        - source:
+            principals:
+              - {{ .Values.allowIstiodJwks.istiodSA | quote }}
+      to:
+        - operation:
+            paths: ["/.well-known/jwks.json"]
+            methods: ["GET"]
+{{- end }}

--- a/infrastructure/dev/istio/goti-policy/templates/strip-internal-headers.yaml
+++ b/infrastructure/dev/istio/goti-policy/templates/strip-internal-headers.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.stripInternalHeaders.enabled }}
+# 외부에서 유입되는 X-User-Id / X-User-Role 헤더를 Gateway에서 제거
+# Istio outputClaimToHeaders가 JWT claim에서 새로 설정하므로
+# 클라이언트가 이 헤더를 위조해도 무시된다
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: strip-internal-headers
+  namespace: istio-system
+spec:
+  workloadSelector:
+    labels:
+      istio: gateway
+  configPatches:
+    - applyTo: HTTP_ROUTE
+      match:
+        context: GATEWAY
+      patch:
+        operation: MERGE
+        value:
+          request_headers_to_remove:
+            - "X-User-Id"
+            - "X-User-Role"
+{{- end }}

--- a/infrastructure/dev/istio/goti-policy/values.yaml
+++ b/infrastructure/dev/istio/goti-policy/values.yaml
@@ -21,5 +21,14 @@ peerAuth:
 allowKubeletProbes:
   enabled: true
 
+# JWT 헤더 위조 방지: Gateway에서 X-User-Id/X-User-Role strip
+stripInternalHeaders:
+  enabled: true
+
+# istiod → user JWKS 엔드포인트 접근 허용 (RequestAuthentication용)
+allowIstiodJwks:
+  enabled: true
+  istiodSA: "cluster.local/ns/istio-system/sa/istiod"
+
 # Phase 2: 외부 서비스 ServiceEntry
 serviceEntries: []

--- a/infrastructure/dev/istio/goti-policy/values.yaml
+++ b/infrastructure/dev/istio/goti-policy/values.yaml
@@ -21,14 +21,12 @@ peerAuth:
 allowKubeletProbes:
   enabled: true
 
-# JWT 헤더 위조 방지: Gateway에서 X-User-Id/X-User-Role strip
-stripInternalHeaders:
-  enabled: true
-
 # istiod → user JWKS 엔드포인트 접근 허용 (RequestAuthentication용)
 allowIstiodJwks:
   enabled: true
   istiodSA: "cluster.local/ns/istio-system/sa/istiod"
+  targetSelector:
+    app.kubernetes.io/name: goti-user
 
 # Phase 2: 외부 서비스 ServiceEntry
 serviceEntries: []


### PR DESCRIPTION
## 관련 이슈
- JWT RS256 전환 + Istio RequestAuthentication 도입 (goti-team-controller 플랜)

## 개요
JWT 인증을 서비스 메시 레벨에서 수행하도록 Istio RequestAuthentication을 도입한다.
RS256 JWT를 Istio sidecar가 검증하고, claim을 X-User-Id/X-User-Role 헤더로 변환하여
MSA 서비스에서 DB 조회 없이 인증 정보를 사용할 수 있도록 한다.

## 작업 내용

### Library Template (goti-common)
- [x] `_requestauthentication.tpl` — Istio RequestAuthentication (jwksUri, outputClaimToHeaders)
- [x] `_authorizationpolicy-jwt.tpl` — JWT 필수 강제 DENY 정책 (excludePaths로 공개 API 제외)

### App Template (goti-server)
- [x] `requestauthentication.yaml`, `authorizationpolicy-jwt.yaml` delegate 추가

### ExternalSecret 확장
- [x] `additionalPaths` 지원 — 서비스별 SSM 경로 분리 (private key는 user 전용)

### Gateway 보안 (goti-policy)
- [x] `strip-internal-headers.yaml` — EnvoyFilter로 외부 X-User-Id/X-User-Role 헤더 strip (위조 방지)
- [x] `allow-istiod-jwks.yaml` — deny-all 하에서 istiod → user JWKS 엔드포인트 접근 허용

### 서비스별 dev values
- [x] goti-user: requestAuthentication + jwtAuthorizationPolicy + additionalPaths(/dev/user)
- [x] goti-ticketing: games/* 공개, 나머지 JWT 필수
- [x] goti-payment: 전체 JWT 필수
- [x] goti-resale: histories/* 공개, 나머지 JWT 필수
- [x] goti-stadium: stadiums/*/baseball-teams/* 공개, 나머지 JWT 필수

### SSM 키 배치 설계
| 경로 | 내용 | 접근 서비스 |
|------|------|-----------|
| `/dev/server/JWT_RSA_PUBLIC_KEY` | RS256 공개키 | 전체 서비스 |
| `/dev/user/JWT_RSA_PRIVATE_KEY` | RS256 비밀키 | user만 (additionalPaths) |

## 테스트
- [x] `helm template` 렌더링 검증 (RequestAuthentication, AuthorizationPolicy DENY, EnvoyFilter)
- [ ] Kind 로컬 클러스터 배포 검증
- [ ] ArgoCD sync 확인
- [ ] goti-server RS256 배포 후 JWT 검증 E2E 테스트