### PR TITLE
feat(monitoring): OTLP endpoint Alloy → OTel Collector 전환

### DIFF
--- a/infrastructure/dev/argocd/values-dev.yaml
+++ b/infrastructure/dev/argocd/values-dev.yaml
@@ -66,6 +66,6 @@ argo-cd:
       server.insecure: true
       # chart 9.x에서 기본값 제거됨 — ApplicationSet 자동 sync 필요 시 명시
       applicationsetcontroller.policy: sync
-      # ArgoCD 트레이싱 → Alloy → Tempo (sync, reconcile, repo-server 등)
-      otlp.address: "alloy-dev.monitoring.svc:4317"
+      # ArgoCD 트레이싱 → OTel Collector → Kafka → Tempo
+      otlp.address: "otel-collector-front-dev-opentelemetry-collector.monitoring.svc:4317"
       otlp.insecure: "true"

--- a/infrastructure/dev/istio/istiod/values-dev.yaml
+++ b/infrastructure/dev/istio/istiod/values-dev.yaml
@@ -18,9 +18,9 @@ istiod:
     accessLogFile: "/dev/stdout"
     # 분산 트레이싱 활성화
     enableTracing: true
-    # OTLP 트레이싱 프로바이더 (Alloy 연동)
+    # OTLP 트레이싱 프로바이더 (OTel Collector 연동)
     extensionProviders:
       - name: otel-tracing
         opentelemetry:
-          service: alloy.monitoring.svc.cluster.local
+          service: otel-collector-front-dev-opentelemetry-collector.monitoring.svc.cluster.local
           port: 4317

--- a/infrastructure/dev/opentelemetry-operator/config/instrumentation.yaml
+++ b/infrastructure/dev/opentelemetry-operator/config/instrumentation.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: goti
 spec:
   exporter:
-    endpoint: http://alloy-dev.monitoring.svc:4317
+    endpoint: http://otel-collector-front-dev-opentelemetry-collector.monitoring.svc:4317
   propagators:
     - tracecontext
     - baggage


### PR DESCRIPTION
## Summary
- Instrumentation CR: `alloy-dev` → `otel-collector-front-dev-opentelemetry-collector` (Java auto-instrumentation)
- ArgoCD tracing: `alloy-dev` → `otel-collector-front-dev-opentelemetry-collector`
- Istio tracing provider: `alloy` → `otel-collector-front-dev-opentelemetry-collector`

## Test plan
- [ ] 머지 후 `kubectl rollout restart deployment -n goti` 실행
- [ ] OTel Collector Front 로그에서 OTLP 데이터 수신 확인
- [ ] Grafana에서 새 traces 조회 가능 확인 (Tempo)
- [ ] Grafana에서 새 logs 조회 가능 확인 (Loki)
- [ ] Grafana에서 app metrics 정상 확인 (Mimir)
- [ ] Alloy는 아직 유지 (K8s scraping 담당)

관련: Alloy→OTel Collector 마이그레이션 Phase 3