### PR TITLE
[FEAT] DLQ 토픽 8개 추가 (dev/prod)

### DIFF
--- a/infrastructure/dev/strimzi-operator/config/topics.yaml
+++ b/infrastructure/dev/strimzi-operator/config/topics.yaml
@@ -125,3 +125,140 @@ spec:
     retention.ms: 604800000
     cleanup.policy: delete
     min.insync.replicas: 2
+---
+# =============================================================================
+# DLQ (Dead Letter Queue) 토픽
+# 처리 실패한 메시지를 보관. partitions: 1 (순서 보장), retention: 30일
+# =============================================================================
+---
+# === 티켓 도메인 DLQ ===
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ticket.order-created.v1.dlq
+  labels:
+    strimzi.io/cluster: goti-kafka
+    domain: ticket
+    type: dlq
+spec:
+  partitions: 1
+  replicas: 3
+  config:
+    retention.ms: 2592000000      # 30일
+    cleanup.policy: delete
+    min.insync.replicas: 2
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ticket.payment-completed.v1.dlq
+  labels:
+    strimzi.io/cluster: goti-kafka
+    domain: ticket
+    type: dlq
+spec:
+  partitions: 1
+  replicas: 3
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+    min.insync.replicas: 2
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ticket.seat-reserved.v1.dlq
+  labels:
+    strimzi.io/cluster: goti-kafka
+    domain: ticket
+    type: dlq
+spec:
+  partitions: 1
+  replicas: 3
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+    min.insync.replicas: 2
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ticket.issued.v1.dlq
+  labels:
+    strimzi.io/cluster: goti-kafka
+    domain: ticket
+    type: dlq
+spec:
+  partitions: 1
+  replicas: 3
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+    min.insync.replicas: 2
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ticket.cancelled.v1.dlq
+  labels:
+    strimzi.io/cluster: goti-kafka
+    domain: ticket
+    type: dlq
+spec:
+  partitions: 1
+  replicas: 3
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+    min.insync.replicas: 2
+---
+# === 사용자 도메인 DLQ ===
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: user.registered.v1.dlq
+  labels:
+    strimzi.io/cluster: goti-kafka
+    domain: user
+    type: dlq
+spec:
+  partitions: 1
+  replicas: 3
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+    min.insync.replicas: 2
+---
+# === 알림 도메인 DLQ ===
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: notification.email-requested.v1.dlq
+  labels:
+    strimzi.io/cluster: goti-kafka
+    domain: notification
+    type: dlq
+spec:
+  partitions: 1
+  replicas: 3
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+    min.insync.replicas: 2
+---
+# === 양도 도메인 DLQ ===
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: resale.listed.v1.dlq
+  labels:
+    strimzi.io/cluster: goti-kafka
+    domain: resale
+    type: dlq
+spec:
+  partitions: 1
+  replicas: 3
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+    min.insync.replicas: 2

--- a/infrastructure/prod/strimzi-operator/config/topics.yaml
+++ b/infrastructure/prod/strimzi-operator/config/topics.yaml
@@ -125,3 +125,140 @@ spec:
     retention.ms: 604800000
     cleanup.policy: delete
     min.insync.replicas: 2
+---
+# =============================================================================
+# DLQ (Dead Letter Queue) 토픽
+# 처리 실패한 메시지를 보관. partitions: 1 (순서 보장), retention: 30일
+# =============================================================================
+---
+# === 티켓 도메인 DLQ ===
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ticket.order-created.v1.dlq
+  labels:
+    strimzi.io/cluster: goti-kafka
+    domain: ticket
+    type: dlq
+spec:
+  partitions: 1
+  replicas: 3
+  config:
+    retention.ms: 2592000000      # 30일
+    cleanup.policy: delete
+    min.insync.replicas: 2
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ticket.payment-completed.v1.dlq
+  labels:
+    strimzi.io/cluster: goti-kafka
+    domain: ticket
+    type: dlq
+spec:
+  partitions: 1
+  replicas: 3
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+    min.insync.replicas: 2
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ticket.seat-reserved.v1.dlq
+  labels:
+    strimzi.io/cluster: goti-kafka
+    domain: ticket
+    type: dlq
+spec:
+  partitions: 1
+  replicas: 3
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+    min.insync.replicas: 2
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ticket.issued.v1.dlq
+  labels:
+    strimzi.io/cluster: goti-kafka
+    domain: ticket
+    type: dlq
+spec:
+  partitions: 1
+  replicas: 3
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+    min.insync.replicas: 2
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ticket.cancelled.v1.dlq
+  labels:
+    strimzi.io/cluster: goti-kafka
+    domain: ticket
+    type: dlq
+spec:
+  partitions: 1
+  replicas: 3
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+    min.insync.replicas: 2
+---
+# === 사용자 도메인 DLQ ===
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: user.registered.v1.dlq
+  labels:
+    strimzi.io/cluster: goti-kafka
+    domain: user
+    type: dlq
+spec:
+  partitions: 1
+  replicas: 3
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+    min.insync.replicas: 2
+---
+# === 알림 도메인 DLQ ===
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: notification.email-requested.v1.dlq
+  labels:
+    strimzi.io/cluster: goti-kafka
+    domain: notification
+    type: dlq
+spec:
+  partitions: 1
+  replicas: 3
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+    min.insync.replicas: 2
+---
+# === 양도 도메인 DLQ ===
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: resale.listed.v1.dlq
+  labels:
+    strimzi.io/cluster: goti-kafka
+    domain: resale
+    type: dlq
+spec:
+  partitions: 1
+  replicas: 3
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete
+    min.insync.replicas: 2


### PR DESCRIPTION
## 관련 이슈
- N/A (Strimzi Kafka 실전 배포 Phase 2-2)

## 개요
기존 8개 이벤트 토픽에 대응하는 DLQ(Dead Letter Queue) 토픽을 추가합니다.
처리 실패한 메시지를 별도 토픽에 보관하여 재처리/분석이 가능하도록 합니다.

## 작업 내용
- [x] dev `topics.yaml`에 DLQ 토픽 8개 추가
- [x] prod `topics.yaml`에 DLQ 토픽 8개 추가
- DLQ 공통 설정: `partitions: 1` (순서 보장), `replicas: 3`, `retention: 30일`
- `type: dlq` 라벨로 DLQ 토픽 식별 가능
- 네이밍: `{원본토픽명}.dlq` (예: `ticket.order-created.v1.dlq`)

### 추가된 DLQ 토픽
| 원본 토픽 | DLQ 토픽 |
|-----------|----------|
| ticket.order-created.v1 | ticket.order-created.v1.dlq |
| ticket.payment-completed.v1 | ticket.payment-completed.v1.dlq |
| ticket.seat-reserved.v1 | ticket.seat-reserved.v1.dlq |
| ticket.issued.v1 | ticket.issued.v1.dlq |
| ticket.cancelled.v1 | ticket.cancelled.v1.dlq |
| user.registered.v1 | user.registered.v1.dlq |
| notification.email-requested.v1 | notification.email-requested.v1.dlq |
| resale.listed.v1 | resale.listed.v1.dlq |

## 테스트
- [ ] ArgoCD sync 확인
- [ ] `kubectl get kafkatopic -n kafka` — 16개 토픽 (기존 8 + DLQ 8) 확인