### PR TITLE
[CHORE] Strimzi 0.51 GA deprecated annotation 제거

### DIFF
--- a/infrastructure/dev/strimzi-operator/config/kafka-cluster.yaml
+++ b/infrastructure/dev/strimzi-operator/config/kafka-cluster.yaml
@@ -32,9 +32,6 @@ apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
   name: goti-kafka
-  annotations:
-    strimzi.io/node-pools: enabled
-    strimzi.io/kraft: enabled
 spec:
   kafka:
     version: "4.2.0"

--- a/infrastructure/prod/strimzi-operator/config/kafka-cluster.yaml
+++ b/infrastructure/prod/strimzi-operator/config/kafka-cluster.yaml
@@ -59,9 +59,6 @@ apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
   name: goti-kafka
-  annotations:
-    strimzi.io/node-pools: enabled
-    strimzi.io/kraft: enabled
 spec:
   kafka:
     version: "4.2.0"


### PR DESCRIPTION
## 관련 이슈
- N/A (Strimzi Kafka Kind 배포 준비 Phase 1)

## 개요
Strimzi 0.51에서 KRaft + KafkaNodePool이 GA되면서 더 이상 필요 없는 deprecated annotation을 제거합니다.
이 수정으로 Kind 클러스터에서 Kafka 첫 배포가 가능해집니다.

## 작업 내용
- [x] dev `kafka-cluster.yaml`에서 `strimzi.io/node-pools: enabled`, `strimzi.io/kraft: enabled` annotation 제거
- [x] prod `kafka-cluster.yaml`에서 동일 annotation 제거
- Strimzi 0.51 릴리스 노트: KRaft+NodePool GA, annotation 명시 불필요

## 테스트
- [ ] Kind 로컬 클러스터 배포 검증
- [ ] ArgoCD sync 확인
- [ ] `kubectl get kafka -n kafka` Ready 확인
- [ ] goti namespace에서 kafka bootstrap 연결 테스트