### PR TITLE
[CHORE] prod 이미지 태그 업데이트: prod-52-c0a6964

### DIFF
--- a/environments/prod/goti-payment/values.yaml
+++ b/environments/prod/goti-payment/values.yaml
@@ -133,3 +133,8 @@ istioPolicy:
       - "/v3/api-docs/*"
   destinationRule:
     enabled: true
+image:
+  repository: harbor.go-ti.shop/prod/goti-payment
+  tag: prod-52-c0a6964
+imagePullSecrets:
+  - name: harbor-creds

--- a/environments/prod/goti-queue/values.yaml
+++ b/environments/prod/goti-queue/values.yaml
@@ -80,3 +80,8 @@ istioPolicy:
     enabled: false
   destinationRule:
     enabled: true
+image:
+  repository: harbor.go-ti.shop/prod/goti-queue
+  tag: prod-52-c0a6964
+imagePullSecrets:
+  - name: harbor-creds

--- a/environments/prod/goti-resale/values.yaml
+++ b/environments/prod/goti-resale/values.yaml
@@ -142,3 +142,8 @@ istioPolicy:
       - "/v3/api-docs/*"
   destinationRule:
     enabled: true
+image:
+  repository: harbor.go-ti.shop/prod/goti-resale
+  tag: prod-52-c0a6964
+imagePullSecrets:
+  - name: harbor-creds

--- a/environments/prod/goti-stadium/values.yaml
+++ b/environments/prod/goti-stadium/values.yaml
@@ -114,3 +114,8 @@ istioPolicy:
       - "/v3/api-docs/*"
   destinationRule:
     enabled: true
+image:
+  repository: harbor.go-ti.shop/prod/goti-stadium
+  tag: prod-52-c0a6964
+imagePullSecrets:
+  - name: harbor-creds

--- a/environments/prod/goti-ticketing/values.yaml
+++ b/environments/prod/goti-ticketing/values.yaml
@@ -160,3 +160,8 @@ istioPolicy:
       - "/v3/api-docs/*"
   destinationRule:
     enabled: true
+image:
+  repository: harbor.go-ti.shop/prod/goti-ticketing
+  tag: prod-52-c0a6964
+imagePullSecrets:
+  - name: harbor-creds

--- a/environments/prod/goti-user/values.yaml
+++ b/environments/prod/goti-user/values.yaml
@@ -134,3 +134,8 @@ istioPolicy:
       - "/.well-known/*"
   destinationRule:
     enabled: true
+image:
+  repository: harbor.go-ti.shop/prod/goti-user
+  tag: prod-52-c0a6964
+imagePullSecrets:
+  - name: harbor-creds


### PR DESCRIPTION
## 변경 사항
- 이미지 태그: `prod-52-c0a6964`
- 레지스트리: `harbor.go-ti.shop/prod/`
- 업데이트된 서비스: `{"include":[{"service":"user"},{"service":"stadium"},{"service":"ticketing"},{"service":"payment"},{"service":"resale"},{"service":"queue"}]}`

## 트리거
- 브랜치: `deploy/prod`
- 커밋: c0a696452180b33780290e1f8aefe2871d4a37fb
- 워크플로우: [#52](https://github.com/Team-Ikujo/Goti-server/actions/runs/24222275693)