### PR TITLE
[CHORE] prod 이미지 태그 업데이트: prod-41-89c92d5

### DIFF
--- a/environments/prod/goti-user/values.yaml
+++ b/environments/prod/goti-user/values.yaml
@@ -1,7 +1,7 @@
 nameOverride: goti-user
 image:
   repository: "harbor.go-ti.shop/prod/goti-user"
-  tag: "prod-40-b67ddba"
+  tag: "prod-41-89c92d5"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds


### PR DESCRIPTION
## 변경 사항
- 이미지 태그: `prod-41-89c92d5`
- 레지스트리: `harbor.go-ti.shop/prod/`
- 업데이트된 서비스: `{"include":[{"service":"user"}]}`

## 트리거
- 브랜치: `deploy/prod`
- 커밋: 89c92d5465654a60c0b1a5f5729ddf02b32c9f9c
- 워크플로우: [#41](https://github.com/Team-Ikujo/Goti-server/actions/runs/23855635498)