### PR TITLE
feat(monitoring): OTel Collector Front/Back ApplicationSet + NetworkPolicy

### DIFF
--- a/gitops/dev/applicationsets/monitoring-appset.yaml
+++ b/gitops/dev/applicationsets/monitoring-appset.yaml
@@ -42,6 +42,16 @@ spec:
                   chartName: pyroscope
                   chartVersion: "1.18.1"
                   valuesFile: values-stacks/dev/pyroscope-values.yaml
+                - component: otel-collector-front
+                  chartRepo: https://open-telemetry.github.io/opentelemetry-helm-charts
+                  chartName: opentelemetry-collector
+                  chartVersion: "0.147.1"
+                  valuesFile: values-stacks/dev/otel-collector-front-values.yaml
+                - component: otel-collector-back
+                  chartRepo: https://open-telemetry.github.io/opentelemetry-helm-charts
+                  chartName: opentelemetry-collector
+                  chartVersion: "0.147.1"
+                  valuesFile: values-stacks/dev/otel-collector-back-values.yaml
   template:
     metadata:
       name: "{{component}}-{{env}}"

--- a/infrastructure/dev/network-policies/monitoring-netpol.yaml
+++ b/infrastructure/dev/network-policies/monitoring-netpol.yaml
@@ -179,6 +179,62 @@ spec:
         - port: 4318
           protocol: TCP
 ---
+# OTel Collector Front: goti namespace에서 OTLP 수신
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-otel-collector-ingress
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: opentelemetry-collector
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: goti
+      ports:
+        - port: 4317    # OTLP gRPC
+          protocol: TCP
+        - port: 4318    # OTLP HTTP
+          protocol: TCP
+---
+# OTel Collector: Kafka broker egress (traces/logs 버퍼링)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-otel-collector-kafka-egress
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: opentelemetry-collector
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kafka
+      ports:
+        - port: 9092    # Kafka broker
+          protocol: TCP
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+---
 # Alloy: goti namespace scrape egress + kube-system metrics
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy


### PR DESCRIPTION
## Summary
- ApplicationSet에 `otel-collector-front`, `otel-collector-back` 추가 (opentelemetry-collector chart 0.147.1)
- NetworkPolicy: OTel Collector OTLP ingress (goti→4317/4318)
- NetworkPolicy: OTel Collector Kafka egress (monitoring→kafka:9092)
- Alloy는 아직 유지 (병행 운영, 다음 PR에서 트래픽 전환)

## Test plan
- [ ] `kubectl get pods -n monitoring -l app.kubernetes.io/name=opentelemetry-collector` — Front/Back Pod Running
- [ ] Front Collector 로그: OTLP receiver started, 에러 없음
- [ ] Back Collector 로그: Kafka 연결 정상, consumer group 등록
- [ ] `otelcol_*` 메트릭 Mimir에서 수집 확인
- [ ] 기존 Alloy 파이프라인 정상 동작 유지

관련: Alloy→OTel Collector 마이그레이션 Phase 2