### PR TITLE
feat(goti-stadium-go): add Phase 6.5 prod helm values (PoC)

### DIFF
--- a/environments/prod/goti-stadium-go/values-aws.yaml
+++ b/environments/prod/goti-stadium-go/values-aws.yaml
@@ -14,6 +14,9 @@ externalSecret:
     kind: ClusterSecretStore
   remoteRef:
     path: /prod/stadium-go
+# TODO(ticketing-go-sync): "~/*.amazonaws.com"는 Istio Sidecar hosts 비표준
+# (`~`는 sidecar 자체 namespace 의미). 외부 도메인은 "*.amazonaws.com" 형식이 표준.
+# ticketing-go-aws.values도 동일 패턴 사용 중이므로 함께 동기 수정 필요.
 istioPolicy:
   sidecar:
     enabled: true
@@ -22,4 +25,4 @@ istioPolicy:
           - "istio-system/*"
           - "./*"
           - "monitoring/*"
-          - "~/*.amazonaws.com"
+          - "*.amazonaws.com"

--- a/environments/prod/goti-stadium-go/values-aws.yaml
+++ b/environments/prod/goti-stadium-go/values-aws.yaml
@@ -1,0 +1,25 @@
+# SG1: 0% weight 첫 배포 — replicaCount: 0 (Java goti-stadium-prod 무영향 보장)
+replicaCount: 0
+image:
+  repository: "harbor.go-ti.shop/prod/goti-stadium-go"
+  tag: "prod-1-0000000"
+  pullPolicy: IfNotPresent
+imagePullSecrets:
+  - name: harbor-creds
+externalSecret:
+  enabled: true
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: aws-ssm
+    kind: ClusterSecretStore
+  remoteRef:
+    path: /prod/stadium-go
+istioPolicy:
+  sidecar:
+    enabled: true
+    egress:
+      - hosts:
+          - "istio-system/*"
+          - "./*"
+          - "monitoring/*"
+          - "~/*.amazonaws.com"

--- a/environments/prod/goti-stadium-go/values.yaml
+++ b/environments/prod/goti-stadium-go/values.yaml
@@ -1,3 +1,7 @@
+# TODO(jwks-automation): user-service JWT 키 회전 시 본 파일 line ~163의
+# inline jwks를 모든 Go 서비스(현재 6개)와 수동 동기화 필요. Phase 6.5 4서비스
+# 확대 전 ConfigMap 또는 RequestAuthentication.jwksUri 참조 방식으로 자동화.
+# 메모리: project_jwks_automation_todo.md
 nameOverride: goti-stadium-go
 
 service:
@@ -24,6 +28,10 @@ pdb:
   enabled: true
   minAvailable: 1
 
+# TODO(W7): Java goti-stadium VS와 동일 (host, path) 조합 → Istio
+# MULTIPLE_VIRTUAL_SERVICES_FOR_HOST. ApplicationSet entry 추가 전 단일 VS에서
+# weight 분배(Java 100 / Go 0) 방식으로 통합 필요. Option A 채택.
+# Swagger 라우팅(/api/docs/stadium/*)은 Go 미구현 전제로 누락 — Java 전용 유지.
 gateway:
   enabled: true
   hosts:
@@ -33,7 +41,7 @@ gateway:
   httpRoutes:
     - match:
         - uri:
-            exact: "/api/v1/stadiums"
+            prefix: "/api/v1/stadiums"
         - uri:
             prefix: "/api/v1/baseball-teams"
       route:
@@ -42,6 +50,9 @@ gateway:
             port:
               number: 8080
 
+# TODO(tuning): cron 윈도우/replica/threshold는 ticketing-go 값 그대로 복제.
+# stadium은 read-heavy 메타 서비스(Redis 캐시 hit율 높음)이므로 부하 관측 후
+# 윈도우 좁히기 또는 desiredReplicas/threshold 차등화 검토.
 autoscaling:
   enabled: true
   minReplicas: 2
@@ -58,11 +69,13 @@ autoscaling:
           desiredReplicas: "4"
       - type: prometheus
         metadata:
-          serverAddress: http://mimir-prod-query-frontend.monitoring.svc:8080/prometheus
+          serverAddress: http://mimir-prod-query-frontend.monitoring.svc.cluster.local:8080/prometheus
           metricName: http_rps_stadium_go
           query: sum(rate(http_server_request_duration_seconds_count{service_name="goti-stadium-go"}[1m]))
           threshold: "50"
 
