### PR TITLE
[FEAT] dev Queue cleanup API 환경변수 추가 (#184)

### DIFF
--- a/environments/dev/goti-queue/values.yaml
+++ b/environments/dev/goti-queue/values.yaml
@@ -101,6 +101,8 @@ env:
     value: "/api/docs/queue/v3/api-docs/swagger-config"
   - name: SPRINGDOC_SWAGGER_UI_URL
     value: "/api/docs/queue/v3/api-docs"
+  - name: QUEUE_CLEANUP_API_ENABLED
+    value: "true"
 
 envFrom:
   - secretRef:

--- a/environments/dev/goti-queue/values.yaml
+++ b/environments/dev/goti-queue/values.yaml
@@ -97,12 +97,13 @@ env:
     value: "-Xms256m -Xmx512m -XX:+UseG1GC -XX:+UseContainerSupport"
   - name: GOTI_MESH_ENABLED
     value: "true"
+  # dev 전용: 대기열 데이터 정리 내부 API 활성화 (prod 활성화 금지)
+  - name: QUEUE_CLEANUP_API_ENABLED
+    value: "true"
   - name: SPRINGDOC_SWAGGER_UI_CONFIG_URL
     value: "/api/docs/queue/v3/api-docs/swagger-config"
   - name: SPRINGDOC_SWAGGER_UI_URL
     value: "/api/docs/queue/v3/api-docs"
-  - name: QUEUE_CLEANUP_API_ENABLED
-    value: "true"
 
 envFrom:
   - secretRef:


### PR DESCRIPTION
## 관련 이슈
- Closes #184

## 개요
Goti-server PR #456에서 추가된 내부 전용 cleanup API를 dev 환경에서 활성화하기 위한 환경변수 추가.

## 작업 내용
- [x] `environments/dev/goti-queue/values.yaml`에 `QUEUE_CLEANUP_API_ENABLED=true` 추가
- dev에서만 활성화, prod는 기본값(false) 유지

## 테스트
- [ ] `helm lint` 통과
- [ ] `helm template` 렌더링 검증
- [ ] Kind 로컬 클러스터 배포 검증
- [ ] ArgoCD sync 확인
