### PR TITLE
[REFACTOR] values 계층화 — Multi-Cloud values layering 패턴 제안

### DIFF
--- a/environments/prod/goti-payment/values-aws.yaml
+++ b/environments/prod/goti-payment/values-aws.yaml
@@ -1,0 +1,26 @@
+replicaCount: 2
+image:
+  repository: "707925622666.dkr.ecr.ap-northeast-2.amazonaws.com/prod/goti-payment"
+  tag: "prod-43-6f4c644"
+  pullPolicy: IfNotPresent
+imagePullSecrets:
+  - name: ecr-creds
+externalSecret:
+  enabled: true
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: aws-ssm
+    kind: ClusterSecretStore
+  remoteRef:
+    path: /prod/server
+    overridePath: /prod/payment
+istioPolicy:
+  sidecar:
+    enabled: true
+    egress:
+      - hosts:
+          - "istio-system/*"
+          - "./*"
+          - "monitoring/*"
+          - "kafka/*"
+          - "~/*.amazonaws.com"

--- a/environments/prod/goti-payment/values-gcp.yaml
+++ b/environments/prod/goti-payment/values-gcp.yaml
@@ -1,0 +1,27 @@
+replicaCount: 2
+image:
+  repository: "asia-northeast3-docker.pkg.dev/goti-gcp/goti-prod-registry/goti-payment"
+  tag: "prod-43-6f4c644"
+  pullPolicy: IfNotPresent
+# GCP: Workload Identity handles Artifact Registry auth
+imagePullSecrets: []
+externalSecret:
+  enabled: true
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: gcp-store
+    kind: ClusterSecretStore
+  remoteRef:
+    nameRegexp: "^goti-prod-server-"
+    nameRewriteSource: "^goti-prod-server-(.*)$"
+    overrideNameRegexp: "^goti-prod-payment-"
+    overrideNameRewriteSource: "^goti-prod-payment-(.*)$"
+istioPolicy:
+  sidecar:
+    enabled: true
+    egress:
+      - hosts:
+          - "istio-system/*"
+          - "./*"
+          - "monitoring/*"
+          - "kafka/*"

--- a/environments/prod/goti-payment/values.yaml
+++ b/environments/prod/goti-payment/values.yaml
@@ -1,11 +1,4 @@
 nameOverride: goti-payment
-replicaCount: 2
-image:
-  repository: "707925622666.dkr.ecr.ap-northeast-2.amazonaws.com/prod/goti-payment"
-  tag: "prod-43-6f4c644"
-  pullPolicy: IfNotPresent
-imagePullSecrets:
-  - name: ecr-creds
 podAnnotations:
   instrumentation.opentelemetry.io/inject-java: "goti/goti-java"
 resources:
@@ -88,18 +81,7 @@ env:
 envFrom:
   - secretRef:
       name: goti-payment-prod-secrets
-externalSecret:
-  enabled: true
-  refreshInterval: "1h"
-  secretStoreRef:
-    name: aws-ssm
-    kind: ClusterSecretStore
-  remoteRef:
-    path: /prod/server
-    overridePath: /prod/payment
-# --- Istio 보안/네트워크 정책 ---
 istioPolicy:
-  # resale → payment (양도 결제/환불)
   authorizationPolicy:
     enabled: true
     allowFrom:
@@ -126,12 +108,3 @@ istioPolicy:
       - "/v3/api-docs/*"
   destinationRule:
     enabled: true
-  sidecar:
-    enabled: true
-    egress:
-      - hosts:
-          - "istio-system/*"
-          - "./*"
-          - "monitoring/*"
-          - "kafka/*"
-          - "~/*.amazonaws.com"

--- a/environments/prod/goti-resale/values-aws.yaml
+++ b/environments/prod/goti-resale/values-aws.yaml
@@ -1,0 +1,26 @@
+replicaCount: 2
+image:
+  repository: "707925622666.dkr.ecr.ap-northeast-2.amazonaws.com/prod/goti-resale"
+  tag: "prod-43-6f4c644"
+  pullPolicy: IfNotPresent
+imagePullSecrets:
+  - name: ecr-creds
+externalSecret:
+  enabled: true
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: aws-ssm
+    kind: ClusterSecretStore
+  remoteRef:
+    path: /prod/server
+    overridePath: /prod/resale
+istioPolicy:
+  sidecar:
+    enabled: true
+    egress:
+      - hosts:
+          - "istio-system/*"
+          - "./*"
+          - "monitoring/*"
+          - "kafka/*"
+          - "~/*.amazonaws.com"

