### PR TITLE
[FIX] ApplicationSet ignoreDifferences /spec/replicas 제거 — replicaCount 변경 반영 차단 해소

### DIFF
--- a/environments/prod/goti-payment-junsang/values.yaml
+++ b/environments/prod/goti-payment-junsang/values.yaml
@@ -33,7 +33,7 @@ resources:
     memory: 768Mi
 
 gateway:
-  enabled: true
+  enabled: false
   hosts:
     - "go-ti.shop"
     - "api.go-ti.shop"

--- a/environments/prod/goti-payment-sungjeon/values.yaml
+++ b/environments/prod/goti-payment-sungjeon/values.yaml
@@ -33,7 +33,7 @@ resources:
     memory: 768Mi
 
 gateway:
-  enabled: true
+  enabled: false
   hosts:
     - "go-ti.shop"
     - "api.go-ti.shop"

--- a/environments/prod/goti-payment-suyeon/values.yaml
+++ b/environments/prod/goti-payment-suyeon/values.yaml
@@ -33,7 +33,7 @@ resources:
     memory: 768Mi
 
 gateway:
-  enabled: true
+  enabled: false
   hosts:
     - "go-ti.shop"
     - "api.go-ti.shop"

--- a/environments/prod/goti-queue-junsang/values.yaml
+++ b/environments/prod/goti-queue-junsang/values.yaml
@@ -33,7 +33,7 @@ resources:
     memory: 1Gi
 
 gateway:
-  enabled: true
+  enabled: false
   hosts:
     - "go-ti.shop"
     - "api.go-ti.shop"

--- a/environments/prod/goti-queue-sungjeon/values.yaml
+++ b/environments/prod/goti-queue-sungjeon/values.yaml
@@ -33,7 +33,7 @@ resources:
     memory: 1Gi
 
 gateway:
-  enabled: true
+  enabled: false
   hosts:
     - "go-ti.shop"
     - "api.go-ti.shop"

--- a/environments/prod/goti-queue-suyeon/values.yaml
+++ b/environments/prod/goti-queue-suyeon/values.yaml
@@ -33,7 +33,7 @@ resources:
     memory: 1Gi
 
 gateway:
-  enabled: true
+  enabled: false
   hosts:
     - "go-ti.shop"
     - "api.go-ti.shop"

--- a/environments/prod/goti-ticketing-junsang/values.yaml
+++ b/environments/prod/goti-ticketing-junsang/values.yaml
@@ -34,7 +34,7 @@ resources:
     memory: 1Gi
 
 gateway:
-  enabled: true
+  enabled: false
   hosts:
     - "go-ti.shop"
     - "api.go-ti.shop"

--- a/environments/prod/goti-ticketing-sungjeon/values.yaml
+++ b/environments/prod/goti-ticketing-sungjeon/values.yaml
@@ -34,7 +34,7 @@ resources:
     memory: 1Gi
 
 gateway:
-  enabled: true
+  enabled: false
   hosts:
     - "go-ti.shop"
     - "api.go-ti.shop"

--- a/environments/prod/goti-ticketing-suyeon/values.yaml
+++ b/environments/prod/goti-ticketing-suyeon/values.yaml
@@ -34,7 +34,7 @@ resources:
     memory: 1Gi
 
 gateway:
-  enabled: true
+  enabled: false
   hosts:
     - "go-ti.shop"
     - "api.go-ti.shop"

--- a/gitops/dev/applicationsets/goti-msa-appset.yaml
+++ b/gitops/dev/applicationsets/goti-msa-appset.yaml
@@ -77,8 +77,5 @@ spec:
         syncOptions:
           - CreateNamespace=true
           - ServerSideApply=true
-      ignoreDifferences:
-        - group: apps
-          kind: Deployment
-          jsonPointers:
-            - /spec/replicas
+          - PruneLast=true
+          - PrunePropagationPolicy=foreground

--- a/gitops/prod/applicationsets/goti-infra-appset.yaml
+++ b/gitops/prod/applicationsets/goti-infra-appset.yaml
@@ -40,8 +40,5 @@ spec:
         syncOptions:
           - CreateNamespace=true
           - ServerSideApply=true
-      ignoreDifferences:
-        - group: apps
-          kind: Deployment
-          jsonPointers:
-            - /spec/replicas
+          - PruneLast=true
+          - PrunePropagationPolicy=foreground

--- a/gitops/prod/applicationsets/goti-msa-appset.yaml
+++ b/gitops/prod/applicationsets/goti-msa-appset.yaml
@@ -85,8 +85,5 @@ spec:
         syncOptions:
           - CreateNamespace=true
           - ServerSideApply=true
-      ignoreDifferences:
-        - group: apps
-          kind: Deployment
-          jsonPointers:
-            - /spec/replicas
+          - PruneLast=true
+          - PrunePropagationPolicy=foreground


### PR DESCRIPTION
## 관련 이슈
- N/A (운영 중 발견된 설정 문제)

## 개요
ApplicationSet의 `ignoreDifferences: /spec/replicas` 설정이 `replicaCount` 변경을 ArgoCD sync에서 완전히 차단하고 있어, POC 서비스 9개의 `replicaCount: 0` 설정이 몇 시간째 반영되지 않는 문제 해결.

## 작업 내용
- [x] prod/dev/infra appset 3개에서 `ignoreDifferences /spec/replicas` 삭제
  - Helm 템플릿(`_deployment.tpl`)의 `{{- if not .Values.autoscaling.enabled }}` 조건분기가 이미 HPA 충돌을 방지하므로 ignoreDifferences 불필요
- [x] `PruneLast=true` + `PrunePropagationPolicy=foreground` 추가 (안전한 prune 순서 보장)
- [x] POC 서비스 9개 `gateway.enabled: false` (Pod 0개인데 VirtualService 남아있으면 503 발생)

## 근본 원인 분석
1. `ignoreDifferences /spec/replicas` → ArgoCD가 replicas 변경을 "차이 없음"으로 판단
2. `ServerSideApply=true` → replicas 필드 소유권이 kube-controller-manager에 있어 ArgoCD가 덮어쓰기 불가
3. `selfHeal: true` → 차이를 감지 못하므로 auto-sync도 트리거 안 됨

## 테스트
- [ ] ArgoCD sync 확인 — POC 서비스 replicas 0 반영 여부
- [ ] HPA 활성화 서비스(ticketing) autoscaling 정상 동작 확인
- [ ] VirtualService 정리 확인 (POC 서비스 503 제거)