### PR TITLE
[CHORE] prod 이미지 태그 업데이트: prod-51-b39eebc

### DIFF
--- a/environments/prod/goti-payment/values.yaml
+++ b/environments/prod/goti-payment/values.yaml
@@ -133,6 +133,6 @@ istioPolicy:
     enabled: true
 image:
   repository: harbor.go-ti.shop/prod/goti-payment
-  tag: prod-50-3e1d97d
+  tag: prod-51-b39eebc
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-queue/values.yaml
+++ b/environments/prod/goti-queue/values.yaml
@@ -4,7 +4,7 @@ autoscaling:
   enabled: false
 image:
   repository: "harbor.go-ti.shop/prod/goti-queue"
-  tag: "prod-50-3e1d97d"
+  tag: "prod-51-b39eebc"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-resale/values.yaml
+++ b/environments/prod/goti-resale/values.yaml
@@ -127,6 +127,6 @@ istioPolicy:
     enabled: true
 image:
   repository: harbor.go-ti.shop/prod/goti-resale
-  tag: prod-50-3e1d97d
+  tag: prod-51-b39eebc
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-stadium/values.yaml
+++ b/environments/prod/goti-stadium/values.yaml
@@ -116,6 +116,6 @@ istioPolicy:
     enabled: true
 image:
   repository: harbor.go-ti.shop/prod/goti-stadium
-  tag: prod-50-3e1d97d
+  tag: prod-51-b39eebc
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-ticketing/values.yaml
+++ b/environments/prod/goti-ticketing/values.yaml
@@ -155,6 +155,6 @@ istioPolicy:
     enabled: true
 image:
   repository: harbor.go-ti.shop/prod/goti-ticketing
-  tag: prod-50-3e1d97d
+  tag: prod-51-b39eebc
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-user/values.yaml
+++ b/environments/prod/goti-user/values.yaml
@@ -134,6 +134,6 @@ istioPolicy:
     enabled: true
 image:
   repository: harbor.go-ti.shop/prod/goti-user
-  tag: prod-50-3e1d97d
+  tag: prod-51-b39eebc
 imagePullSecrets:
   - name: harbor-creds


### PR DESCRIPTION
## 변경 사항
- 이미지 태그: `prod-51-b39eebc`
- 레지스트리: `harbor.go-ti.shop/prod/`
- 업데이트된 서비스: `{"include":[{"service":"user"},{"service":"stadium"},{"service":"ticketing"},{"service":"payment"},{"service":"resale"},{"service":"queue"}]}`

## 트리거
- 브랜치: `deploy/prod`
- 커밋: b39eebcf5bcd104c6f67fa37357fed2df0c26f56
- 워크플로우: [#51](https://github.com/Team-Ikujo/Goti-server/actions/runs/24166766564)