### PR TITLE
[CHORE] prod 이미지 태그 업데이트: prod-42-1dec9ce

### DIFF
--- a/environments/prod/goti-payment/values.yaml
+++ b/environments/prod/goti-payment/values.yaml
@@ -1,7 +1,7 @@
 nameOverride: goti-payment
 image:
   repository: "harbor.go-ti.shop/prod/goti-payment"
-  tag: "prod-40-b67ddba"
+  tag: "prod-42-1dec9ce"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-resale/values.yaml
+++ b/environments/prod/goti-resale/values.yaml
@@ -1,7 +1,7 @@
 nameOverride: goti-resale
 image:
   repository: "harbor.go-ti.shop/prod/goti-resale"
-  tag: "prod-40-b67ddba"
+  tag: "prod-42-1dec9ce"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-stadium/values.yaml
+++ b/environments/prod/goti-stadium/values.yaml
@@ -1,7 +1,7 @@
 nameOverride: goti-stadium
 image:
   repository: "harbor.go-ti.shop/prod/goti-stadium"
-  tag: "prod-40-b67ddba"
+  tag: "prod-42-1dec9ce"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-ticketing/values.yaml
+++ b/environments/prod/goti-ticketing/values.yaml
@@ -1,7 +1,7 @@
 nameOverride: goti-ticketing
 image:
   repository: "harbor.go-ti.shop/prod/goti-ticketing"
-  tag: "prod-40-b67ddba"
+  tag: "prod-42-1dec9ce"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-user/values.yaml
+++ b/environments/prod/goti-user/values.yaml
@@ -1,7 +1,7 @@
 nameOverride: goti-user
 image:
   repository: "harbor.go-ti.shop/prod/goti-user"
-  tag: "prod-40-b67ddba"
+  tag: "prod-42-1dec9ce"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds


### PR DESCRIPTION
## 변경 사항
- 이미지 태그: `prod-42-1dec9ce`
- 레지스트리: `harbor.go-ti.shop/prod/`
- 업데이트된 서비스: `{"include":[{"service":"user"},{"service":"stadium"},{"service":"ticketing"},{"service":"payment"},{"service":"resale"}]}`

## 트리거
- 브랜치: `deploy/prod`
- 커밋: 1dec9ce4db8ff824f59a4e46c56d6c043385a706
- 워크플로우: [#42](https://github.com/Team-Ikujo/Goti-server/actions/runs/23855961417)