### PR TITLE
🚨 [Failover] Harbor 장애 감지 — ECR로 전환 (2026-04-09 06:01)

### DIFF
--- a/environments/prod/goti-guardrail/values-aws.yaml
+++ b/environments/prod/goti-guardrail/values-aws.yaml
@@ -1,11 +1,11 @@
 # AWS EKS — Harbor에서 직접 pull (ECR replication 미설정)
 replicaCount: 1
 image:
-  repository: "harbor.go-ti.shop/prod/goti-guardrail"
+  repository: "707925622666.dkr.ecr.ap-northeast-2.amazonaws.com/goti-guardrail"
   tag: "prod-3-e74c600"
   pullPolicy: IfNotPresent
 imagePullSecrets:
-  - name: harbor-creds
+  - name: ecr-creds
 externalSecret:
   enabled: true
   refreshInterval: "1h"

--- a/environments/prod/goti-mouse-macro/values-aws.yaml
+++ b/environments/prod/goti-mouse-macro/values-aws.yaml
@@ -6,7 +6,7 @@ image:
 
 # harbor-creds: infrastructure/prod/external-secrets/config/harbor-creds-externalsecret.yaml 에서 생성
 imagePullSecrets:
-  - name: harbor-creds
+  - name: ecr-creds
 
 serviceAccount:
   annotations:


### PR DESCRIPTION
## Harbor 장애 감지\n\n**Harbor 상태:** ``\n**전환 방향:** Harbor → ECR\n\n### 변경 내용\n- 모든 prod 서비스 이미지 레지스트리를 ECR로 변경\n- imagePullSecrets: `harbor-creds` → `ecr-creds`\n\n### 주의\n- Harbor 복구 후 deactivate PR이 자동 생성됩니다\n- 이 PR 머지 시 ArgoCD가 자동으로 ECR에서 이미지를 pull합니다