### PR TITLE
[CHORE] prod 이미지 태그 업데이트: prod-12-ea56727

### DIFF
--- a/environments/prod/goti-user/values.yaml
+++ b/environments/prod/goti-user/values.yaml
@@ -1,7 +1,7 @@
 nameOverride: goti-user
 image:
   repository: "harbor.go-ti.shop/prod/goti-user"
-  tag: "prod-11-ea56727"
+  tag: "prod-12-ea56727"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds


### PR DESCRIPTION
## 변경 사항
- 이미지 태그: `prod-12-ea56727`
- 레지스트리: `harbor.go-ti.shop/prod/`
- 업데이트된 서비스: `{"include":[{"service":"user"}]}`

## 트리거
- 브랜치: `deploy/prod`
- 커밋: ea56727236914aea9f36e00d80c5b78a299e65dd
- 워크플로우: [#12](https://github.com/Team-Ikujo/Goti-server/actions/runs/23402319425)