### PR TITLE
[FIX] Falco nodeSelector 복구 + Kyverno 3.7.x 업그레이드

### DIFF
--- a/infrastructure/prod/falco/values.yaml
+++ b/infrastructure/prod/falco/values.yaml
@@ -6,6 +6,9 @@
 #   - 대응: memory limit 1Gi로 상향 + OOMKill 시 자동 재시작으로 운영
 #   - 0.44.0 출시 시 chart 업그레이드 필요
 
+# nodeSelector 초기화 — kubectl 직접 수정으로 falco-disabled=true가 설정되어 있었음
+nodeSelector: {}
+
 driver:
   kind: modern_ebpf
 

--- a/infrastructure/prod/kyverno/application.yaml
+++ b/infrastructure/prod/kyverno/application.yaml
@@ -10,7 +10,7 @@ spec:
   sources:
     - repoURL: https://kyverno.github.io/kyverno/
       chart: kyverno
-      targetRevision: 3.3.*
+      targetRevision: 3.7.*
       helm:
         valueFiles:
           - $values/infrastructure/prod/kyverno/values.yaml

--- a/infrastructure/prod/kyverno/values.yaml
+++ b/infrastructure/prod/kyverno/values.yaml
@@ -45,6 +45,7 @@ reportsController:
 features:
   policyExceptions:
     enabled: true
+    namespace: "*"
 
 config:
   excludeGroups:


### PR DESCRIPTION
## 관련 이슈
- 없음

## 개요
kubectl 직접 수정으로 비활성화된 Falco DaemonSet nodeSelector를 Helm values로 복구하고,
Kyverno chart를 3.7.x로 업그레이드하여 policyExceptions.namespace 필수 설정을 추가.

## 작업 내용
- [x] Falco values.yaml에 nodeSelector 설정 추가 (kubectl drift 해소)
- [x] Kyverno chart 3.7.x 업그레이드 (application.yaml targetRevision 변경)
- [x] Kyverno policyExceptions.namespace 설정 추가 (3.7.x 필수 항목)

## 테스트
- [ ] `helm lint` 통과
- [ ] `helm template` 렌더링 검증
- [ ] Kind 로컬 클러스터 배포 검증
- [ ] ArgoCD sync 확인 (해당 시)