### PR TITLE
[CHORE] prod 이미지 태그 업데이트: prod-48-e652be4

### DIFF
--- a/environments/prod/goti-stadium/values.yaml
+++ b/environments/prod/goti-stadium/values.yaml
@@ -114,3 +114,8 @@ istioPolicy:
       - "/v3/api-docs/*"
   destinationRule:
     enabled: true
+image:
+  repository: harbor.go-ti.shop/prod/goti-stadium
+  tag: prod-48-e652be4
+imagePullSecrets:
+  - name: harbor-creds


### PR DESCRIPTION
## 변경 사항
- 이미지 태그: `prod-48-e652be4`
- 레지스트리: `harbor.go-ti.shop/prod/`
- 업데이트된 서비스: `{"include":[{"service":"stadium"}]}`

## 트리거
- 브랜치: `deploy/prod`
- 커밋: e652be458ee094466704c79a9f528ebda21461fb
- 워크플로우: [#48](https://github.com/Team-Ikujo/Goti-server/actions/runs/24017651960)