### PR TITLE
[CHORE] prod 이미지 태그 업데이트: prod-49-4bbdc87

### DIFF
--- a/environments/prod/goti-payment/values.yaml
+++ b/environments/prod/goti-payment/values.yaml
@@ -55,8 +55,8 @@ autoscaling:
       - type: cron
         metadata:
           timezone: "Asia/Seoul"
-          start: "30 10 * * *"  # 10:30 KST — 티켓 오픈 30분 전 사전 준비
-          end: "0 13 * * *"     # 13:00 KST
+          start: "30 10 * * *" # 10:30 KST — 티켓 오픈 30분 전 사전 준비
+          end: "0 13 * * *" # 13:00 KST
           desiredReplicas: "4"
       - type: prometheus
         metadata:
@@ -131,3 +131,8 @@ istioPolicy:
       - "/v3/api-docs/*"
   destinationRule:
     enabled: true
+image:
+  repository: harbor.go-ti.shop/prod/goti-payment
+  tag: prod-49-4bbdc87
+imagePullSecrets:
+  - name: harbor-creds

--- a/environments/prod/goti-resale/values.yaml
+++ b/environments/prod/goti-resale/values.yaml
@@ -125,3 +125,8 @@ istioPolicy:
       - "/v3/api-docs/*"
   destinationRule:
     enabled: true
+image:
+  repository: harbor.go-ti.shop/prod/goti-resale
+  tag: prod-49-4bbdc87
+imagePullSecrets:
+  - name: harbor-creds

--- a/environments/prod/goti-stadium/values.yaml
+++ b/environments/prod/goti-stadium/values.yaml
@@ -114,3 +114,8 @@ istioPolicy:
       - "/v3/api-docs/*"
   destinationRule:
     enabled: true
+image:
+  repository: harbor.go-ti.shop/prod/goti-stadium
+  tag: prod-49-4bbdc87
+imagePullSecrets:
+  - name: harbor-creds

--- a/environments/prod/goti-ticketing/values.yaml
+++ b/environments/prod/goti-ticketing/values.yaml
@@ -59,19 +59,19 @@ gateway:
               number: 8080
 autoscaling:
   enabled: true
-  minReplicas: 3        # 항상 3개 웜 상태 유지 (JVM 워밍업 완료된 인스턴스)
-  maxReplicas: 10       # 실제 티켓팅 스파이크 수용
+  minReplicas: 3 # 항상 3개 웜 상태 유지 (JVM 워밍업 완료된 인스턴스)
+  maxReplicas: 10 # 실제 티켓팅 스파이크 수용
   keda:
     enabled: true
-    cooldownPeriod: 300  # 스파이크 후 성급한 scale-down 방지 (60 → 300초)
+    cooldownPeriod: 300 # 스파이크 후 성급한 scale-down 방지 (60 → 300초)
     triggers:
       # Cron: 티켓 오픈 30분 전(9:30 KST) ~ 정오(12:00 KST) 바닥 6개 보장
       # → Karpenter가 미리 노드 프로비저닝 → JVM 워밍업 완료 후 트래픽 수신
       - type: cron
         metadata:
           timezone: "Asia/Seoul"
-          start: "30 10 * * *"  # 10:30 KST — 티켓 오픈 30분 전 사전 준비
-          end: "0 13 * * *"     # 13:00 KST — 판매 마감 후 일반 수준으로 복귀
+          start: "30 10 * * *" # 10:30 KST — 티켓 오픈 30분 전 사전 준비
+          end: "0 13 * * *" # 13:00 KST — 판매 마감 후 일반 수준으로 복귀
           desiredReplicas: "6"
       # Prometheus: 실제 RPS 반응형 추가 스케일 (Cron이 바닥 보장, Prometheus가 천장 제어)
       - type: prometheus
@@ -153,3 +153,8 @@ istioPolicy:
       - "/v3/api-docs/*"
   destinationRule:
     enabled: true
+image:
+  repository: harbor.go-ti.shop/prod/goti-ticketing
+  tag: prod-49-4bbdc87
+imagePullSecrets:
+  - name: harbor-creds

--- a/environments/prod/goti-user/values.yaml
+++ b/environments/prod/goti-user/values.yaml
@@ -47,7 +47,7 @@ gateway:
               number: 8080
 autoscaling:
   enabled: true
-  minReplicas: 3        # 야간 비용 절감 (현재 static 4개 → KEDA 관리로 전환)
+  minReplicas: 3 # 야간 비용 절감 (현재 static 4개 → KEDA 관리로 전환)
   maxReplicas: 10
   keda:
     enabled: true
@@ -57,8 +57,8 @@ autoscaling:
       - type: cron
         metadata:
           timezone: "Asia/Seoul"
-          start: "50 10 * * *"  # 10:50 KST — 티켓 오픈 10분 전 사전 준비 (로그인 트래픽 선행)
-          end: "0 13 * * *"     # 13:00 KST
+          start: "50 10 * * *" # 10:50 KST — 티켓 오픈 10분 전 사전 준비 (로그인 트래픽 선행)
+          end: "0 13 * * *" # 13:00 KST
           desiredReplicas: "5"
       - type: prometheus
         metadata:
@@ -132,3 +132,8 @@ istioPolicy:
       - "/.well-known/*"
   destinationRule:
     enabled: true
+image:
+  repository: harbor.go-ti.shop/prod/goti-user
+  tag: prod-49-4bbdc87
+imagePullSecrets:
+  - name: harbor-creds


### PR DESCRIPTION
## 변경 사항
- 이미지 태그: `prod-49-4bbdc87`
- 레지스트리: `harbor.go-ti.shop/prod/`
- 업데이트된 서비스: `{"include":[{"service":"user"},{"service":"stadium"},{"service":"ticketing"},{"service":"payment"},{"service":"resale"}]}`

## 트리거
- 브랜치: `deploy/prod`
- 커밋: 4bbdc87908800235ded02785532e75504992c18e
- 워크플로우: [#49](https://github.com/Team-Ikujo/Goti-server/actions/runs/24029531395)