### PR TITLE
[FEAT] prod Kafka 프로덕션 설정 + kafka-exporter Service 수정

### DIFF
--- a/infrastructure/dev/strimzi-operator/config/kafka-exporter-service.yaml
+++ b/infrastructure/dev/strimzi-operator/config/kafka-exporter-service.yaml
@@ -1,0 +1,21 @@
+# Kafka Exporter 메트릭 전용 headless Service
+# Strimzi kafka-exporter는 별도 Service를 자동 생성하지 않으므로
+# ServiceMonitor 타겟용 수동 생성
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka-exporter-metrics
+  namespace: kafka
+  labels:
+    strimzi.io/cluster: goti-kafka
+    strimzi.io/component-type: kafka-exporter
+spec:
+  clusterIP: None
+  selector:
+    strimzi.io/cluster: goti-kafka
+    strimzi.io/component-type: kafka-exporter
+  ports:
+    - name: tcp-prometheus
+      port: 9404
+      targetPort: 9404
+      protocol: TCP

--- a/infrastructure/prod/strimzi-operator/config/kafka-cluster.yaml
+++ b/infrastructure/prod/strimzi-operator/config/kafka-cluster.yaml
@@ -63,14 +63,12 @@ spec:
   kafka:
     version: "4.2.0"
     listeners:
-      - name: plain
-        port: 9092
-        type: internal
-        tls: false
       - name: tls
         port: 9093
         type: internal
         tls: true
+        authentication:
+          type: scram-sha-512
     config:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3

--- a/infrastructure/prod/strimzi-operator/config/kafka-exporter-service.yaml
+++ b/infrastructure/prod/strimzi-operator/config/kafka-exporter-service.yaml
@@ -1,0 +1,21 @@
+# Kafka Exporter 메트릭 전용 headless Service
+# Strimzi kafka-exporter는 별도 Service를 자동 생성하지 않으므로
+# ServiceMonitor 타겟용 수동 생성
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka-exporter-metrics
+  namespace: kafka
+  labels:
+    strimzi.io/cluster: goti-kafka
+    strimzi.io/component-type: kafka-exporter
+spec:
+  clusterIP: None
+  selector:
+    strimzi.io/cluster: goti-kafka
+    strimzi.io/component-type: kafka-exporter
+  ports:
+    - name: tcp-prometheus
+      port: 9404
+      targetPort: 9404
+      protocol: TCP

