### PR TITLE
chore(dev): 메모리 절감 — 메인 replica 2→1, sungjeon POC 0

### DIFF
--- a/environments/dev/goti-payment-sungjeon/values.yaml
+++ b/environments/dev/goti-payment-sungjeon/values.yaml
@@ -9,7 +9,7 @@
 
 nameOverride: goti-payment-sungjeon
 
-replicaCount: 1
+replicaCount: 0  # 리소스 절감 — POC 테스트 시 1로 복원
 
 autoscaling:
   enabled: false

--- a/environments/dev/goti-payment/values.yaml
+++ b/environments/dev/goti-payment/values.yaml
@@ -1,6 +1,6 @@
 nameOverride: goti-payment
 
-replicaCount: 2
+replicaCount: 1
 
 autoscaling:
   enabled: true

--- a/environments/dev/goti-queue-sungjeon/values.yaml
+++ b/environments/dev/goti-queue-sungjeon/values.yaml
@@ -9,7 +9,7 @@
 
 nameOverride: goti-queue-sungjeon
 
-replicaCount: 1
+replicaCount: 0  # 리소스 절감 — POC 테스트 시 1로 복원
 
 # POC이므로 오토스케일링 비활성화 — 고정 리소스로 공정한 비교
 autoscaling:

--- a/environments/dev/goti-resale/values.yaml
+++ b/environments/dev/goti-resale/values.yaml
@@ -1,6 +1,6 @@
 nameOverride: goti-resale
 
-replicaCount: 2
+replicaCount: 1
 
 autoscaling:
   enabled: true

--- a/environments/dev/goti-stadium/values.yaml
+++ b/environments/dev/goti-stadium/values.yaml
@@ -1,6 +1,6 @@
 nameOverride: goti-stadium
 
-replicaCount: 2
+replicaCount: 1
 
 autoscaling:
   enabled: true

--- a/environments/dev/goti-ticketing-sungjeon/values.yaml
+++ b/environments/dev/goti-ticketing-sungjeon/values.yaml
@@ -11,7 +11,7 @@
 
 nameOverride: goti-ticketing-sungjeon
 
-replicaCount: 1
+replicaCount: 0  # 리소스 절감 — POC 테스트 시 1로 복원
 
 autoscaling:
   enabled: false

--- a/environments/dev/goti-ticketing/values.yaml
+++ b/environments/dev/goti-ticketing/values.yaml
@@ -1,6 +1,6 @@
 nameOverride: goti-ticketing
 
-replicaCount: 2
+replicaCount: 1
 
 autoscaling:
   enabled: true

--- a/environments/dev/goti-user/values.yaml
+++ b/environments/dev/goti-user/values.yaml
@@ -1,6 +1,6 @@
 nameOverride: goti-user
 
-replicaCount: 2
+replicaCount: 1
 
 autoscaling:
   enabled: true


### PR DESCRIPTION
## Summary
- 메인 서비스 5개 replica 2→1: payment, resale, stadium, user, ticketing (dev에서 HA 불필요)
- sungjeon POC 3개 replica 1→0: payment, queue, ticketing (테스트 시 복원)
- 예상 절감: ~5.4Gi (Java 서비스 8개 × ~600Mi)

## 배경
- 30Gi 메모리 중 ~26Gi 사용 → 스왑 8Gi 풀 사용, OOM 발생
- Alloy→OTel Collector 전환 중 병행 운영으로 메모리 초과 경험
- 내일 POC 테스트를 위한 여유 확보 필요

## Test plan
- [ ] ArgoCD sync 후 Pod 수 감소 확인
- [ ] `free -h`로 메모리 여유 확인 (목표: 가용 5Gi+)
- [ ] 메인 서비스 정상 동작 확인