### PR TITLE
[CHORE] prod 이미지 태그 업데이트: prod-33-57bdd30

### DIFF
--- a/environments/prod/goti-user/values.yaml
+++ b/environments/prod/goti-user/values.yaml
@@ -1,7 +1,7 @@
 nameOverride: goti-user
 image:
   repository: "harbor.go-ti.shop/prod/goti-user"
-  tag: "prod-21-71dcf1b"
+  tag: "prod-33-57bdd30"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds
@@ -94,19 +94,15 @@ externalSecret:
   remoteRef:
     path: /prod/server
     overridePath: /prod/user
-
 # --- Istio 보안/네트워크 정책 ---
-
 istioPolicy:
   # user 서비스는 다른 서비스로부터 호출받지 않음 (Gateway 통해서만 접근)
   authorizationPolicy:
     enabled: true
     allowFrom: []
-
   requestAuthentication:
     enabled: true
     jwksUri: "http://goti-user-prod.goti.svc.cluster.local:8080/.well-known/jwks.json"
-
   jwtAuthorizationPolicy:
     enabled: true
     excludePaths:
@@ -122,10 +118,8 @@ istioPolicy:
       - "/v3/api-docs/*"
       - "/.well-known"
       - "/.well-known/*"
-
   destinationRule:
     enabled: true
-
   sidecar:
     enabled: true
     egress:


### PR DESCRIPTION
## 변경 사항
- 이미지 태그: `prod-33-57bdd30`
- 레지스트리: `harbor.go-ti.shop/prod/`
- 업데이트된 서비스: `{"include":[{"service":"user"}]}`

## 트리거
- 브랜치: `deploy/prod`
- 커밋: 57bdd3000d39a22cfbf75f7d0f7e3618d3a86725
- 워크플로우: [#33](https://github.com/Team-Ikujo/Goti-server/actions/runs/23736668472)