### PR TITLE
[BUG] kafka-exporter CrashLoopBackOff — Go RE2 regex 호환 수정

### DIFF
--- a/infrastructure/dev/strimzi-operator/config/kafka-cluster.yaml
+++ b/infrastructure/dev/strimzi-operator/config/kafka-cluster.yaml
@@ -62,8 +62,9 @@ spec:
           name: kafka-metrics
           key: kafka-metrics-config.yml
   kafkaExporter:
-    topicRegex: "^(?!__).*"
-    groupRegex: "^(?!strimzi-).*"
+    # Go RE2 엔진은 negative lookahead (?!) 미지원 — 전체 수집 후 Grafana/alert에서 필터링
+    topicRegex: ".*"
+    groupRegex: ".*"
     resources:
       requests:
         cpu: 50m

--- a/infrastructure/prod/strimzi-operator/config/kafka-cluster.yaml
+++ b/infrastructure/prod/strimzi-operator/config/kafka-cluster.yaml
@@ -86,8 +86,9 @@ spec:
           name: kafka-metrics
           key: kafka-metrics-config.yml
   kafkaExporter:
-    topicRegex: "^(?!__).*"
-    groupRegex: "^(?!strimzi-).*"
+    # Go RE2 엔진은 negative lookahead (?!) 미지원 — 전체 수집 후 Grafana/alert에서 필터링
+    topicRegex: ".*"
+    groupRegex: ".*"
     resources:
       requests:
         cpu: 100m


### PR DESCRIPTION
## 관련 이슈
- N/A (긴급 수정 — kafka-exporter pod CrashLoopBackOff)

## 개요
kafka-exporter가 Go RE2 regex 엔진을 사용하는데, negative lookahead `(?!...)` 구문을 지원하지 않아 panic으로 CrashLoopBackOff 발생.

```
panic: regexp: Compile(`^(?!__).*`): error parsing regexp: invalid or unsupported Perl syntax: `(?!`
```

## 작업 내용
- [x] dev `kafka-cluster.yaml`: `topicRegex`/`groupRegex`를 `".*"`로 변경
- [x] prod `kafka-cluster.yaml`: 동일 수정
- 내부 토픽 필터링은 Grafana 쿼리/alert expr 레벨에서 처리

## 테스트
- [ ] kafka-exporter pod Running 확인
- [ ] `/metrics` 엔드포인트 정상 응답 확인