--- a/infrastructure/prod/strimzi-operator/config/kafka-users.yaml
+++ b/infrastructure/prod/strimzi-operator/config/kafka-users.yaml
@@ -1,0 +1,185 @@
+# KafkaUser CRs — 서비스별 SCRAM-SHA-512 인증 + ACL
+# prod 전용: dev는 인증 없이 운영 (개발 편의)
+# Strimzi User Operator가 자동으로 Secret 생성 (namespace: kafka)
+---
+# === goti-ticketing 서비스 ===
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: goti-ticketing
+  labels:
+    strimzi.io/cluster: goti-kafka
+spec:
+  authentication:
+    type: scram-sha-512
+  authorization:
+    type: simple
+    acls:
+      # ticket 도메인 토픽 produce/consume
+      - resource:
+          type: topic
+          name: ticket.
+          patternType: prefix
+        operations: [Read, Write, Describe]
+      # ticket DLQ
+      - resource:
+          type: topic
+          name: ticket.
+          patternType: prefix
+        operations: [Read, Write, Describe]
+      # consumer group
+      - resource:
+          type: group
+          name: goti-ticketing
+          patternType: prefix
+        operations: [Read, Describe]
+---
+# === goti-user 서비스 ===
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: goti-user
+  labels:
+    strimzi.io/cluster: goti-kafka
+spec:
+  authentication:
+    type: scram-sha-512
+  authorization:
+    type: simple
+    acls:
+      - resource:
+          type: topic
+          name: user.
+          patternType: prefix
+        operations: [Read, Write, Describe]
+      - resource:
+          type: group
+          name: goti-user
+          patternType: prefix
+        operations: [Read, Describe]
+---
+# === goti-payment 서비스 ===
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: goti-payment
+  labels:
+    strimzi.io/cluster: goti-kafka
+spec:
+  authentication:
+    type: scram-sha-512
+  authorization:
+    type: simple
+    acls:
+      # payment-completed produce
+      - resource:
+          type: topic
+          name: ticket.payment-completed.v1
+          patternType: literal
+        operations: [Write, Describe]
+      # order-created consume (결제 요청 수신)
+      - resource:
+          type: topic
+          name: ticket.order-created.v1
+          patternType: literal
+        operations: [Read, Describe]
+      - resource:
+          type: group
+          name: goti-payment
+          patternType: prefix
+        operations: [Read, Describe]
+---
+# === goti-stadium 서비스 ===
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: goti-stadium
+  labels:
+    strimzi.io/cluster: goti-kafka
+spec:
+  authentication:
+    type: scram-sha-512
+  authorization:
+    type: simple
+    acls:
+      # seat-reserved consume (좌석 예약 이벤트 수신)
+      - resource:
+          type: topic
+          name: ticket.seat-reserved.v1
+          patternType: literal
+        operations: [Read, Describe]
+      - resource:
+          type: group
+          name: goti-stadium
+          patternType: prefix
+        operations: [Read, Describe]
+---
+# === goti-resale 서비스 ===
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: goti-resale
+  labels:
+    strimzi.io/cluster: goti-kafka
+spec:
+  authentication:
+    type: scram-sha-512
+  authorization:
+    type: simple
+    acls:
+      - resource:
+          type: topic
+          name: resale.
+          patternType: prefix
+        operations: [Read, Write, Describe]
+      # ticket 이벤트 구독 (양도 대상 확인)
+      - resource:
+          type: topic
+          name: ticket.issued.v1
+          patternType: literal
+        operations: [Read, Describe]
+      - resource:
+          type: topic
+          name: ticket.cancelled.v1
+          patternType: literal
+        operations: [Read, Describe]
+      - resource:
+          type: group
+          name: goti-resale
+          patternType: prefix
+        operations: [Read, Describe]
+---
+# === goti-notification 서비스 ===
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: goti-notification
+  labels:
+    strimzi.io/cluster: goti-kafka
+spec:
+  authentication:
+    type: scram-sha-512
+  authorization:
+    type: simple
+    acls:
+      - resource:
+          type: topic
+          name: notification.
+          patternType: prefix
+        operations: [Read, Write, Describe]
+      # 모든 도메인 이벤트 구독 (알림 트리거)
+      - resource:
+          type: topic
+          name: ticket.
+          patternType: prefix
+        operations: [Read, Describe]
+      - resource:
+          type: topic
+          name: user.
+          patternType: prefix
+        operations: [Read, Describe]
+      - resource:
+          type: group
+          name: goti-notification
+          patternType: prefix
+        operations: [Read, Describe]

--- a/infrastructure/prod/strimzi-operator/config/kafka-users.yaml
+++ b/infrastructure/prod/strimzi-operator/config/kafka-users.yaml
@@ -15,13 +15,7 @@ spec:
   authorization:
     type: simple
     acls:
-      # ticket 도메인 토픽 produce/consume
-      - resource:
-          type: topic
-          name: ticket.
-          patternType: prefix
-        operations: [Read, Write, Describe]
-      # ticket DLQ
+      # ticket 도메인 토픽 전체 (DLQ ticket.*.dlq 포함)
       - resource:
           type: topic
           name: ticket.

--- a/infrastructure/prod/strimzi-operator/config/topics.yaml
+++ b/infrastructure/prod/strimzi-operator/config/topics.yaml
@@ -1,8 +1,8 @@
-# KafkaTopic CRs — 도메인별 이벤트 토픽
+# KafkaTopic CRs — 도메인별 이벤트 토픽 (EKS prod)
 # 네이밍: {domain}.{event-type}.{version}
-# MSA 전환 시 서비스 간 비동기 이벤트 처리용
+# prod: 고트래픽 토픽 partition 확대, 감사 토픽 retention 연장
 ---
-# === 티켓 도메인 ===
+# === 티켓 도메인 (고트래픽: partition 12) ===
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
@@ -11,10 +11,10 @@ metadata:
     strimzi.io/cluster: goti-kafka
     domain: ticket
 spec:
-  partitions: 6
+  partitions: 12
   replicas: 3
   config:
-    retention.ms: 604800000      # 7일
+    retention.ms: 1209600000      # 14일
     cleanup.policy: delete
     min.insync.replicas: 2
 ---
@@ -26,10 +26,10 @@ metadata:
     strimzi.io/cluster: goti-kafka
     domain: ticket
 spec:
-  partitions: 6
+  partitions: 12
   replicas: 3
   config:
-    retention.ms: 604800000
+    retention.ms: 1209600000      # 14일
     cleanup.policy: delete
     min.insync.replicas: 2
 ---
@@ -41,13 +41,14 @@ metadata:
     strimzi.io/cluster: goti-kafka
     domain: ticket
 spec:
-  partitions: 6
+  partitions: 12
   replicas: 3
   config:
-    retention.ms: 604800000
+    retention.ms: 1209600000      # 14일
     cleanup.policy: delete
     min.insync.replicas: 2
 ---
+# === 티켓 도메인 (감사: partition 6, retention 90일) ===
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
@@ -59,7 +60,7 @@ spec:
   partitions: 6
   replicas: 3
   config:
-    retention.ms: 2592000000     # 30일
+    retention.ms: 7776000000      # 90일 (감사 목적)
     cleanup.policy: delete
     min.insync.replicas: 2
 ---
@@ -74,11 +75,11 @@ spec:
   partitions: 6
   replicas: 3
   config:
-    retention.ms: 2592000000
+    retention.ms: 7776000000      # 90일 (감사 목적)
     cleanup.policy: delete
     min.insync.replicas: 2
 ---
-# === 사용자 도메인 ===
+# === 사용자 도메인 (partition 6) ===
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
@@ -87,14 +88,14 @@ metadata:
     strimzi.io/cluster: goti-kafka
     domain: user
 spec:
-  partitions: 3
+  partitions: 6
   replicas: 3
   config:
-    retention.ms: 2592000000
+    retention.ms: 2592000000      # 30일
     cleanup.policy: delete
     min.insync.replicas: 2
 ---
-# === 알림 도메인 ===
+# === 알림 도메인 (partition 6) ===
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
@@ -103,14 +104,14 @@ metadata:
     strimzi.io/cluster: goti-kafka
     domain: notification
 spec:
-  partitions: 3
+  partitions: 6
   replicas: 3
   config:
-    retention.ms: 259200000      # 3일
+    retention.ms: 604800000       # 7일
     cleanup.policy: delete
     min.insync.replicas: 2
 ---
-# === 양도 도메인 ===
+# === 양도 도메인 (partition 6) ===
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
@@ -119,16 +120,16 @@ metadata:
     strimzi.io/cluster: goti-kafka
     domain: resale
 spec:
-  partitions: 3
+  partitions: 6
   replicas: 3
   config:
-    retention.ms: 604800000
+    retention.ms: 604800000       # 7일
     cleanup.policy: delete
     min.insync.replicas: 2
 ---
 # =============================================================================
 # DLQ (Dead Letter Queue) 토픽
-# 처리 실패한 메시지를 보관. partitions: 1 (순서 보장), retention: 30일
+# 처리 실패한 메시지를 보관. partitions: 1 (순서 보장), retention: 90일 (prod)
 # =============================================================================
 ---
 # === 티켓 도메인 DLQ ===
@@ -144,7 +145,7 @@ spec:
   partitions: 1
   replicas: 3
   config:
-    retention.ms: 2592000000      # 30일
+    retention.ms: 7776000000      # 90일 (prod: 재처리/감사 여유)
     cleanup.policy: delete
     min.insync.replicas: 2
 ---
@@ -160,7 +161,7 @@ spec:
   partitions: 1
   replicas: 3
   config:
-    retention.ms: 2592000000
+    retention.ms: 7776000000
     cleanup.policy: delete
     min.insync.replicas: 2
 ---
@@ -176,7 +177,7 @@ spec:
   partitions: 1
   replicas: 3
   config:
-    retention.ms: 2592000000
+    retention.ms: 7776000000
     cleanup.policy: delete
     min.insync.replicas: 2
 ---
@@ -192,7 +193,7 @@ spec:
   partitions: 1
   replicas: 3
   config:
-    retention.ms: 2592000000
+    retention.ms: 7776000000
     cleanup.policy: delete
     min.insync.replicas: 2
 ---
@@ -208,7 +209,7 @@ spec:
   partitions: 1
   replicas: 3
   config:
-    retention.ms: 2592000000
+    retention.ms: 7776000000
     cleanup.policy: delete
     min.insync.replicas: 2
 ---
@@ -225,7 +226,7 @@ spec:
   partitions: 1
   replicas: 3
   config:
-    retention.ms: 2592000000
+    retention.ms: 7776000000
     cleanup.policy: delete
     min.insync.replicas: 2
 ---