+# TODO(verify): /healthz가 DB/Redis ping 포함 시 RDS 풀 초기화에 3~5s 소요
+# 가능 → liveness 재시작 루프 위험. 코드 확인 후 필요 시 liveness만 10s로 조정.
 probes:
   liveness:
     httpGet:
@@ -118,6 +131,7 @@ env:
   # --- OTel ---
   - name: STADIUM_OTEL_ENABLED
     value: "true"
+  # FQDN .cluster.local 명시 — Istio sidecar/DNS proxy 환경 resolve 안전성
   - name: STADIUM_OTEL_ENDPOINT
     value: "http://otel-collector.monitoring.svc.cluster.local:4317"
   - name: STADIUM_OTEL_SERVICE_NAME
@@ -134,6 +148,8 @@ configMap:
 # --- Istio 보안/네트워크 정책 ---
 istioPolicy:
   # ticketing(Java) + ticketing-go(Go) 양쪽 호출자 허용 (Phase 6.5 공존 기간)
+  # TODO(phase 7 / Step 4b): Java ticketing deprecation 후 from-ticketing 규칙
+  # 제거. Java SA 잔존 시 공격 표면 확대.
   authorizationPolicy:
     enabled: true
     allowFrom:
@@ -155,17 +171,20 @@ istioPolicy:
               - operation:
                   paths: ["/api/v1/stadiums*", "/api/v1/baseball-teams*"]
                   methods: ["GET"]
+  # TODO(consistency): Java goti-stadium values에는 issuer 미설정. JWT iss claim
+  # 실제 발급 값 확인 후 Java values에도 동일 issuer 추가해 일관성 확보.
   requestAuthentication:
     enabled: true
     issuer: "goti-user-service"
     jwks: '{"keys":[{"alg":"RS256","kty":"RSA","kid":"goti-jwt-key-1","e":"AQAB","use":"sig","n":"tXlfiSkDgSujDP6wUyQc57RrUGkTK6x3Fe-W5VhZhBumzDDoRNglcZ3C9AY_iF9GdlZOgcUdKLEVplLuEZGQpHUdA5CwgzQkwNXs242Mgo6QyHGdbDXZXEhe42vl1gcdgnahY7UQLcWGUr6--Fuc5G2LMW6rlTGwagT05SKzGRbTRef3gt8D8_hdsp654vnrdW2ReRQltnffHR9XL8buuKIduGW5vfiCVtNRFsaiT_o0SA86a5gK9qmXUGJIDPLc9onZ3v6G8gtFOES4MmR0elT2VTf22tM0GeIhnDOrjVRBa5I-M6c4OTMDrmeHKhUJygj-rjfNT5effpQzUz0_Xw"}]}'
+  # 의도: stadium은 public read API (경기장/팀 메타데이터 조회) — 비로그인 접근 허용.
+  # AuthorizationPolicy.allowFrom으로 mesh 내부 호출자(GET only) 별도 제한.
+  # 향후 쓰기 메서드 추가 시 chart의 jwtAuthorizationPolicy에 method 분리 필요.
   jwtAuthorizationPolicy:
     enabled: true
     excludePaths:
-      - "/api/v1/stadiums"
-      - "/api/v1/stadiums/*"
-      - "/api/v1/baseball-teams"
-      - "/api/v1/baseball-teams/*"
+      - "/api/v1/stadiums*"
+      - "/api/v1/baseball-teams*"
       - "/healthz"
       - "/readyz"
       - "/metrics"

