### PR TITLE
feat(guardrail): K8s 배포 구성 — values + ApplicationSet

### DIFF
--- a/environments/dev/goti-guardrail/values.yaml
+++ b/environments/dev/goti-guardrail/values.yaml
@@ -24,14 +24,14 @@ probes:
     httpGet:
       path: /health
       port: http
-    initialDelaySeconds: 5
+    initialDelaySeconds: 15
     periodSeconds: 10
     failureThreshold: 3
   readiness:
     httpGet:
       path: /health/ready
       port: http
-    initialDelaySeconds: 5
+    initialDelaySeconds: 10
     periodSeconds: 5
     failureThreshold: 3
 
@@ -45,20 +45,14 @@ resources:
 
 env:
   - name: GUARDRAIL_REDIS_URL
-    value: "redis://host.docker.internal:6379/1"  # dev: 호스트 PC Redis, DB 1번
+    value: "redis://host.docker.internal:6379/1"  # dev only: 호스트 PC Redis, DB 1번. prod에서는 ExternalSecret으로 교체
+  - name: PYTHONDONTWRITEBYTECODE
+    value: "1"
+  - name: PYTHONUNBUFFERED
+    value: "1"
 
 gateway:
   enabled: false  # Guardrail은 Istio ExtAuthz로 연동 (VirtualService 불필요)
-
-autoscaling:
-  enabled: false
-  minReplicas: 1
-  maxReplicas: 5
-  targetCPUUtilizationPercentage: 70
-
-pdb:
-  enabled: false
-  minAvailable: 1
 
 podSecurityContext:
   runAsNonRoot: true
@@ -77,12 +71,12 @@ configMap:
   enabled: false
 
 externalSecret:
-  enabled: false
+  enabled: false  # dev only: Redis 인증 미사용. prod에서는 enabled: true + remoteRef 설정
 
 # --- Istio 보안/네트워크 정책 ---
 istioPolicy:
   authorizationPolicy:
-    enabled: false  # ExtAuthz로 사용되므로 별도 설정 불필요
+    enabled: false  # ExtAuthz 서버로 동작하여 자체 AuthorizationPolicy 불필요. 호출 제한은 Istio mesh 레벨에서 처리
   destinationRule:
     enabled: true
   sidecar:

--- a/environments/dev/goti-guardrail/values.yaml
+++ b/environments/dev/goti-guardrail/values.yaml
@@ -1,0 +1,94 @@
+nameOverride: goti-guardrail
+
+replicaCount: 1
+
+image:
+  repository: "707925622666.dkr.ecr.ap-northeast-2.amazonaws.com/goti-guardrail"
+  tag: "latest"  # TODO: CI/CD 구축 후 실제 태그로 교체
+  pullPolicy: Always
+
+imagePullSecrets:
+  - name: ecr-creds
+
+podAnnotations:
+  # dev only: 호스트 PC Redis는 Envoy 프록시 우회
+  traffic.sidecar.istio.io/excludeOutboundPorts: "6379"
+
+service:
+  type: ClusterIP
+  port: 8000
+  name: http
+
+probes:
+  liveness:
+    httpGet:
+      path: /health
+      port: http
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    failureThreshold: 3
+  readiness:
+    httpGet:
+      path: /health/ready
+      port: http
+    initialDelaySeconds: 5
+    periodSeconds: 5
+    failureThreshold: 3
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 128Mi
+  limits:
+    cpu: 200m
+    memory: 256Mi
+
+env:
+  - name: GUARDRAIL_REDIS_URL
+    value: "redis://host.docker.internal:6379/1"  # dev: 호스트 PC Redis, DB 1번
+
+gateway:
+  enabled: false  # Guardrail은 Istio ExtAuthz로 연동 (VirtualService 불필요)
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+
+pdb:
+  enabled: false
+  minAvailable: 1
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  fsGroup: 1000
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop: ["ALL"]
+  seccompProfile:
+    type: RuntimeDefault
+
+configMap:
+  enabled: false
+
+externalSecret:
+  enabled: false
+
+# --- Istio 보안/네트워크 정책 ---
+istioPolicy:
+  authorizationPolicy:
+    enabled: false  # ExtAuthz로 사용되므로 별도 설정 불필요
+  destinationRule:
+    enabled: true
+  sidecar:
+    enabled: true
+    egress:
+      - hosts:
+          - "istio-system/*"
+          - "./*"
+          - "monitoring/*"

