### PR TITLE
[CHORE] prod 이미지 태그 업데이트: prod-50-3e1d97d

### DIFF
--- a/environments/prod/goti-payment/values.yaml
+++ b/environments/prod/goti-payment/values.yaml
@@ -133,6 +133,6 @@ istioPolicy:
     enabled: true
 image:
   repository: harbor.go-ti.shop/prod/goti-payment
-  tag: prod-49-4bbdc87
+  tag: prod-50-3e1d97d
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-queue/values.yaml
+++ b/environments/prod/goti-queue/values.yaml
@@ -1,21 +1,15 @@
 nameOverride: goti-queue
-
 replicaCount: 1
-
 autoscaling:
   enabled: false
-
 image:
-  repository: "707925622666.dkr.ecr.ap-northeast-2.amazonaws.com/goti-queue"
-  tag: "poc-suyeon-37-8856b54"
+  repository: "harbor.go-ti.shop/prod/goti-queue"
+  tag: "prod-50-3e1d97d"
   pullPolicy: IfNotPresent
-
 imagePullSecrets:
-  - name: ecr-creds
-
+  - name: harbor-creds
 podAnnotations:
   instrumentation.opentelemetry.io/inject-java: "goti/goti-java"
-
 resources:
   requests:
     cpu: 200m
@@ -23,7 +17,6 @@ resources:
   limits:
     cpu: 2000m
     memory: 1Gi
-
 gateway:
   enabled: true
   hosts:
@@ -44,7 +37,6 @@ gateway:
             host: goti-queue-prod
             port:
               number: 8080
-
 probes:
   liveness:
     httpGet:
@@ -58,13 +50,11 @@ probes:
       port: http
     initialDelaySeconds: 30
     periodSeconds: 5
-
 serviceMonitor:
   enabled: true
   port: http
   path: "/actuator/prometheus"
   interval: "15s"
-
 env:
   - name: SPRING_PROFILES_ACTIVE
     value: "prod"
@@ -83,11 +73,9 @@ env:
         key: REDIS_AUTH_TOKEN
   - name: QUEUE_MAX_CAPACITY
     value: "100"
-
 envFrom:
   - secretRef:
       name: goti-queue-prod-secrets
-
 externalSecret:
   enabled: true
   refreshInterval: "1h"
@@ -97,7 +85,6 @@ externalSecret:
   remoteRef:
     path: /prod/server
     overridePath: /prod/queue
-
 istioPolicy:
   authorizationPolicy:
     enabled: false

--- a/environments/prod/goti-resale/values.yaml
+++ b/environments/prod/goti-resale/values.yaml
@@ -127,6 +127,6 @@ istioPolicy:
     enabled: true
 image:
   repository: harbor.go-ti.shop/prod/goti-resale
-  tag: prod-49-4bbdc87
+  tag: prod-50-3e1d97d
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-stadium/values.yaml
+++ b/environments/prod/goti-stadium/values.yaml
@@ -116,6 +116,6 @@ istioPolicy:
     enabled: true
 image:
   repository: harbor.go-ti.shop/prod/goti-stadium
-  tag: prod-49-4bbdc87
+  tag: prod-50-3e1d97d
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-ticketing/values.yaml
+++ b/environments/prod/goti-ticketing/values.yaml
@@ -155,6 +155,6 @@ istioPolicy:
     enabled: true
 image:
   repository: harbor.go-ti.shop/prod/goti-ticketing
-  tag: prod-49-4bbdc87
+  tag: prod-50-3e1d97d
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-user/values.yaml
+++ b/environments/prod/goti-user/values.yaml
@@ -134,6 +134,6 @@ istioPolicy:
     enabled: true
 image:
   repository: harbor.go-ti.shop/prod/goti-user
-  tag: prod-49-4bbdc87
+  tag: prod-50-3e1d97d
 imagePullSecrets:
   - name: harbor-creds


### PR DESCRIPTION
## 변경 사항
- 이미지 태그: `prod-50-3e1d97d`
- 레지스트리: `harbor.go-ti.shop/prod/`
- 업데이트된 서비스: `{"include":[{"service":"user"},{"service":"stadium"},{"service":"ticketing"},{"service":"payment"},{"service":"resale"},{"service":"queue"}]}`

## 트리거
- 브랜치: `deploy/prod`
- 커밋: 3e1d97d54c8b0e317abb2f1d4ae98f60796e8d8f
- 워크플로우: [#50](https://github.com/Team-Ikujo/Goti-server/actions/runs/24065334357)