@@ -242,7 +243,7 @@ spec:
   partitions: 1
   replicas: 3
   config:
-    retention.ms: 2592000000
+    retention.ms: 7776000000
     cleanup.policy: delete
     min.insync.replicas: 2
 ---
@@ -259,6 +260,6 @@ spec:
   partitions: 1
   replicas: 3
   config:
-    retention.ms: 2592000000
+    retention.ms: 7776000000
     cleanup.policy: delete
     min.insync.replicas: 2

--- a/infrastructure/prod/strimzi-operator/config/topics.yaml
+++ b/infrastructure/prod/strimzi-operator/config/topics.yaml
@@ -161,7 +161,7 @@ spec:
   partitions: 1
   replicas: 3
   config:
-    retention.ms: 7776000000
+    retention.ms: 7776000000      # 90일
     cleanup.policy: delete
     min.insync.replicas: 2
 ---
@@ -177,7 +177,7 @@ spec:
   partitions: 1
   replicas: 3
   config:
-    retention.ms: 7776000000
+    retention.ms: 7776000000      # 90일
     cleanup.policy: delete
     min.insync.replicas: 2
 ---
@@ -193,7 +193,7 @@ spec:
   partitions: 1
   replicas: 3
   config:
-    retention.ms: 7776000000
+    retention.ms: 7776000000      # 90일
     cleanup.policy: delete
     min.insync.replicas: 2
 ---
@@ -209,7 +209,7 @@ spec:
   partitions: 1
   replicas: 3
   config:
-    retention.ms: 7776000000
+    retention.ms: 7776000000      # 90일
     cleanup.policy: delete
     min.insync.replicas: 2
 ---
@@ -226,7 +226,7 @@ spec:
   partitions: 1
   replicas: 3
   config:
-    retention.ms: 7776000000
+    retention.ms: 7776000000      # 90일
     cleanup.policy: delete
     min.insync.replicas: 2
 ---
@@ -243,7 +243,7 @@ spec:
   partitions: 1
   replicas: 3
   config:
-    retention.ms: 7776000000
+    retention.ms: 7776000000      # 90일
     cleanup.policy: delete
     min.insync.replicas: 2
 ---
@@ -260,6 +260,6 @@ spec:
   partitions: 1
   replicas: 3
   config:
-    retention.ms: 7776000000
+    retention.ms: 7776000000      # 90일
     cleanup.policy: delete
     min.insync.replicas: 2


### PR DESCRIPTION
## 관련 이슈
- N/A (Strimzi Kafka Phase 3 — EKS 프로덕션 준비)

## 개요
EKS 프로덕션 환경을 위한 Kafka 설정 차별화 + kafka-exporter ServiceMonitor 타겟용 Service 수정.

## 작업 내용

### kafka-exporter Service 수정 (dev/prod)
- [x] `kafka-exporter-service.yaml` 신규 — Strimzi kafka-exporter가 자동 Service 미생성, ServiceMonitor 타겟용 headless Service 수동 생성

### prod 인증 (SCRAM-SHA-512 + TLS)
- [x] prod `kafka-cluster.yaml`: plain listener(9092) 제거, TLS(9093) + SCRAM-SHA-512 인증
- [x] dev는 인증 없이 유지 (개발 편의)

### prod 토픽 차별화
| 토픽 그룹 | dev partition | prod partition | prod retention |
|-----------|-------------|---------------|----------------|
| ticket 주문/결제/좌석 | 6 | **12** | **14일** |
| ticket 발권/취소 | 6 | 6 | **90일 (감사)** |
| user/notification/resale | 3 | **6** | 7~30일 |
| DLQ 전체 | 1 | 1 | **90일** |

### KafkaUser + ACL (prod only)
- [x] 6개 서비스별 SCRAM-SHA-512 사용자: ticketing, user, payment, stadium, resale, notification
- [x] 최소 권한 ACL: 각 서비스가 자기 도메인 토픽만 접근

## 테스트
- [ ] dev: kafka-exporter Service 생성 → ServiceMonitor targets 확인
- [ ] dev: `curl kafka-exporter-metrics.kafka.svc:9404/metrics` 메트릭 수집 확인
- [ ] prod: EKS 배포 후 KafkaUser Secret 자동 생성 확인
- [ ] prod: TLS + SCRAM 인증으로 서비스 연결 테스트