### PR TITLE
[CHORE] prod 이미지 태그 업데이트: prod-25-71dcf1b

### DIFF
--- a/environments/prod/goti-resale/values.yaml
+++ b/environments/prod/goti-resale/values.yaml
@@ -1,16 +1,12 @@
 nameOverride: goti-resale
-
 image:
-  repository: "707925622666.dkr.ecr.ap-northeast-2.amazonaws.com/goti-resale"
-  tag: "dev-35-de629ba"
+  repository: "harbor.go-ti.shop/prod/goti-resale"
+  tag: "prod-25-71dcf1b"
   pullPolicy: IfNotPresent
-
 imagePullSecrets:
-  - name: ecr-creds
-
+  - name: harbor-creds
 podAnnotations:
   instrumentation.opentelemetry.io/inject-java: "goti/goti-java"
-
 resources:
   requests:
     cpu: 250m
@@ -18,7 +14,6 @@ resources:
   limits:
     cpu: 1000m
     memory: 768Mi
-
 gateway:
   enabled: true
   hosts:
@@ -54,7 +49,6 @@ gateway:
             host: goti-resale-prod
             port:
               number: 8080
-
 probes:
   liveness:
     httpGet:
@@ -68,7 +62,6 @@ probes:
       port: http
     initialDelaySeconds: 30
     periodSeconds: 5
-
 env:
   - name: SPRING_PROFILES_ACTIVE
     value: "prod"
@@ -87,11 +80,9 @@ env:
     value: "/api/docs/resale/v3/api-docs/swagger-config"
   - name: SPRINGDOC_SWAGGER_UI_URL
     value: "/api/docs/resale/v3/api-docs"
-
 envFrom:
   - secretRef:
       name: goti-resale-prod-secrets
-
 externalSecret:
   enabled: true
   refreshInterval: "1h"


### PR DESCRIPTION
## 변경 사항
- 이미지 태그: `prod-25-71dcf1b`
- 레지스트리: `harbor.go-ti.shop/prod/`
- 업데이트된 서비스: `{"include":[{"service":"resale"}]}`

## 트리거
- 브랜치: `deploy/prod`
- 커밋: 71dcf1b6abc321a14d0c2b791c7f6902a81808d1
- 워크플로우: [#25](https://github.com/Team-Ikujo/Goti-server/actions/runs/23709389019)