### PR TITLE
[FEAT] kafka-exporter 추가 + consumer lag alert 메트릭 수정

### DIFF
--- a/infrastructure/dev/strimzi-operator/config/kafka-cluster.yaml
+++ b/infrastructure/dev/strimzi-operator/config/kafka-cluster.yaml
@@ -62,8 +62,8 @@ spec:
           name: kafka-metrics
           key: kafka-metrics-config.yml
   kafkaExporter:
-    topicRegex: ".*"
-    groupRegex: ".*"
+    topicRegex: "^(?!__).*"
+    groupRegex: "^(?!strimzi-).*"
     resources:
       requests:
         cpu: 50m
@@ -71,6 +71,16 @@ spec:
       limits:
         cpu: 200m
         memory: 128Mi
+    template:
+      pod:
+        securityContext:
+          runAsNonRoot: true
+      container:
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
   entityOperator:
     topicOperator:
       resources:

--- a/infrastructure/dev/strimzi-operator/config/kafka-cluster.yaml
+++ b/infrastructure/dev/strimzi-operator/config/kafka-cluster.yaml
@@ -61,6 +61,16 @@ spec:
         configMapKeyRef:
           name: kafka-metrics
           key: kafka-metrics-config.yml
+  kafkaExporter:
+    topicRegex: ".*"
+    groupRegex: ".*"
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 200m
+        memory: 128Mi
   entityOperator:
     topicOperator:
       resources:

--- a/infrastructure/dev/strimzi-operator/config/kafka-exporter-servicemonitor.yaml
+++ b/infrastructure/dev/strimzi-operator/config/kafka-exporter-servicemonitor.yaml
@@ -1,0 +1,22 @@
+# Kafka Exporter 메트릭 → Alloy 스크래핑
+# Consumer group lag 등 kafka-exporter 전용 메트릭 수집
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: kafka-exporter-metrics
+  namespace: kafka
+  labels:
+    release: kube-prometheus-stack-dev
+    strimzi.io/cluster: goti-kafka
+spec:
+  selector:
+    matchLabels:
+      strimzi.io/cluster: goti-kafka
+      strimzi.io/component-type: kafka-exporter
+  namespaceSelector:
+    matchNames:
+      - kafka
+  endpoints:
+    - port: tcp-prometheus
+      path: /metrics
+      interval: 30s

--- a/infrastructure/dev/strimzi-operator/config/kafka-exporter-servicemonitor.yaml
+++ b/infrastructure/dev/strimzi-operator/config/kafka-exporter-servicemonitor.yaml
@@ -20,3 +20,4 @@ spec:
     - port: tcp-prometheus
       path: /metrics
       interval: 30s
+      scrapeTimeout: 15s

--- a/infrastructure/dev/strimzi-operator/config/prometheus-rules.yaml
+++ b/infrastructure/dev/strimzi-operator/config/prometheus-rules.yaml
@@ -45,12 +45,13 @@ spec:
     - name: kafka_consumer
       rules:
         # kafka-exporter가 노출하는 consumer group lag 메트릭
+        # sum by로 집계하여 파티션 단위 alert storm 방지
         - alert: KafkaConsumerLagHigh
           expr: |
-            kafka_consumergroup_lag > 10000
+            sum by (consumergroup, topic) (kafka_consumergroup_lag) > 10000
           for: 10m
           labels:
             severity: warning
           annotations:
             summary: "Consumer group {{ $labels.consumergroup }} lag is high"
-            description: "Consumer group {{ $labels.consumergroup }}의 lag이 {{ $value }}입니다. 처리 지연을 확인하세요."
+            description: "Consumer group {{ $labels.consumergroup }}의 토픽 {{ $labels.topic }} lag 합계가 {{ $value }}입니다. 처리 지연을 확인하세요."

--- a/infrastructure/dev/strimzi-operator/config/prometheus-rules.yaml
+++ b/infrastructure/dev/strimzi-operator/config/prometheus-rules.yaml
@@ -44,10 +44,10 @@ spec:
 
     - name: kafka_consumer
       rules:
-        # MSA 전환 후 Consumer Group 메트릭 활성화 시 사용
+        # kafka-exporter가 노출하는 consumer group lag 메트릭
         - alert: KafkaConsumerLagHigh
           expr: |
-            kafka_consumergroup_group_lag > 10000
+            kafka_consumergroup_lag > 10000
           for: 10m
           labels:
             severity: warning


### PR DESCRIPTION
## 관련 이슈
- N/A (Strimzi Kafka 실전 배포 Phase 2-1)

## 개요
Kafka consumer group lag 메트릭 수집을 위해 kafka-exporter를 추가하고, 기존 alert의 잘못된 메트릭명을 수정합니다.

**배경**: `KafkaConsumerLagHigh` alert이 `kafka_consumergroup_group_lag` 메트릭에 의존하지만, 이 메트릭은 broker JMX가 아닌 kafka-exporter가 노출합니다. kafka-exporter 없이는 해당 alert이 동작하지 않는 상태였습니다.

## 작업 내용
- [x] dev `kafka-cluster.yaml`에 `spec.kafkaExporter` 섹션 추가 (topicRegex/groupRegex/resources)
- [x] `kafka-exporter-servicemonitor.yaml` 신규 생성 — kafka-exporter 전용 메트릭 스크래핑
- [x] `prometheus-rules.yaml` alert expr 수정: `kafka_consumergroup_group_lag` → `kafka_consumergroup_lag`

## 테스트
- [ ] ArgoCD sync 확인
- [ ] `kubectl get pods -n kafka` — kafka-exporter pod 기동 확인
- [ ] `curl kafka-exporter:9404/metrics | grep kafka_consumergroup` — 메트릭 노출 확인
- [ ] Prometheus에서 `kafka_consumergroup_lag` 메트릭 조회 확인