### PR TITLE
[CHORE] prod 이미지 태그 업데이트: prod-34-57bdd30

### DIFF
--- a/environments/prod/goti-stadium/values.yaml
+++ b/environments/prod/goti-stadium/values.yaml
@@ -1,7 +1,7 @@
 nameOverride: goti-stadium
 image:
   repository: "harbor.go-ti.shop/prod/goti-stadium"
-  tag: "prod-31-71dcf1b"
+  tag: "prod-34-57bdd30"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds
@@ -96,9 +96,7 @@ externalSecret:
   remoteRef:
     path: /prod/server
     overridePath: /prod/stadium
-
 # --- Istio 보안/네트워크 정책 ---
-
 istioPolicy:
   # ticketing → stadium (경기장/팀 조회)
   authorizationPolicy:
@@ -113,11 +111,9 @@ istioPolicy:
               - operation:
                   paths: ["/api/v1/stadiums*", "/api/v1/baseball-teams*"]
                   methods: ["GET"]
-
   requestAuthentication:
     enabled: true
     jwksUri: "http://goti-user-prod.goti.svc.cluster.local:8080/.well-known/jwks.json"
-
   jwtAuthorizationPolicy:
     enabled: true
     excludePaths:
@@ -131,10 +127,8 @@ istioPolicy:
       - "/swagger-ui/*"
       - "/v3/api-docs"
       - "/v3/api-docs/*"
-
   destinationRule:
     enabled: true
-
   sidecar:
     enabled: true
     egress:


### PR DESCRIPTION
## 변경 사항
- 이미지 태그: `prod-34-57bdd30`
- 레지스트리: `harbor.go-ti.shop/prod/`
- 업데이트된 서비스: `{"include":[{"service":"stadium"}]}`

## 트리거
- 브랜치: `deploy/prod`
- 커밋: 57bdd3000d39a22cfbf75f7d0f7e3618d3a86725
- 워크플로우: [#34](https://github.com/Team-Ikujo/Goti-server/actions/runs/23736707928)