### PR TITLE
[CHORE] prod 이미지 태그 업데이트: prod-53-a630ef6

### DIFF
--- a/environments/prod/goti-payment/values-aws.yaml
+++ b/environments/prod/goti-payment/values-aws.yaml
@@ -1,7 +1,7 @@
 replicaCount: 2
 image:
   repository: "harbor.go-ti.shop/prod/goti-payment"
-  tag: "prod-52-c0a6964"
+  tag: "prod-53-a630ef6"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-resale/values-aws.yaml
+++ b/environments/prod/goti-resale/values-aws.yaml
@@ -1,7 +1,7 @@
 replicaCount: 2
 image:
   repository: "harbor.go-ti.shop/prod/goti-resale"
-  tag: "prod-52-c0a6964"
+  tag: "prod-53-a630ef6"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-ticketing/values-aws.yaml
+++ b/environments/prod/goti-ticketing/values-aws.yaml
@@ -1,7 +1,7 @@
 replicaCount: 2
 image:
   repository: "harbor.go-ti.shop/prod/goti-ticketing"
-  tag: "prod-52-c0a6964"
+  tag: "prod-53-a630ef6"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-user/values-aws.yaml
+++ b/environments/prod/goti-user/values-aws.yaml
@@ -1,7 +1,7 @@
 replicaCount: 4
 image:
   repository: "harbor.go-ti.shop/prod/goti-user"
-  tag: "prod-52-c0a6964"
+  tag: "prod-53-a630ef6"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds


### PR DESCRIPTION
## 변경 사항
- 이미지 태그: `prod-53-a630ef6`
- 레지스트리: `harbor.go-ti.shop/prod/`
- 업데이트된 서비스: `{"include":[{"service":"user"},{"service":"ticketing"},{"service":"payment"},{"service":"resale"}]}`

## 트리거
- 브랜치: `deploy/prod`
- 커밋: a630ef66be1714e72bb53702a764d2b47ef23d7c
- 워크플로우: [#53](https://github.com/Team-Ikujo/Goti-server/actions/runs/24234261290)