### PR TITLE
[CHORE] prod 이미지 태그 업데이트: prod-39-b9bdd0f

### DIFF
--- a/environments/prod/goti-user/values.yaml
+++ b/environments/prod/goti-user/values.yaml
@@ -1,7 +1,7 @@
 nameOverride: goti-user
 image:
   repository: "harbor.go-ti.shop/prod/goti-user"
-  tag: "prod-38-190dc9d"
+  tag: "prod-39-b9bdd0f"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds


### PR DESCRIPTION
## 변경 사항
- 이미지 태그: `prod-39-b9bdd0f`
- 레지스트리: `harbor.go-ti.shop/prod/`
- 업데이트된 서비스: `{"include":[{"service":"user"}]}`

## 트리거
- 브랜치: `deploy/prod`
- 커밋: b9bdd0f40897e3e05dbc9eba7d927a5d0d471316
- 워크플로우: [#39](https://github.com/Team-Ikujo/Goti-server/actions/runs/23836548387)