### PR TITLE
[CHORE] guardrail prod 이미지 태��� 업데이트: prod-1-faa65ea

### DIFF
--- a/environments/prod/goti-guardrail/values-aws.yaml
+++ b/environments/prod/goti-guardrail/values-aws.yaml
@@ -2,7 +2,7 @@
 replicaCount: 1
 image:
   repository: "harbor.go-ti.shop/prod/goti-guardrail"
-  tag: "init-0000000"
+  tag: "prod-1-faa65ea"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds


### PR DESCRIPTION
## 변경 사항
- 이미지 태그: `prod-1-faa65ea`
- 레지스트리: `harbor.go-ti.shop/prod/goti-guardrail`

## 트리거
- 브랜치: `deploy/prod`
- 커밋: faa65ea24811f0d9c14de90904a57612d42d58b4
- 워크플로우: [#1](https://github.com/Team-Ikujo/Goti-guardrail-server/actions/runs/24021324500)