--- a/environments/prod/goti-resale/values-gcp.yaml
+++ b/environments/prod/goti-resale/values-gcp.yaml
@@ -1,0 +1,27 @@
+replicaCount: 2
+image:
+  repository: "asia-northeast3-docker.pkg.dev/goti-gcp/goti-prod-registry/goti-resale"
+  tag: "prod-43-6f4c644"
+  pullPolicy: IfNotPresent
+# GCP: Workload Identity handles Artifact Registry auth
+imagePullSecrets: []
+externalSecret:
+  enabled: true
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: gcp-store
+    kind: ClusterSecretStore
+  remoteRef:
+    nameRegexp: "^goti-prod-server-"
+    nameRewriteSource: "^goti-prod-server-(.*)$"
+    overrideNameRegexp: "^goti-prod-resale-"
+    overrideNameRewriteSource: "^goti-prod-resale-(.*)$"
+istioPolicy:
+  sidecar:
+    enabled: true
+    egress:
+      - hosts:
+          - "istio-system/*"
+          - "./*"
+          - "monitoring/*"
+          - "kafka/*"

--- a/environments/prod/goti-resale/values.yaml
+++ b/environments/prod/goti-resale/values.yaml
@@ -1,11 +1,4 @@
 nameOverride: goti-resale
-replicaCount: 2
-image:
-  repository: "707925622666.dkr.ecr.ap-northeast-2.amazonaws.com/prod/goti-resale"
-  tag: "prod-43-6f4c644"
-  pullPolicy: IfNotPresent
-imagePullSecrets:
-  - name: ecr-creds
 podAnnotations:
   instrumentation.opentelemetry.io/inject-java: "goti/goti-java"
 resources:
@@ -86,18 +79,7 @@ env:
 envFrom:
   - secretRef:
       name: goti-resale-prod-secrets
-externalSecret:
-  enabled: true
-  refreshInterval: "1h"
-  secretStoreRef:
-    name: aws-ssm
-    kind: ClusterSecretStore
-  remoteRef:
-    path: /prod/server
-    overridePath: /prod/resale
-# --- Istio 보안/네트워크 정책 ---
 istioPolicy:
-  # payment → resale (양도 완료/거래 조회)
   authorizationPolicy:
     enabled: true
     allowFrom:
@@ -126,12 +108,3 @@ istioPolicy:
       - "/v3/api-docs/*"
   destinationRule:
     enabled: true
-  sidecar:
-    enabled: true
-    egress:
-      - hosts:
-          - "istio-system/*"
-          - "./*"
-          - "monitoring/*"
-          - "kafka/*"
-          - "~/*.amazonaws.com"

--- a/environments/prod/goti-stadium/values-aws.yaml
+++ b/environments/prod/goti-stadium/values-aws.yaml
@@ -1,0 +1,26 @@
+replicaCount: 2
+image:
+  repository: "707925622666.dkr.ecr.ap-northeast-2.amazonaws.com/prod/goti-stadium"
+  tag: "prod-43-6f4c644"
+  pullPolicy: IfNotPresent
+imagePullSecrets:
+  - name: ecr-creds
+externalSecret:
+  enabled: true
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: aws-ssm
+    kind: ClusterSecretStore
+  remoteRef:
+    path: /prod/server
+    overridePath: /prod/stadium
+istioPolicy:
+  sidecar:
+    enabled: true
+    egress:
+      - hosts:
+          - "istio-system/*"
+          - "./*"
+          - "monitoring/*"
+          - "kafka/*"
+          - "~/*.amazonaws.com"

