### PR TITLE
[CHORE] prod 이미지 태그 업데이트: prod-35-57bdd30

### DIFF
--- a/environments/prod/goti-resale/values.yaml
+++ b/environments/prod/goti-resale/values.yaml
@@ -1,7 +1,7 @@
 nameOverride: goti-resale
 image:
   repository: "harbor.go-ti.shop/prod/goti-resale"
-  tag: "prod-25-71dcf1b"
+  tag: "prod-35-57bdd30"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds
@@ -94,9 +94,7 @@ externalSecret:
   remoteRef:
     path: /prod/server
     overridePath: /prod/resale
-
 # --- Istio 보안/네트워크 정책 ---
-
 istioPolicy:
   # payment → resale (양도 완료/거래 조회)
   authorizationPolicy:
@@ -111,11 +109,9 @@ istioPolicy:
               - operation:
                   paths: ["/api/v1/resales/orders/*"]
                   methods: ["GET", "PATCH"]
-
   requestAuthentication:
     enabled: true
     jwksUri: "http://goti-user-prod.goti.svc.cluster.local:8080/.well-known/jwks.json"
-
   jwtAuthorizationPolicy:
     enabled: true
     excludePaths:
@@ -127,10 +123,8 @@ istioPolicy:
       - "/swagger-ui/*"
       - "/v3/api-docs"
       - "/v3/api-docs/*"
-
   destinationRule:
     enabled: true
-
   sidecar:
     enabled: true
     egress:


### PR DESCRIPTION
## 변경 사항
- 이미지 태그: `prod-35-57bdd30`
- 레지스트리: `harbor.go-ti.shop/prod/`
- 업데이트된 서비스: `{"include":[{"service":"resale"}]}`

## 트리거
- 브랜치: `deploy/prod`
- 커밋: 57bdd3000d39a22cfbf75f7d0f7e3618d3a86725
- 워크플로우: [#35](https://github.com/Team-Ikujo/Goti-server/actions/runs/23736924554)