--- a/environments/prod/goti-stadium-go/values.yaml
+++ b/environments/prod/goti-stadium-go/values.yaml
@@ -1,0 +1,173 @@
+nameOverride: goti-stadium-go
+
+service:
+  type: ClusterIP
+  port: 8080
+  name: http
+
+serviceMonitor:
+  enabled: true
+  port: http
+  path: /metrics
+  interval: 15s
+  release: kube-prometheus-stack-prod
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 1000m
+    memory: 256Mi
+
+pdb:
+  enabled: true
+  minAvailable: 1
+
+gateway:
+  enabled: true
+  hosts:
+    - "go-ti.shop"
+    - "api.go-ti.shop"
+  gatewayRef: "istio-system/goti-shared-gateway"
+  httpRoutes:
+    - match:
+        - uri:
+            exact: "/api/v1/stadiums"
+        - uri:
+            prefix: "/api/v1/baseball-teams"
+      route:
+        - destination:
+            host: goti-stadium-go-prod
+            port:
+              number: 8080
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 10
+  keda:
+    enabled: true
+    cooldownPeriod: 300
+    triggers:
+      - type: cron
+        metadata:
+          timezone: "Asia/Seoul"
+          start: "30 10 * * *"
+          end: "0 13 * * *"
+          desiredReplicas: "4"
+      - type: prometheus
+        metadata:
+          serverAddress: http://mimir-prod-query-frontend.monitoring.svc:8080/prometheus
+          metricName: http_rps_stadium_go
+          query: sum(rate(http_server_request_duration_seconds_count{service_name="goti-stadium-go"}[1m]))
+          threshold: "50"
+
+probes:
+  liveness:
+    httpGet:
+      path: /healthz
+      port: http
+    initialDelaySeconds: 3
+    periodSeconds: 10
+    failureThreshold: 3
+  readiness:
+    httpGet:
+      path: /readyz
+      port: http
+    initialDelaySeconds: 3
+    periodSeconds: 5
+    failureThreshold: 3
+
+podAnnotations:
+  sidecar.istio.io/inject: "true"
+  # ElastiCache Redis TLS — Istio sidecar 우회
+  traffic.sidecar.istio.io/excludeOutboundPorts: "6379"
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  fsGroup: 65532
+
+securityContext:
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop: ["ALL"]
+  seccompProfile:
+    type: RuntimeDefault
+
+# 환경변수: STADIUM_ prefix (Viper가 config.Load("stadium")에서 자동 생성)
+# envFrom 사용하지 않음 — 개별 매핑으로 명시적 관리
+env:
+  # --- 인프라 (Secret에서 주입) ---
+  - name: STADIUM_DATABASE_URL
+    valueFrom:
+      secretKeyRef:
+        name: goti-stadium-go-prod-secrets
+        key: STADIUM_DATABASE_URL
+  - name: STADIUM_REDIS_URL
+    valueFrom:
+      secretKeyRef:
+        name: goti-stadium-go-prod-secrets
+        key: STADIUM_REDIS_URL
+  - name: STADIUM_JWT_PUBLIC_KEY_PEM
+    valueFrom:
+      secretKeyRef:
+        name: goti-stadium-go-prod-secrets
+        key: STADIUM_JWT_PUBLIC_KEY_PEM
+  # --- OTel ---
+  - name: STADIUM_OTEL_ENABLED
+    value: "true"
+  - name: STADIUM_OTEL_ENDPOINT
+    value: "http://otel-collector.monitoring.svc.cluster.local:4317"
+  - name: STADIUM_OTEL_SERVICE_NAME
+    value: "goti-stadium-go"
+  # OTel SDK 표준 환경변수 (Go SDK가 직접 참조)
+  - name: OTEL_SERVICE_NAME
+    value: "goti-stadium-go"
+  - name: OTEL_EXPORTER_OTLP_ENDPOINT
+    value: "http://otel-collector.monitoring.svc.cluster.local:4317"
+
+configMap:
+  enabled: false
+
+# --- Istio 보안/네트워크 정책 ---
+istioPolicy:
+  # ticketing(Java) + ticketing-go(Go) 양쪽 호출자 허용 (Phase 6.5 공존 기간)
+  authorizationPolicy:
+    enabled: true
+    allowFrom:
+      - name: from-ticketing
+        rules:
+          - from:
+              - source:
+                  principals: ["cluster.local/ns/goti/sa/goti-ticketing-prod"]
+            to:
+              - operation:
+                  paths: ["/api/v1/stadiums*", "/api/v1/baseball-teams*"]
+                  methods: ["GET"]
+      - name: from-ticketing-go
+        rules:
+          - from:
+              - source:
+                  principals: ["cluster.local/ns/goti/sa/goti-ticketing-go-prod"]
+            to:
+              - operation:
+                  paths: ["/api/v1/stadiums*", "/api/v1/baseball-teams*"]
+                  methods: ["GET"]
+  requestAuthentication:
+    enabled: true
+    issuer: "goti-user-service"
+    jwks: '{"keys":[{"alg":"RS256","kty":"RSA","kid":"goti-jwt-key-1","e":"AQAB","use":"sig","n":"tXlfiSkDgSujDP6wUyQc57RrUGkTK6x3Fe-W5VhZhBumzDDoRNglcZ3C9AY_iF9GdlZOgcUdKLEVplLuEZGQpHUdA5CwgzQkwNXs242Mgo6QyHGdbDXZXEhe42vl1gcdgnahY7UQLcWGUr6--Fuc5G2LMW6rlTGwagT05SKzGRbTRef3gt8D8_hdsp654vnrdW2ReRQltnffHR9XL8buuKIduGW5vfiCVtNRFsaiT_o0SA86a5gK9qmXUGJIDPLc9onZ3v6G8gtFOES4MmR0elT2VTf22tM0GeIhnDOrjVRBa5I-M6c4OTMDrmeHKhUJygj-rjfNT5effpQzUz0_Xw"}]}'
+  jwtAuthorizationPolicy:
+    enabled: true
+    excludePaths:
+      - "/api/v1/stadiums"
+      - "/api/v1/stadiums/*"
+      - "/api/v1/baseball-teams"
+      - "/api/v1/baseball-teams/*"
+      - "/healthz"
+      - "/readyz"
+      - "/metrics"
+  destinationRule:
+    enabled: true