--- a/gitops/dev/applicationsets/goti-infra-appset.yaml
+++ b/gitops/dev/applicationsets/goti-infra-appset.yaml
@@ -1,0 +1,46 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: goti-infra
+  namespace: argocd
+spec:
+  generators:
+    - list:
+        elements:
+          - service: guardrail
+            namespace: goti
+            valuesFile: environments/dev/goti-guardrail/values.yaml
+          # TODO: queue-gate (Go), bot-detection (Python) 추가 예정
+  template:
+    metadata:
+      name: "goti-{{service}}-dev"
+    spec:
+      project: goti
+      source:
+        repoURL: "https://github.com/Team-Ikujo/Goti-k8s.git"
+        targetRevision: main  # dev only: HEAD tracking
+        path: "charts/goti-server"
+        helm:
+          valueFiles:
+            - "../../{{valuesFile}}"
+      destination:
+        server: "https://kubernetes.default.svc"
+        namespace: "{{namespace}}"
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        retry:
+          limit: 5
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m
+        syncOptions:
+          - CreateNamespace=true
+          - ServerSideApply=true
+      ignoreDifferences:
+        - group: apps
+          kind: Deployment
+          jsonPointers:
+            - /spec/replicas

--- a/gitops/dev/applicationsets/goti-infra-appset.yaml
+++ b/gitops/dev/applicationsets/goti-infra-appset.yaml
@@ -18,7 +18,7 @@ spec:
       project: goti
       source:
         repoURL: "https://github.com/Team-Ikujo/Goti-k8s.git"
-        targetRevision: main  # dev only: HEAD tracking
+        targetRevision: main  # dev only: HEAD tracking — prod는 반드시 semver tag 고정
         path: "charts/goti-server"
         helm:
           valueFiles:


### PR DESCRIPTION
## 관련 이슈
- Goti-guardrail-server PR #1 (K8s 배포 준비 — Dockerfile, 환경변수, Redis lifecycle)

## 개요
Goti-guardrail-server(봇 탐지 점수제 가드레일)의 K8s 배포를 위한 Helm values와 ArgoCD ApplicationSet을 추가한다.
비즈니스 MSA 서비스와 분리된 인프라 서비스용 ApplicationSet(`goti-infra`)을 신설하여, 향후 queue-gate(Go)와 bot-detection(Python) 서비스도 동일 구조로 추가할 수 있도록 한다.

## 작업 내용
- [x] `environments/dev/goti-guardrail/values.yaml` — Python FastAPI 서비스 values
  - port 8000, `/health` (liveness) + `/health/ready` (readiness) probe
  - resources: 50m~200m CPU, 128Mi~256Mi Memory
  - Istio: sidecar injection + DestinationRule + Sidecar egress 제한
  - Redis: `host.docker.internal:6379/1` (dev 호스트 PC, DB 1번 분리)
  - Gateway disabled (Istio ExtAuthz로 연동 예정)
- [x] `gitops/dev/applicationsets/goti-infra-appset.yaml` — 인프라 서비스용 ApplicationSet
  - guardrail 등록, goti-msa-appset과 분리 (비즈니스 vs 인프라)
  - charts/goti-server (goti-common library chart) 재사용

### 아키텍처 결정
- **goti-msa-appset과 분리**: guardrail은 비즈니스 MSA가 아닌 인프라/보안 서비스
- **charts/goti-server 재사용**: goti-common library chart가 충분히 범용적이므로 별도 chart 불필요
- **Redis 분리 전략**: dev는 호스트 Redis DB 1번 공유, prod는 별도 ElastiCache 예정

### TODO (후속 작업)
- ECR 레포지토리 `goti-guardrail` 생성
- GitHub Actions CI/CD (Python → ECR push)
- Istio ExtAuthz 설정 (guardrail → 예매 구간 인라인 인가)
- queue-gate, bot-detection 서비스 추가

## 테스트
- [x] `helm lint` 통과
- [x] `helm template` 렌더링 검증 (Deployment, Service, DestinationRule, Sidecar 정상)
- [ ] Kind 로컬 클러스터 배포 검증 (ECR 이미지 빌드 후)
- [ ] ArgoCD sync 확인

