### PR TITLE
[CHORE] prod 이미지 태그 업데이트: prod-19-71dcf1b

### DIFF
--- a/environments/prod/goti-user/values.yaml
+++ b/environments/prod/goti-user/values.yaml
@@ -1,7 +1,7 @@
 nameOverride: goti-user
 image:
   repository: "harbor.go-ti.shop/prod/goti-user"
-  tag: "prod-11-ea56727"
+  tag: "prod-19-71dcf1b"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds


### PR DESCRIPTION
## 변경 사항
- 이미지 태그: `prod-19-71dcf1b`
- 레지스트리: `harbor.go-ti.shop/prod/`
- 업데이트된 서비스: `{"include":[{"service":"user"}]}`

## 트리거
- 브랜치: `deploy/prod`
- 커밋: 71dcf1b6abc321a14d0c2b791c7f6902a81808d1
- 워크플로우: [#19](https://github.com/Team-Ikujo/Goti-server/actions/runs/23470341450)