--- a/environments/prod/goti-stadium/values-gcp.yaml
+++ b/environments/prod/goti-stadium/values-gcp.yaml
@@ -1,0 +1,27 @@
+replicaCount: 2
+image:
+  repository: "asia-northeast3-docker.pkg.dev/goti-gcp/goti-prod-registry/goti-stadium"
+  tag: "prod-43-6f4c644"
+  pullPolicy: IfNotPresent
+# GCP: Workload Identity handles Artifact Registry auth
+imagePullSecrets: []
+externalSecret:
+  enabled: true
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: gcp-store
+    kind: ClusterSecretStore
+  remoteRef:
+    nameRegexp: "^goti-prod-server-"
+    nameRewriteSource: "^goti-prod-server-(.*)$"
+    overrideNameRegexp: "^goti-prod-stadium-"
+    overrideNameRewriteSource: "^goti-prod-stadium-(.*)$"
+istioPolicy:
+  sidecar:
+    enabled: true
+    egress:
+      - hosts:
+          - "istio-system/*"
+          - "./*"
+          - "monitoring/*"
+          - "kafka/*"

--- a/environments/prod/goti-stadium/values.yaml
+++ b/environments/prod/goti-stadium/values.yaml
@@ -1,11 +1,4 @@
 nameOverride: goti-stadium
-replicaCount: 2
-image:
-  repository: "707925622666.dkr.ecr.ap-northeast-2.amazonaws.com/prod/goti-stadium"
-  tag: "prod-43-6f4c644"
-  pullPolicy: IfNotPresent
-imagePullSecrets:
-  - name: ecr-creds
 podAnnotations:
   instrumentation.opentelemetry.io/inject-java: "goti/goti-java"
 resources:
@@ -88,18 +81,7 @@ env:
 envFrom:
   - secretRef:
       name: goti-stadium-prod-secrets
-externalSecret:
-  enabled: true
-  refreshInterval: "1h"
-  secretStoreRef:
-    name: aws-ssm
-    kind: ClusterSecretStore
-  remoteRef:
-    path: /prod/server
-    overridePath: /prod/stadium
-# --- Istio 보안/네트워크 정책 ---
 istioPolicy:
-  # ticketing → stadium (경기장/팀 조회)
   authorizationPolicy:
     enabled: true
     allowFrom:
@@ -130,12 +112,3 @@ istioPolicy:
       - "/v3/api-docs/*"
   destinationRule:
     enabled: true
-  sidecar:
-    enabled: true
-    egress:
-      - hosts:
-          - "istio-system/*"
-          - "./*"
-          - "monitoring/*"
-          - "kafka/*"
-          - "~/*.amazonaws.com"

--- a/environments/prod/goti-ticketing/values-aws.yaml
+++ b/environments/prod/goti-ticketing/values-aws.yaml
@@ -1,0 +1,26 @@
+replicaCount: 2
+image:
+  repository: "707925622666.dkr.ecr.ap-northeast-2.amazonaws.com/prod/goti-ticketing"
+  tag: "prod-43-6f4c644"
+  pullPolicy: IfNotPresent
+imagePullSecrets:
+  - name: ecr-creds
+externalSecret:
+  enabled: true
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: aws-ssm
+    kind: ClusterSecretStore
+  remoteRef:
+    path: /prod/server
+    overridePath: /prod/ticketing
+istioPolicy:
+  sidecar:
+    enabled: true
+    egress:
+      - hosts:
+          - "istio-system/*"
+          - "./*"
+          - "monitoring/*"
+          - "kafka/*"
+          - "~/*.amazonaws.com"

--- a/environments/prod/goti-ticketing/values-gcp.yaml
+++ b/environments/prod/goti-ticketing/values-gcp.yaml
@@ -1,0 +1,27 @@
+replicaCount: 2
+image:
+  repository: "asia-northeast3-docker.pkg.dev/goti-gcp/goti-prod-registry/goti-ticketing"
+  tag: "prod-43-6f4c644"
+  pullPolicy: IfNotPresent
+# GCP: Workload Identity handles Artifact Registry auth
+imagePullSecrets: []
+externalSecret:
+  enabled: true
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: gcp-store
+    kind: ClusterSecretStore
+  remoteRef:
+    nameRegexp: "^goti-prod-server-"
+    nameRewriteSource: "^goti-prod-server-(.*)$"
+    overrideNameRegexp: "^goti-prod-ticketing-"
+    overrideNameRewriteSource: "^goti-prod-ticketing-(.*)$"
+istioPolicy:
+  sidecar:
+    enabled: true
+    egress:
+      - hosts:
+          - "istio-system/*"
+          - "./*"
+          - "monitoring/*"
+          - "kafka/*"

