### PR TITLE
feat(monitoring): Alloy→OTel Collector 마이그레이션 인프라 준비

### DIFF
--- a/gitops/dev/projects/monitoring-project.yaml
+++ b/gitops/dev/projects/monitoring-project.yaml
@@ -10,6 +10,7 @@ spec:
     - "https://prometheus-community.github.io/helm-charts"
     - "https://grafana.github.io/helm-charts"
     - "https://grafana-community.github.io/helm-charts"  # Tempo community chart 이관 (Loki는 미이관, 2026-03 확인)
+    - "https://open-telemetry.github.io/opentelemetry-helm-charts"  # OTel Collector (Alloy 대체)
   destinations:
     - namespace: monitoring
       server: "https://kubernetes.default.svc"

--- a/infrastructure/dev/network-policies/kafka-netpol.yaml
+++ b/infrastructure/dev/network-policies/kafka-netpol.yaml
@@ -126,11 +126,11 @@ spec:
         - port: 53
           protocol: TCP
 ---
-# monitoring에서 Kafka 메트릭 scrape 허용
+# monitoring에서 Kafka 메트릭 scrape + OTel Collector producer/consumer 허용
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: allow-kafka-metrics-scrape
+  name: allow-kafka-from-monitoring
   namespace: kafka
 spec:
   podSelector:
@@ -144,5 +144,7 @@ spec:
             matchLabels:
               kubernetes.io/metadata.name: monitoring
       ports:
-        - port: 9404
+        - port: 9092    # Kafka broker (OTel Collector traces/logs 버퍼링)
+          protocol: TCP
+        - port: 9404    # Kafka JMX exporter (메트릭 scrape)
           protocol: TCP

--- a/infrastructure/dev/network-policies/monitoring-netpol.yaml
+++ b/infrastructure/dev/network-policies/monitoring-netpol.yaml
@@ -31,6 +31,7 @@ spec:
           protocol: TCP
 ---
 # Mimir: Istio Gateway에서 접근 허용 (K6 부하테스트 메트릭 Push + Prometheus 쿼리)
+# SingleBinary 모드: component 레이블 없이 name만으로 매칭
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -38,13 +39,8 @@ metadata:
   namespace: monitoring
 spec:
   podSelector:
-    matchExpressions:
-      - key: app.kubernetes.io/name
-        operator: In
-        values: ["mimir"]
-      - key: app.kubernetes.io/component
-        operator: In
-        values: ["distributor", "query-frontend"]
+    matchLabels:
+      app.kubernetes.io/name: mimir
   policyTypes:
     - Ingress
   ingress:

--- a/infrastructure/dev/strimzi-operator/config/topics.yaml
+++ b/infrastructure/dev/strimzi-operator/config/topics.yaml
@@ -127,9 +127,9 @@ spec:
     min.insync.replicas: 2
 ---
 # =============================================================================
-# === 모니터링 도메인 (트레이스 버퍼) ===
-# Alloy → Kafka → Alloy(consumer) → Tempo
-# Tempo OOMKilled 방지: Kafka가 트레이스를 버퍼링하여 Tempo 유입 속도 제어
+# === 모니터링 도메인 (텔레메트리 버퍼) ===
+# OTel Collector Front → Kafka → OTel Collector Back → Tempo/Loki
+# Kafka가 traces/logs를 버퍼링하여 백엔드 OOM 방지 및 스파이크 흡수
 ---
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
@@ -146,6 +146,25 @@ spec:
     cleanup.policy: delete
     min.insync.replicas: 2
     max.message.bytes: 1048576     # 1MB (트레이스 배치)
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: observability.logs.v1
+  labels:
+    strimzi.io/cluster: goti-kafka
+    domain: observability
+spec:
+  partitions: 6
+  replicas: 3
+  config:
+    retention.ms: 7200000          # 2시간 (Loki 장애 대비 여유)
+    retention.bytes: 5368709120    # 5GB/partition
+    cleanup.policy: delete
+    compression.type: lz4          # logs는 고처리량 → lz4 압축
+    max.message.bytes: 1048576     # 1MB
+    segment.bytes: 536870912
+    min.insync.replicas: 2
 # =============================================================================
 # DLQ (Dead Letter Queue) 토픽
 # 처리 실패한 메시지를 보관. partitions: 1 (순서 보장), retention: 30일


### PR DESCRIPTION
## Summary
- Kafka `observability.logs.v1` 토픽 추가 (6파티션, 2시간 보존, lz4 압축) — logs Kafka 버퍼링용
- monitoring → kafka 9092 ingress NetworkPolicy 추가 (OTel Collector producer/consumer 통신)
- ArgoCD monitoring project에 OTel Helm chart repo 등록
- Mimir NetworkPolicy를 SingleBinary 모드 호환으로 변경 (matchExpressions → matchLabels)

## Test plan
- [ ] `kubectl get kafkatopic -n kafka observability.logs.v1` — 토픽 생성 확인
- [ ] `kubectl get netpol -n kafka allow-kafka-from-monitoring` — 정책 적용 확인
- [ ] `kubectl get netpol -n monitoring allow-mimir-ingress` — SingleBinary 호환 확인
- [ ] ArgoCD monitoring project에 `open-telemetry.github.io` sourceRepo 추가 확인
- [ ] 기존 모니터링 파이프라인 정상 동작 확인 (Grafana 대시보드)

관련: Alloy→OTel Collector + Mimir SingleBinary 마이그레이션 Phase 0+1 (인프라)

🤖 Generated with [Claude Code](https://claude.com/claude-code)