### PR TITLE
🚨 [Failover] Harbor 장애 감지 — ECR로 전환 (2026-04-09 06:56)

### DIFF
--- a/environments/prod/goti-guardrail/values-aws.yaml
+++ b/environments/prod/goti-guardrail/values-aws.yaml
@@ -1,11 +1,11 @@
 # AWS EKS — Harbor에서 직접 pull (ECR replication 미설정)
 replicaCount: 1
 image:
-  repository: "harbor.go-ti.shop/prod/goti-guardrail"
+  repository: "707925622666.dkr.ecr.ap-northeast-2.amazonaws.com/goti-guardrail"
   tag: "prod-3-e74c600"
   pullPolicy: IfNotPresent
 imagePullSecrets:
-  - name: harbor-creds
+  - name: ecr-creds
 externalSecret:
   enabled: true
   refreshInterval: "1h"

--- a/environments/prod/goti-mouse-macro/values-aws.yaml
+++ b/environments/prod/goti-mouse-macro/values-aws.yaml
@@ -6,7 +6,7 @@ image:
 
 # harbor-creds: infrastructure/prod/external-secrets/config/harbor-creds-externalsecret.yaml 에서 생성
 imagePullSecrets:
-  - name: harbor-creds
+  - name: ecr-creds
 
 serviceAccount:
   annotations:

--- a/environments/prod/goti-payment/values-aws.yaml
+++ b/environments/prod/goti-payment/values-aws.yaml
@@ -1,10 +1,10 @@
 replicaCount: 2
 image:
-  repository: "harbor.go-ti.shop/prod/goti-payment"
+  repository: "707925622666.dkr.ecr.ap-northeast-2.amazonaws.com/goti-payment"
   tag: "prod-51-b39eebc"
   pullPolicy: IfNotPresent
 imagePullSecrets:
-  - name: harbor-creds
+  - name: ecr-creds
 externalSecret:
   enabled: true
   refreshInterval: "1h"

--- a/environments/prod/goti-queue/values-aws.yaml
+++ b/environments/prod/goti-queue/values-aws.yaml
@@ -1,10 +1,10 @@
 replicaCount: 2
 image:
-  repository: "harbor.go-ti.shop/prod/goti-queue"
+  repository: "707925622666.dkr.ecr.ap-northeast-2.amazonaws.com/goti-queue"
   tag: "prod-51-b39eebc"
   pullPolicy: IfNotPresent
 imagePullSecrets:
-  - name: harbor-creds
+  - name: ecr-creds
 externalSecret:
   enabled: true
   refreshInterval: "1h"

--- a/environments/prod/goti-resale/values-aws.yaml
+++ b/environments/prod/goti-resale/values-aws.yaml
@@ -1,10 +1,10 @@
 replicaCount: 2
 image:
-  repository: "harbor.go-ti.shop/prod/goti-resale"
+  repository: "707925622666.dkr.ecr.ap-northeast-2.amazonaws.com/goti-resale"
   tag: "prod-51-b39eebc"
   pullPolicy: IfNotPresent
 imagePullSecrets:
-  - name: harbor-creds
+  - name: ecr-creds
 externalSecret:
   enabled: true
   refreshInterval: "1h"

--- a/environments/prod/goti-stadium/values-aws.yaml
+++ b/environments/prod/goti-stadium/values-aws.yaml
@@ -1,10 +1,10 @@
 replicaCount: 2
 image:
-  repository: "harbor.go-ti.shop/prod/goti-stadium"
+  repository: "707925622666.dkr.ecr.ap-northeast-2.amazonaws.com/goti-stadium"
   tag: "prod-51-b39eebc"
   pullPolicy: IfNotPresent
 imagePullSecrets:
-  - name: harbor-creds
+  - name: ecr-creds
 externalSecret:
   enabled: true
   refreshInterval: "1h"

--- a/environments/prod/goti-ticketing/values-aws.yaml
+++ b/environments/prod/goti-ticketing/values-aws.yaml
@@ -1,10 +1,10 @@
 replicaCount: 2
 image:
-  repository: "harbor.go-ti.shop/prod/goti-ticketing"
+  repository: "707925622666.dkr.ecr.ap-northeast-2.amazonaws.com/goti-ticketing"
   tag: "prod-51-b39eebc"
   pullPolicy: IfNotPresent
 imagePullSecrets:
-  - name: harbor-creds
+  - name: ecr-creds
 externalSecret:
   enabled: true
   refreshInterval: "1h"

--- a/environments/prod/goti-user/values-aws.yaml
+++ b/environments/prod/goti-user/values-aws.yaml
@@ -1,10 +1,10 @@
 replicaCount: 4
 image:
-  repository: "harbor.go-ti.shop/prod/goti-user"
+  repository: "707925622666.dkr.ecr.ap-northeast-2.amazonaws.com/goti-user"
   tag: "prod-51-b39eebc"
   pullPolicy: IfNotPresent
 imagePullSecrets:
-  - name: harbor-creds
+  - name: ecr-creds
 externalSecret:
   enabled: true
   refreshInterval: "1h"


### PR DESCRIPTION
## Harbor 장애 감지

**Harbor 상태:** ``
**전환 방향:** Harbor → ECR

### 변경 내용
- 모든 prod 서비스 이미지 레지스트리를 ECR로 변경
- imagePullSecrets: `harbor-creds` → `ecr-creds`

### 주의
- Harbor 복구 후 deactivate PR이 자동 생성됩니다
- 이 PR 머지 시 ArgoCD가 자동으로 ECR에서 이미지를 pull합니다