--- a/environments/prod/goti-ticketing/values.yaml
+++ b/environments/prod/goti-ticketing/values.yaml
@@ -1,11 +1,4 @@
 nameOverride: goti-ticketing
-replicaCount: 2
-image:
-  repository: "707925622666.dkr.ecr.ap-northeast-2.amazonaws.com/prod/goti-ticketing"
-  tag: "prod-43-6f4c644"
-  pullPolicy: IfNotPresent
-imagePullSecrets:
-  - name: ecr-creds
 podAnnotations:
   instrumentation.opentelemetry.io/inject-java: "goti/goti-java"
 resources:
@@ -116,18 +109,7 @@ env:
 envFrom:
   - secretRef:
       name: goti-ticketing-prod-secrets
-externalSecret:
-  enabled: true
-  refreshInterval: "1h"
-  secretStoreRef:
-    name: aws-ssm
-    kind: ClusterSecretStore
-  remoteRef:
-    path: /prod/server
-    overridePath: /prod/ticketing
-# --- Istio 보안/네트워크 정책 ---
 istioPolicy:
-  # payment → ticketing (결제 확인 콜백)
   authorizationPolicy:
     enabled: true
     allowFrom:
@@ -160,12 +142,3 @@ istioPolicy:
       - "/v3/api-docs/*"
   destinationRule:
     enabled: true
-  sidecar:
-    enabled: true
-    egress:
-      - hosts:
-          - "istio-system/*"
-          - "./*"
-          - "monitoring/*"
-          - "kafka/*"
-          - "~/*.amazonaws.com"

--- a/environments/prod/goti-user/values-aws.yaml
+++ b/environments/prod/goti-user/values-aws.yaml
@@ -1,0 +1,30 @@
+replicaCount: 4
+image:
+  repository: "707925622666.dkr.ecr.ap-northeast-2.amazonaws.com/prod/goti-user"
+  tag: "prod-46-e652be4"
+  pullPolicy: IfNotPresent
+imagePullSecrets:
+  - name: ecr-creds
+externalSecret:
+  enabled: true
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: aws-ssm
+    kind: ClusterSecretStore
+  remoteRef:
+    path: /prod/server
+    overridePath: /prod/user
+istioPolicy:
+  sidecar:
+    enabled: true
+    egress:
+      - hosts:
+          - "istio-system/*"
+          - "./*"
+          - "monitoring/*"
+          - "kafka/*"
+          - "~/*.googleapis.com"
+          - "~/*.naver.com"
+          - "~/*.kakao.com"
+          - "~/*.nurigo.com"
+          - "~/*.amazonaws.com"

--- a/environments/prod/goti-user/values-gcp.yaml
+++ b/environments/prod/goti-user/values-gcp.yaml
@@ -1,0 +1,31 @@
+replicaCount: 2
+image:
+  repository: "asia-northeast3-docker.pkg.dev/goti-gcp/goti-prod-registry/goti-user"
+  tag: "prod-46-e652be4"
+  pullPolicy: IfNotPresent
+# GCP: Workload Identity handles Artifact Registry auth
+imagePullSecrets: []
+externalSecret:
+  enabled: true
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: gcp-store
+    kind: ClusterSecretStore
+  remoteRef:
+    nameRegexp: "^goti-prod-server-"
+    nameRewriteSource: "^goti-prod-server-(.*)$"
+    overrideNameRegexp: "^goti-prod-user-"
+    overrideNameRewriteSource: "^goti-prod-user-(.*)$"
+istioPolicy:
+  sidecar:
+    enabled: true
+    egress:
+      - hosts:
+          - "istio-system/*"
+          - "./*"
+          - "monitoring/*"
+          - "kafka/*"
+          - "~/*.googleapis.com"
+          - "~/*.naver.com"
+          - "~/*.kakao.com"
+          - "~/*.nurigo.com"

