### PR TITLE
[CHORE] prod 이미지 태그 업데이트: prod-36-57bdd30

### DIFF
--- a/environments/prod/goti-payment/values.yaml
+++ b/environments/prod/goti-payment/values.yaml
@@ -1,7 +1,7 @@
 nameOverride: goti-payment
 image:
   repository: "harbor.go-ti.shop/prod/goti-payment"
-  tag: "prod-30-71dcf1b"
+  tag: "prod-36-57bdd30"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds
@@ -96,9 +96,7 @@ externalSecret:
   remoteRef:
     path: /prod/server
     overridePath: /prod/payment
-
 # --- Istio 보안/네트워크 정책 ---
-
 istioPolicy:
   # resale → payment (양도 결제/환불)
   authorizationPolicy:
@@ -113,11 +111,9 @@ istioPolicy:
               - operation:
                   paths: ["/api/v1/resales/payments", "/api/v1/resales/payments/*"]
                   methods: ["POST", "PATCH"]
-
   requestAuthentication:
     enabled: true
     jwksUri: "http://goti-user-prod.goti.svc.cluster.local:8080/.well-known/jwks.json"
-
   jwtAuthorizationPolicy:
     enabled: true
     excludePaths:
@@ -127,10 +123,8 @@ istioPolicy:
       - "/swagger-ui/*"
       - "/v3/api-docs"
       - "/v3/api-docs/*"
-
   destinationRule:
     enabled: true
-
   sidecar:
     enabled: true
     egress:


### PR DESCRIPTION
## 변경 사항
- 이미지 태그: `prod-36-57bdd30`
- 레지스트리: `harbor.go-ti.shop/prod/`
- 업데이트된 서비스: `{"include":[{"service":"payment"}]}`

## 트리거
- 브랜치: `deploy/prod`
- 커밋: 57bdd3000d39a22cfbf75f7d0f7e3618d3a86725
- 워크플로우: [#36](https://github.com/Team-Ikujo/Goti-server/actions/runs/23736931795)