### PR TITLE
[CHORE] prod 이미지 태그 업데이트: prod-40-b67ddba

### DIFF
--- a/environments/prod/goti-payment/values.yaml
+++ b/environments/prod/goti-payment/values.yaml
@@ -1,7 +1,7 @@
 nameOverride: goti-payment
 image:
   repository: "harbor.go-ti.shop/prod/goti-payment"
-  tag: "prod-36-57bdd30"
+  tag: "prod-40-b67ddba"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-resale/values.yaml
+++ b/environments/prod/goti-resale/values.yaml
@@ -1,7 +1,7 @@
 nameOverride: goti-resale
 image:
   repository: "harbor.go-ti.shop/prod/goti-resale"
-  tag: "prod-35-57bdd30"
+  tag: "prod-40-b67ddba"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-stadium/values.yaml
+++ b/environments/prod/goti-stadium/values.yaml
@@ -1,7 +1,7 @@
 nameOverride: goti-stadium
 image:
   repository: "harbor.go-ti.shop/prod/goti-stadium"
-  tag: "prod-34-57bdd30"
+  tag: "prod-40-b67ddba"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-ticketing/values.yaml
+++ b/environments/prod/goti-ticketing/values.yaml
@@ -1,7 +1,7 @@
 nameOverride: goti-ticketing
 image:
   repository: "harbor.go-ti.shop/prod/goti-ticketing"
-  tag: "prod-37-57bdd30"
+  tag: "prod-40-b67ddba"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-user/values.yaml
+++ b/environments/prod/goti-user/values.yaml
@@ -1,7 +1,7 @@
 nameOverride: goti-user
 image:
   repository: "harbor.go-ti.shop/prod/goti-user"
-  tag: "prod-39-b9bdd0f"
+  tag: "prod-40-b67ddba"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds


### PR DESCRIPTION
## 변경 사항
- 이미지 태그: `prod-40-b67ddba`
- 레지스트리: `harbor.go-ti.shop/prod/`
- 업데이트된 서비스: `{"include":[{"service":"user"},{"service":"stadium"},{"service":"ticketing"},{"service":"payment"},{"service":"resale"}]}`

## 트리거
- 브랜치: `deploy/prod`
- 커밋: b67ddbaed7d922bbf86c016e97fa36037edd6608
- 워크플로우: [#40](https://github.com/Team-Ikujo/Goti-server/actions/runs/23840373329)