--- a/environments/prod/goti-user/values.yaml
+++ b/environments/prod/goti-user/values.yaml
@@ -1,11 +1,4 @@
 nameOverride: goti-user
-replicaCount: 4
-image:
-  repository: "707925622666.dkr.ecr.ap-northeast-2.amazonaws.com/prod/goti-user"
-  tag: "prod-46-e652be4"
-  pullPolicy: IfNotPresent
-imagePullSecrets:
-  - name: ecr-creds
 podAnnotations:
   instrumentation.opentelemetry.io/inject-java: "goti/goti-java"
 resources:
@@ -88,33 +81,17 @@ env:
 envFrom:
   - secretRef:
       name: goti-user-prod-secrets
-externalSecret:
-  enabled: true
-  refreshInterval: "1h"
-  secretStoreRef:
-    name: aws-ssm
-    kind: ClusterSecretStore
-  remoteRef:
-    path: /prod/server
-    overridePath: /prod/user
-# --- Istio 보안/네트워크 정책 ---
 istioPolicy:
-  # user 서비스는 다른 서비스로부터 호출받지 않음 (Gateway 통해서만 접근)
   authorizationPolicy:
     enabled: true
     allowFrom: []
   requestAuthentication:
     enabled: true
     jwks: '{"keys":[{"alg":"RS256","kty":"RSA","kid":"goti-jwt-key-1","e":"AQAB","use":"sig","n":"tXlfiSkDgSujDP6wUyQc57RrUGkTK6x3Fe-W5VhZhBumzDDoRNglcZ3C9AY_iF9GdlZOgcUdKLEVplLuEZGQpHUdA5CwgzQkwNXs242Mgo6QyHGdbDXZXEhe42vl1gcdgnahY7UQLcWGUr6--Fuc5G2LMW6rlTGwagT05SKzGRbTRef3gt8D8_hdsp654vnrdW2ReRQltnffHR9XL8buuKIduGW5vfiCVtNRFsaiT_o0SA86a5gK9qmXUGJIDPLc9onZ3v6G8gtFOES4MmR0elT2VTf22tM0GeIhnDOrjVRBa5I-M6c4OTMDrmeHKhUJygj-rjfNT5effpQzUz0_Xw"}]}'
-  # 테스트 API IP 제한: Cloudflare WAF에서 이미 IP 제한 중
-  # Istio remoteIpBlocks는 Cloudflare→ALB 경로에서 X-Forwarded-For 전달 이슈로 비활성화
   testIpAllowlist:
     enabled: false
     allowedIps:
       - "221.152.162.218/32"
-      # - "팀원B_IP/32"
-      # - "팀원C_IP/32"
-      # - "팀원D_IP/32"
   jwtAuthorizationPolicy:
     enabled: true
     excludePaths:
@@ -132,19 +109,3 @@ istioPolicy:
       - "/.well-known/*"
   destinationRule:
     enabled: true
-  sidecar:
-    enabled: true
-    egress:
-      - hosts:
-          - "istio-system/*"
-          - "./*"
-          - "monitoring/*"
-          - "kafka/*"
-          # OAuth 소셜 로그인 (Google, Naver, Kakao)
-          - "~/*.googleapis.com"
-          - "~/*.naver.com"
-          - "~/*.kakao.com"
-          # SMS 발송 (Nurigo/CoolSMS)
-          - "~/*.nurigo.com"
-          # AWS (SSM Parameter Store, STS)
-          - "~/*.amazonaws.com"

--- a/gitops/prod-gcp/applicationsets/goti-msa-appset.yaml
+++ b/gitops/prod-gcp/applicationsets/goti-msa-appset.yaml
@@ -7,21 +7,27 @@ spec:
   generators:
     - list:
         elements:
+          # values 계층화: 공통 values.yaml + GCP 오버라이드 values-gcp.yaml
           - service: user
             namespace: goti
-            valuesFile: environments/prod-gcp/goti-user/values.yaml
+            valuesFile: environments/prod/goti-user/values.yaml
+            cloudValuesFile: environments/prod/goti-user/values-gcp.yaml
           - service: stadium
             namespace: goti
