### PR TITLE
[CHORE] K8s 프로덕션 보안 하드닝 + P0 Critical 즉시 조치 (#52)

### DIFF
--- a/environments/dev/goti-payment/values.yaml
+++ b/environments/dev/goti-payment/values.yaml
@@ -128,6 +128,6 @@ istioPolicy:
       - hosts:
           - "istio-system/*"
           - "./*"
-          - "monitoring/alloy-dev.monitoring.svc.cluster.local"
+          - "monitoring/*"
           - "kafka/*"
           - "~/*.amazonaws.com"

--- a/environments/dev/goti-resale/values.yaml
+++ b/environments/dev/goti-resale/values.yaml
@@ -128,6 +128,6 @@ istioPolicy:
       - hosts:
           - "istio-system/*"
           - "./*"
-          - "monitoring/alloy-dev.monitoring.svc.cluster.local"
+          - "monitoring/*"
           - "kafka/*"
           - "~/*.amazonaws.com"

--- a/environments/dev/goti-stadium/values.yaml
+++ b/environments/dev/goti-stadium/values.yaml
@@ -130,6 +130,6 @@ istioPolicy:
       - hosts:
           - "istio-system/*"
           - "./*"
-          - "monitoring/alloy-dev.monitoring.svc.cluster.local"
+          - "monitoring/*"
           - "kafka/*"
           - "~/*.amazonaws.com"

--- a/environments/dev/goti-ticketing/values.yaml
+++ b/environments/dev/goti-ticketing/values.yaml
@@ -142,6 +142,6 @@ istioPolicy:
       - hosts:
           - "istio-system/*"
           - "./*"
-          - "monitoring/alloy-dev.monitoring.svc.cluster.local"
+          - "monitoring/*"
           - "kafka/*"
           - "~/*.amazonaws.com"

--- a/environments/dev/goti-user/values.yaml
+++ b/environments/dev/goti-user/values.yaml
@@ -122,7 +122,7 @@ istioPolicy:
       - hosts:
           - "istio-system/*"
           - "./*"
-          - "monitoring/alloy-dev.monitoring.svc.cluster.local"
+          - "monitoring/*"
           - "kafka/*"
           # OAuth 소셜 로그인 (Google, Naver, Kakao)
           - "~/*.googleapis.com"

--- a/gitops/prod/projects/infra-project.yaml
+++ b/gitops/prod/projects/infra-project.yaml
@@ -12,6 +12,12 @@ spec:
       server: "https://kubernetes.default.svc"
     - namespace: istio-system
       server: "https://kubernetes.default.svc"
+    - namespace: monitoring
+      server: "https://kubernetes.default.svc"
+    - namespace: goti
+      server: "https://kubernetes.default.svc"
+    - namespace: kafka
+      server: "https://kubernetes.default.svc"
     - namespace: kyverno
       server: "https://kubernetes.default.svc"
   clusterResourceWhitelist:
@@ -27,9 +33,94 @@ spec:
       kind: MutatingWebhookConfiguration
     - group: "admissionregistration.k8s.io"
       kind: ValidatingWebhookConfiguration
+    # External Secrets (cluster-scoped)
+    - group: "external-secrets.io"
+      kind: ClusterSecretStore
     - group: "kyverno.io"
       kind: ClusterPolicy
-  # Istio, ArgoCD 리소스 타입이 다양하므로 namespace 경계로 격리
   namespaceResourceWhitelist:
-    - group: "*"
-      kind: "*"
+    # Core
+    - group: ""
+      kind: Service
+    - group: ""
+      kind: ConfigMap
+    - group: ""
+      kind: Secret
+    - group: ""
+      kind: ServiceAccount
+    - group: ""
+      kind: Endpoints
+    # Apps
+    - group: "apps"
+      kind: Deployment
+    - group: "apps"
+      kind: DaemonSet
+    - group: "apps"
+      kind: StatefulSet
+    # RBAC
+    - group: "rbac.authorization.k8s.io"
+      kind: Role
+    - group: "rbac.authorization.k8s.io"
+      kind: RoleBinding
+    # Istio
+    - group: "networking.istio.io"
+      kind: Gateway
+    - group: "networking.istio.io"
+      kind: VirtualService
+    - group: "networking.istio.io"
+      kind: DestinationRule
+    - group: "networking.istio.io"
+      kind: EnvoyFilter
+    - group: "networking.istio.io"
+      kind: ServiceEntry
+    - group: "networking.istio.io"
+      kind: Sidecar
+    - group: "security.istio.io"
+      kind: PeerAuthentication
+    - group: "security.istio.io"
+      kind: AuthorizationPolicy
+    - group: "security.istio.io"
+      kind: RequestAuthentication
+    # Monitoring
+    - group: "monitoring.coreos.com"
+      kind: ServiceMonitor
+    - group: "monitoring.coreos.com"
+      kind: PodMonitor
+    - group: "monitoring.coreos.com"
+      kind: PrometheusRule
+    # ArgoCD
+    - group: "argoproj.io"
+      kind: Application
+    - group: "argoproj.io"
+      kind: ApplicationSet
+    - group: "argoproj.io"
+      kind: AppProject
+    # NetworkPolicy
+    - group: "networking.k8s.io"
+      kind: NetworkPolicy
+    # OTel
+    - group: "opentelemetry.io"
+      kind: Instrumentation
+    - group: "opentelemetry.io"
+      kind: OpenTelemetryCollector
+    # Strimzi Kafka
+    - group: "kafka.strimzi.io"
+      kind: Kafka
+    - group: "kafka.strimzi.io"
+      kind: KafkaTopic
+    - group: "kafka.strimzi.io"
+      kind: KafkaUser
+    # External Secrets
+    - group: "external-secrets.io"
+      kind: ExternalSecret
+    # Batch
+    - group: "batch"
+      kind: CronJob
+    - group: "batch"
+      kind: Job
+    # Policy
+    - group: "policy"
+      kind: PodDisruptionBudget
+    # Autoscaling
+    - group: "autoscaling"
+      kind: HorizontalPodAutoscaler

--- a/infrastructure/dev/cert-manager/application.yaml
+++ b/infrastructure/dev/cert-manager/application.yaml
@@ -9,7 +9,7 @@ spec:
   sources:
     - repoURL: https://charts.jetstack.io
       chart: cert-manager
-      targetRevision: v1.17.*
+      targetRevision: v1.17.4
       helm:
         valueFiles:
           - $values/infrastructure/dev/cert-manager/values.yaml

--- a/infrastructure/dev/external-secrets/application.yaml
+++ b/infrastructure/dev/external-secrets/application.yaml
@@ -8,7 +8,7 @@ spec:
   sources:
     - repoURL: https://charts.external-secrets.io
       chart: external-secrets
-      targetRevision: 2.1.*
+      targetRevision: 2.1.0
       helm:
         valueFiles:
           - $values/infrastructure/dev/external-secrets/values.yaml

--- a/infrastructure/dev/network-policies/argocd-netpol.yaml
+++ b/infrastructure/dev/network-policies/argocd-netpol.yaml
@@ -70,7 +70,12 @@ spec:
   policyTypes:
     - Egress
   egress:
-    - ports:
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 169.254.169.254/32
+      ports:
         - port: 443
           protocol: TCP
 ---
@@ -87,7 +92,12 @@ spec:
   policyTypes:
     - Egress
   egress:
-    - ports:
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 169.254.169.254/32
+      ports:
         - port: 443
           protocol: TCP
         - port: 6443

--- a/infrastructure/dev/network-policies/argocd-netpol.yaml
+++ b/infrastructure/dev/network-policies/argocd-netpol.yaml
@@ -70,6 +70,7 @@ spec:
   policyTypes:
     - Egress
   egress:
+    # Kind 환경에서 GitHub IP가 동적이므로 0.0.0.0/0 허용, IMDS만 차단
     - to:
         - ipBlock:
             cidr: 0.0.0.0/0
@@ -92,6 +93,8 @@ spec:
   policyTypes:
     - Egress
   egress:
+    # Kind 환경에서 K8s API 서버 IP가 동적이므로 0.0.0.0/0 허용, IMDS만 차단
+    # prod에서는 API 서버 ClusterIP/대역으로 제한 필요
     - to:
         - ipBlock:
             cidr: 0.0.0.0/0

--- a/infrastructure/dev/network-policies/goti-netpol.yaml
+++ b/infrastructure/dev/network-policies/goti-netpol.yaml
@@ -131,6 +131,14 @@ spec:
         - port: 6379
           protocol: TCP
     # 외부 HTTPS (AWS SSM, OAuth 등 — Sidecar에서 L7 세분화)
-    - ports:
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+              - 169.254.169.254/32
+      ports:
         - port: 443
           protocol: TCP

--- a/infrastructure/dev/network-policies/kafka-netpol.yaml
+++ b/infrastructure/dev/network-policies/kafka-netpol.yaml
@@ -87,7 +87,12 @@ spec:
   egress:
     - to:
         - podSelector: {}
-    - ports:
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 169.254.169.254/32
+      ports:
         - port: 443
           protocol: TCP
         - port: 6443

--- a/infrastructure/dev/network-policies/kafka-netpol.yaml
+++ b/infrastructure/dev/network-policies/kafka-netpol.yaml
@@ -45,6 +45,7 @@ spec:
   policyTypes:
     - Ingress
     - Egress
+  # TODO: inter-broker 포트(9091, 9090 등) 명시하여 최소 권한 적용
   ingress:
     - from:
         - podSelector:
@@ -87,6 +88,8 @@ spec:
   egress:
     - to:
         - podSelector: {}
+    # Kind 환경에서 K8s API 서버 IP가 동적이므로 0.0.0.0/0 허용, IMDS만 차단
+    # prod에서는 API 서버 ClusterIP/대역으로 제한 필요
     - to:
         - ipBlock:
             cidr: 0.0.0.0/0

--- a/infrastructure/dev/network-policies/monitoring-netpol.yaml
+++ b/infrastructure/dev/network-policies/monitoring-netpol.yaml
@@ -110,6 +110,13 @@ spec:
     - to:
         - namespaceSelector:
             matchLabels:
+              kubernetes.io/metadata.name: kafka
+      ports:
+        - port: 9404
+          protocol: TCP
+    - to:
+        - namespaceSelector:
+            matchLabels:
               kubernetes.io/metadata.name: kube-system
       ports:
         - port: 8080

--- a/infrastructure/dev/opentelemetry-operator/application.yaml
+++ b/infrastructure/dev/opentelemetry-operator/application.yaml
@@ -10,7 +10,7 @@ spec:
   sources:
     - repoURL: https://open-telemetry.github.io/opentelemetry-helm-charts
       chart: opentelemetry-operator
-      targetRevision: 0.107.*
+      targetRevision: 0.107.2
       helm:
         valueFiles:
           - $values/infrastructure/dev/opentelemetry-operator/values.yaml

--- a/infrastructure/dev/strimzi-operator/application.yaml
+++ b/infrastructure/dev/strimzi-operator/application.yaml
@@ -10,7 +10,7 @@ spec:
   sources:
     - repoURL: https://strimzi.io/charts/
       chart: strimzi-kafka-operator
-      targetRevision: 0.51.*
+      targetRevision: 0.51.0
       helm:
         valueFiles:
           - $values/infrastructure/dev/strimzi-operator/values.yaml

--- a/infrastructure/prod/cert-manager/application.yaml
+++ b/infrastructure/prod/cert-manager/application.yaml
@@ -9,7 +9,7 @@ spec:
   sources:
     - repoURL: https://charts.jetstack.io
       chart: cert-manager
-      targetRevision: v1.17.*
+      targetRevision: v1.17.4
       helm:
         valueFiles:
           - $values/infrastructure/prod/cert-manager/values.yaml

--- a/infrastructure/prod/external-secrets/application.yaml
+++ b/infrastructure/prod/external-secrets/application.yaml
@@ -8,7 +8,7 @@ spec:
   sources:
     - repoURL: https://charts.external-secrets.io
       chart: external-secrets
-      targetRevision: 2.1.*
+      targetRevision: 2.1.0
       helm:
         valueFiles:
           - $values/infrastructure/prod/external-secrets/values.yaml

--- a/infrastructure/prod/opentelemetry-operator/application.yaml
+++ b/infrastructure/prod/opentelemetry-operator/application.yaml
@@ -10,7 +10,7 @@ spec:
   sources:
     - repoURL: https://open-telemetry.github.io/opentelemetry-helm-charts
       chart: opentelemetry-operator
-      targetRevision: 0.107.*
+      targetRevision: 0.107.2
       helm:
         valueFiles:
           - $values/infrastructure/prod/opentelemetry-operator/values.yaml


### PR DESCRIPTION
## 관련 이슈
- Closes #52

## 개요
K8s 인프라 보안 하드닝 + 프로덕션 준비 종합 점검에서 발견된 P0 Critical 3건 즉시 조치.
CIS Benchmark / NSA-CISA 가이드 기반 보안 강화.

## 작업 내용

### 보안 하드닝 (커밋 1-2)
- [x] dev/prod 서비스별 securityContext 강화 (readOnlyRootFilesystem, runAsNonRoot, allowPrivilegeEscalation: false)
- [x] NetworkPolicy defense-in-depth (goti, argocd, kafka, monitoring namespace)
- [x] prod 불필요 리소스 정리 (Kyverno, goti-policy, mesh-policy, storageclass 등)
- [x] prod Istio istiod 보안 설정 강화
- [x] Kafka 클러스터 보안 설정 + Grafana 대시보드 SSOT
- [x] 리뷰 피드백 반영 (External Secrets, Strimzi config-application 분리 등)

### P0 Critical 즉시 조치 (커밋 3)
- [x] **P0-1**: prod infra-project `namespaceResourceWhitelist` 와일드카드(`*/*`) → 명시적 리소스 열거
- [x] **P0-2**: NetworkPolicy egress IMDS(`169.254.169.254`) 차단
  - goti: 외부 HTTPS에 private IP 대역(RFC1918) 제외
  - argocd: repo-server, application-controller에 IMDS 차단
  - kafka: strimzi operator에 ipBlock + IMDS 차단
- [x] **P0-3**: Helm chart 와일드카드 버전 → exact patch 버전 고정
  - cert-manager `v1.17.4`, external-secrets `2.1.0`
  - otel-operator `0.107.2`, strimzi `0.51.0`

## 테스트
- [x] YAML syntax 검증 (13/13 통과)
- [ ] Kind 로컬 클러스터 배포 검증
- [ ] ArgoCD sync 확인
- [ ] NetworkPolicy 변경 후 기존 트래픽 정상 확인