### PR TITLE
[CHORE] prod 이미지 태그 업데이트: prod-46-e652be4

### DIFF
--- a/environments/prod/goti-user/values.yaml
+++ b/environments/prod/goti-user/values.yaml
@@ -2,7 +2,7 @@ nameOverride: goti-user
 replicaCount: 2
 image:
   repository: "harbor.go-ti.shop/prod/goti-user"
-  tag: "prod-43-6f4c644"
+  tag: "prod-46-e652be4"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds
@@ -115,7 +115,6 @@ istioPolicy:
       # - "팀원B_IP/32"
       # - "팀원C_IP/32"
       # - "팀원D_IP/32"
-
   jwtAuthorizationPolicy:
     enabled: true
     excludePaths:


### PR DESCRIPTION
## 변경 사항
- 이미지 태그: `prod-46-e652be4`
- 레지스트리: `harbor.go-ti.shop/prod/`
- 업데이트된 서비스: `{"include":[{"service":"user"}]}`

## 트리거
- 브랜치: `deploy/prod`
- 커밋: e652be458ee094466704c79a9f528ebda21461fb
- 워크플로우: [#46](https://github.com/Team-Ikujo/Goti-server/actions/runs/23929791700)