-            valuesFile: environments/prod-gcp/goti-stadium/values.yaml
+            valuesFile: environments/prod/goti-stadium/values.yaml
+            cloudValuesFile: environments/prod/goti-stadium/values-gcp.yaml
           - service: ticketing
             namespace: goti
-            valuesFile: environments/prod-gcp/goti-ticketing/values.yaml
+            valuesFile: environments/prod/goti-ticketing/values.yaml
+            cloudValuesFile: environments/prod/goti-ticketing/values-gcp.yaml
           - service: payment
             namespace: goti
-            valuesFile: environments/prod-gcp/goti-payment/values.yaml
+            valuesFile: environments/prod/goti-payment/values.yaml
+            cloudValuesFile: environments/prod/goti-payment/values-gcp.yaml
           - service: resale
             namespace: goti
-            valuesFile: environments/prod-gcp/goti-resale/values.yaml
+            valuesFile: environments/prod/goti-resale/values.yaml
+            cloudValuesFile: environments/prod/goti-resale/values-gcp.yaml
   template:
     metadata:
       name: "goti-{{service}}-prod-gcp"
@@ -36,6 +42,7 @@ spec:
         helm:
           valueFiles:
             - "../../{{valuesFile}}"
+            - "../../{{cloudValuesFile}}"
       destination:
         server: "https://kubernetes.default.svc"
         namespace: "{{namespace}}"

--- a/gitops/prod/applicationsets/goti-msa-appset.yaml
+++ b/gitops/prod/applicationsets/goti-msa-appset.yaml
@@ -7,49 +7,64 @@ spec:
   generators:
     - list:
         elements:
+          # --- MSA 핵심 서비스 (values 계층화: values.yaml + values-aws.yaml) ---
           - service: user
             namespace: goti
             valuesFile: environments/prod/goti-user/values.yaml
+            cloudValuesFile: environments/prod/goti-user/values-aws.yaml
           - service: stadium
             namespace: goti
             valuesFile: environments/prod/goti-stadium/values.yaml
+            cloudValuesFile: environments/prod/goti-stadium/values-aws.yaml
           - service: ticketing
             namespace: goti
             valuesFile: environments/prod/goti-ticketing/values.yaml
+            cloudValuesFile: environments/prod/goti-ticketing/values-aws.yaml
           - service: payment
             namespace: goti
             valuesFile: environments/prod/goti-payment/values.yaml
+            cloudValuesFile: environments/prod/goti-payment/values-aws.yaml
           - service: resale
             namespace: goti
             valuesFile: environments/prod/goti-resale/values.yaml
-          # --- [POC] Queue 부하테스트용 (수연/준상/성전) ---
+            cloudValuesFile: environments/prod/goti-resale/values-aws.yaml
+          # --- [POC] Queue 부하테스트용 (수연/준상/성전) — 단일 values (AWS only) ---
           - service: queue-suyeon
             namespace: goti
             valuesFile: environments/prod/goti-queue-suyeon/values.yaml
+            cloudValuesFile: environments/prod/goti-queue-suyeon/values.yaml
           - service: queue-junsang
             namespace: goti
             valuesFile: environments/prod/goti-queue-junsang/values.yaml
+            cloudValuesFile: environments/prod/goti-queue-junsang/values.yaml
           - service: queue-sungjeon
             namespace: goti
             valuesFile: environments/prod/goti-queue-sungjeon/values.yaml
+            cloudValuesFile: environments/prod/goti-queue-sungjeon/values.yaml
           - service: ticketing-suyeon
             namespace: goti
             valuesFile: environments/prod/goti-ticketing-suyeon/values.yaml
+            cloudValuesFile: environments/prod/goti-ticketing-suyeon/values.yaml
           - service: ticketing-junsang
             namespace: goti
             valuesFile: environments/prod/goti-ticketing-junsang/values.yaml
+            cloudValuesFile: environments/prod/goti-ticketing-junsang/values.yaml
           - service: ticketing-sungjeon
             namespace: goti
             valuesFile: environments/prod/goti-ticketing-sungjeon/values.yaml
