### PR TITLE
[CHORE] prod 이미지 태그 업데이트: prod-38-190dc9d

### DIFF
--- a/environments/prod/goti-user/values.yaml
+++ b/environments/prod/goti-user/values.yaml
@@ -1,7 +1,7 @@
 nameOverride: goti-user
 image:
   repository: "harbor.go-ti.shop/prod/goti-user"
-  tag: "prod-33-57bdd30"
+  tag: "prod-38-190dc9d"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds


### PR DESCRIPTION
## 변경 사항
- 이미지 태그: `prod-38-190dc9d`
- 레지스트리: `harbor.go-ti.shop/prod/`
- 업데이트된 서비스: `{"include":[{"service":"user"}]}`

## 트리거
- 브랜치: `deploy/prod`
- 커밋: 190dc9d0e865c7c1118049d12979f1bda9880978
- 워크플로우: [#38](https://github.com/Team-Ikujo/Goti-server/actions/runs/23835583420)