### PR DESCRIPTION
## 관련 이슈
- Refs: Phase 6.5 SDD `docs/migration/java-to-go/phase6.5-go-prod-infra-sdd.md`

## 개요
Phase 7 audit S6 점검에서 발견된 Critical 갭 — **Go 5서비스가 prod helm values조차 Java 기준** — 해소를 위한 Phase 6.5 PoC. stadium(read-mostly leaf 서비스)을 첫 대상으로 ticketing-go values 패턴 100% 복제.

검증 후 user/queue/resale/payment 4서비스에 일괄 적용 예정.

## 작업 내용
- [x] `environments/prod/goti-stadium-go/values.yaml` — ticketing-go 패턴 + stadium 특화
- [x] `environments/prod/goti-stadium-go/values-aws.yaml` — replicaCount: 0, ECR/SSM 경로

### Stadium 특화
| 항목 | 값 |
|------|-----|
| nameOverride | `goti-stadium-go` (Java `goti-stadium`과 완전 분리) |
| 라우트 | `/api/v1/stadiums` (exact) + `/api/v1/baseball-teams` (prefix) |
| env prefix | `STADIUM_` (Viper `config.Load(\"stadium\")`) |
| 주입 secret | DATABASE_URL / REDIS_URL / JWT_PUBLIC_KEY_PEM (leaf 서비스라 서비스간 통신 env·QR·QUEUE secret 제외) |
| AuthPolicy | from-ticketing + from-ticketing-go (Java/Go 공존 호출자 허용) |
| KEDA | prometheus(`service_name=\"goti-stadium-go\"`) + cron(10:30~13:00 KST 4 replica) |
| ECR | `harbor.go-ti.shop/prod/goti-stadium-go` |
| SSM path | `/prod/stadium-go` |

### 6대 안전 가드 적용
- **SG1** (0% weight): `replicaCount: 0`
- **SG2** (별도 deployment): `goti-stadium-go-prod` (Java `goti-stadium-prod` 무영향)
- **SG3** (별도 ServiceAccount + Secret): `goti-stadium-go-prod-secrets` 분리
- **SG5** (manifest 검증): `helm template` 467 lines, error/warning 0

## ⚠️ 주의사항 — VS 라우트 충돌 가능성
같은 host(`go-ti.shop`, `api.go-ti.shop`)에 대해 Java(`goti-stadium`) VS와 Go(`goti-stadium-go`) VS가 동일 path(`/api/v1/stadiums`)를 매칭하게 됨.

**현재 PR은 안전**: ApplicationSet entry 미추가 상태(W7)이므로 VS 자체가 클러스터에 배포되지 않음.

W7 ApplicationSet entry 추가 전 라우팅 전략 재논의 필요:
- Option A: VS weight 분배 (Java 100% / Go 0% → 점진 전환)
- Option B: Go는 별도 host (예: `go.go-ti.shop`)로 분리

## 후속 PR (Phase 6.5 W2~W7)
- W2: ECR CD 워크플로우 (Goti-go 레포)
- W4: AWS Secrets Manager `/prod/stadium-go` + ExternalSecret (Goti-Terraform)
- W7: ApplicationSet entry 추가 (Goti-k8s)

## 테스트
- [x] \`helm template\` 렌더링 검증 — 467 lines, error/warning 0
- [ ] \`helm lint\` 실행 (goti-server chart)
- [ ] Kind 로컬 클러스터 배포 검증 (해당 없음 — prod values)
- [ ] ArgoCD sync 확인 (W7 ApplicationSet 추가 후)

## Acceptance Gate 진행도
- [x] **G1**: stadium values 작성 + ticketing-go 패턴 준수
- [x] **G2**: helm template error 0 warning 0
- [ ] G3~G7: 후속 PR 진행 후