+            cloudValuesFile: environments/prod/goti-ticketing-sungjeon/values.yaml
           - service: payment-suyeon
             namespace: goti
             valuesFile: environments/prod/goti-payment-suyeon/values.yaml
+            cloudValuesFile: environments/prod/goti-payment-suyeon/values.yaml
           - service: payment-junsang
             namespace: goti
             valuesFile: environments/prod/goti-payment-junsang/values.yaml
+            cloudValuesFile: environments/prod/goti-payment-junsang/values.yaml
           - service: payment-sungjeon
             namespace: goti
             valuesFile: environments/prod/goti-payment-sungjeon/values.yaml
+            cloudValuesFile: environments/prod/goti-payment-sungjeon/values.yaml
   template:
     metadata:
       name: "goti-{{service}}-prod"
@@ -66,6 +81,7 @@ spec:
         helm:
           valueFiles:
             - "../../{{valuesFile}}"
+            - "../../{{cloudValuesFile}}"
       destination:
         server: "https://kubernetes.default.svc"
         namespace: "{{namespace}}"


### PR DESCRIPTION
## 관련 이슈
- Multi-Cloud(AWS+GCP) K8s manifest 관리 방식 개선

## 개요
현재 디렉토리 분기 방식(`environments/prod/` vs `environments/prod-gcp/`)을 **values 파일 계층화** 방식으로 리팩토링하는 제안입니다.

**Before (현재)**: 서비스별 전체 values를 클라우드별 디렉토리에 복사
```
environments/prod/goti-user/values.yaml         ← AWS 전용 (전체 설정)
environments/prod-gcp/goti-user/values.yaml     ← GCP 전용 (전체 설정, 복사본)
```

**After (제안)**: 공통 설정 1곳 + 클라우드 차이만 오버라이드
```
environments/prod/goti-user/values.yaml         ← 공통 (gateway, probes, env, istioPolicy)
environments/prod/goti-user/values-aws.yaml     ← AWS만 (ECR, aws-ssm, amazonaws egress)
environments/prod/goti-user/values-gcp.yaml     ← GCP만 (AR, gcp-store, nameRegexp)
```

## 작업 내용
- [x] 5개 MSA 서비스 values 3분할 (user, ticketing, payment, resale, stadium)
- [x] AWS ApplicationSet: `valueFiles` 2개 참조 (`values.yaml` + `values-aws.yaml`)
- [x] GCP ApplicationSet: `environments/prod-gcp/` → `environments/prod/` 통합 참조

### 클라우드별 오버라이드 항목
| 항목 | values-aws.yaml | values-gcp.yaml |
|------|----------------|-----------------|
| image.repository | ECR / Harbor | Artifact Registry |
| imagePullSecrets | ecr-creds / harbor-creds | [] (Workload Identity) |
| externalSecret | aws-ssm, path 기반 | gcp-store, nameRegexp 기반 |
| sidecar egress | `~/*.amazonaws.com` 포함 | amazonaws.com 제외 |
| replicaCount | 서비스별 (user=4) | 2 (공통) |

### 장점
- **공통 설정 1곳 관리**: gateway, probes, env, Istio 정책 변경 시 한 번만 수정
- **불완전 복사 방지**: GCP values에 누락된 설정(gateway, allowFrom 등)이 공통에서 자동 상속
- **클라우드 추가 용이**: `values-azure.yaml` 하나만 추가

### 단점
- **Helm array 교체**: sidecar egress 같은 배열은 클라우드 파일에서 전체 재정의 필요
- **파일 수 증가**: 서비스당 1 → 3 파일

## 테스트
- [ ] `helm template` 렌더링 검증 (values.yaml + values-aws.yaml 조합)
- [ ] `helm template` 렌더링 검증 (values.yaml + values-gcp.yaml 조합)
- [ ] ArgoCD sync dry-run (AWS)
- [ ] ArgoCD sync dry-run (GCP)

## 팀 논의 포인트
이 PR은 **현재 디렉토리 방식(A)** vs **values 계층화 방식(B)** 비교를 위한 제안입니다.
두 방식 모두 동작 가능하며, 팀 선호에 따라 결정하면 됩니다.