### PR TITLE
feat(ci): automate JWKS rotation via GitHub Actions (ADR-0010 Option E)

### DIFF
--- a/.github/workflows/rotate-jwks.yml
+++ b/.github/workflows/rotate-jwks.yml
@@ -1,0 +1,152 @@
+name: Rotate JWKS
+
+# ADR-0010 Rev 2 (Option E) — JWKS 배포 자동화.
+#
+# 동작:
+#   SSM /prod/server/JWT_RSA_PUBLIC_KEY (PEM) + /prod/server/JWT_KID
+#     → scripts/pem-to-jwks.py로 JWKS JSON 생성
+#     → scripts/patch-jwks.sh로 8개 values.yaml 치환
+#     → diff 있으면 PR 생성, 없으면 no-op 종료
+#
+# 트리거:
+#   - workflow_dispatch: 수동 실행 (키 회전 즉시 반영용)
+#   - repository_dispatch(jwks-rotate): 외부 이벤트 (Terraform apply 완료 훅 등)
+#   - schedule: 하루 1회 (drift 감지 안전망)
+#
+# 이전 실패 예방:
+#   - SSM `--output text`는 개행을 리터럴 `\n`으로 흘림 → pem-to-jwks.py에서 복원
+#   - yq는 포맷 재작성으로 idempotent 깨짐 → sed line-replace 사용
+#   - PEM은 SecureString이라 `--with-decryption` 필수
+
+on:
+  workflow_dispatch:
+  repository_dispatch:
+    types:
+      - jwks-rotate
+  schedule:
+    # 매일 03:00 KST (UTC 18:00) — 트래픽 적은 시간
+    - cron: '0 18 * * *'
+
+env:
+  PEM_PARAMETER: /prod/server/JWT_RSA_PUBLIC_KEY
+  KID_PARAMETER: /prod/server/JWT_KID
+  JWCRYPTO_VERSION: '1.5.6'
+
+jobs:
+  rotate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: AWS 인증 (SSM read)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ap-northeast-2
+
+      - name: Python 환경 준비
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: jwcrypto 설치
+        run: pip install "jwcrypto==${JWCRYPTO_VERSION}"
+
+      - name: SSM에서 PEM + KID 조회
+        id: ssm
+        run: |
+          PEM=$(aws ssm get-parameter \
+            --name "$PEM_PARAMETER" \
+            --with-decryption \
+            --query Parameter.Value \
+            --output text)
+          KID=$(aws ssm get-parameter \
+            --name "$KID_PARAMETER" \
+            --query Parameter.Value \
+            --output text)
+
+          if [[ -z "$PEM" || -z "$KID" ]]; then
+            echo "error: SSM 값 비어있음 (PEM 길이=${#PEM}, KID=$KID)" >&2
+            exit 1
+          fi
+
+          # PEM 임시 파일로 (pem-to-jwks.py가 개행 리터럴 자동 복원)
+          PEM_FILE=$(mktemp)
+          printf '%s' "$PEM" > "$PEM_FILE"
+
+          echo "pem_file=$PEM_FILE" >> "$GITHUB_OUTPUT"
+          echo "kid=$KID" >> "$GITHUB_OUTPUT"
+          echo "::add-mask::$KID"
+
+      - name: JWKS 생성
+        id: jwks
+        run: |
+          JWKS=$(python scripts/pem-to-jwks.py \
+            "${{ steps.ssm.outputs.pem_file }}" \
+            --kid "${{ steps.ssm.outputs.kid }}")
+          # 다른 step에 넘기기 위해 output 사용 (JWKS 자체는 비밀 아님 — 공개키 기반)
+          echo "jwks<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$JWKS" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: values.yaml 8개 치환
+        env:
+          JWKS: ${{ steps.jwks.outputs.jwks }}
+        run: ./scripts/patch-jwks.sh
+
+      - name: diff 검사
+        id: diff
+        run: |
+          if git diff --quiet environments/prod/*/values.yaml; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "변경 없음 — JWKS가 이미 최신. 종료."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            git diff --stat environments/prod/*/values.yaml
+          fi
+
+      - name: PR 생성
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GIT_PAT }}
+        run: |
+          DATE=$(date '+%Y-%m-%d %H:%M')
+          BRANCH="rotate-jwks/$(date +%s)"
+          TITLE="chore(jwks): rotate JWKS from SSM ($DATE)"
+
+          BODY_FILE=$(mktemp)
+          cat > "$BODY_FILE" <<'EOF'
+          ## JWKS 자동 회전
+
+          `/prod/server/JWT_RSA_PUBLIC_KEY` (SSM) 기준으로 JWKS를 재생성해 8개 서비스 values.yaml을 동기화합니다.
+
+          ### 변경 내용
+          - `environments/prod/goti-{payment,queue,resale,stadium,stadium-go,ticketing,ticketing-go,user}/values.yaml`
+          - 필드: `istioPolicy.requestAuthentication.jwks`
+
+          ### 검증
+          - [x] PEM → JWKS 바이트 변환 (scripts/pem-to-jwks.py, jwcrypto 기반)
+          - [x] 8파일 single-line jwks 필드만 치환 (scripts/patch-jwks.sh, sed line-replace)
+          - [ ] 리뷰어: `helm template` 8서비스 error 0 확인 후 머지
+
+          자동화 설계: ADR-0010 Rev 2 (Option E).
+          EOF
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add environments/prod/*/values.yaml
+          git commit -m "$TITLE"
+          git push origin "$BRANCH"
+
+          gh pr create \
+            --title "$TITLE" \
+            --body-file "$BODY_FILE" \
+            --base main \
+            --head "$BRANCH" \
+            --label "rotate-jwks"

--- a/environments/prod/goti-stadium-go/values-aws.yaml
+++ b/environments/prod/goti-stadium-go/values-aws.yaml
@@ -14,6 +14,9 @@ externalSecret:
     kind: ClusterSecretStore
   remoteRef:
     path: /prod/stadium-go
+# TODO(ticketing-go-sync): "~/*.amazonaws.com"는 Istio Sidecar hosts 비표준
+# (`~`는 sidecar 자체 namespace 의미). 외부 도메인은 "*.amazonaws.com" 형식이 표준.
+# ticketing-go-aws.values도 동일 패턴 사용 중이므로 함께 동기 수정 필요.
 istioPolicy:
   sidecar:
     enabled: true
@@ -22,4 +25,4 @@ istioPolicy:
           - "istio-system/*"
           - "./*"
           - "monitoring/*"
-          - "~/*.amazonaws.com"
+          - "*.amazonaws.com"

--- a/environments/prod/goti-stadium-go/values-aws.yaml
+++ b/environments/prod/goti-stadium-go/values-aws.yaml
@@ -1,0 +1,25 @@
+# SG1: 0% weight 첫 배포 — replicaCount: 0 (Java goti-stadium-prod 무영향 보장)
+replicaCount: 0
+image:
+  repository: "harbor.go-ti.shop/prod/goti-stadium-go"
+  tag: "prod-1-0000000"
+  pullPolicy: IfNotPresent
+imagePullSecrets:
+  - name: harbor-creds
+externalSecret:
+  enabled: true
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: aws-ssm
+    kind: ClusterSecretStore
+  remoteRef:
+    path: /prod/stadium-go
+istioPolicy:
+  sidecar:
+    enabled: true
+    egress:
+      - hosts:
+          - "istio-system/*"
+          - "./*"
+          - "monitoring/*"
+          - "~/*.amazonaws.com"

--- a/environments/prod/goti-stadium-go/values.yaml
+++ b/environments/prod/goti-stadium-go/values.yaml
@@ -1,3 +1,7 @@
+# TODO(jwks-automation): user-service JWT 키 회전 시 본 파일 line ~163의
+# inline jwks를 모든 Go 서비스(현재 6개)와 수동 동기화 필요. Phase 6.5 4서비스
+# 확대 전 ConfigMap 또는 RequestAuthentication.jwksUri 참조 방식으로 자동화.
+# 메모리: project_jwks_automation_todo.md
 nameOverride: goti-stadium-go
 
 service:
@@ -24,6 +28,10 @@ pdb:
   enabled: true
   minAvailable: 1
 
+# TODO(W7): Java goti-stadium VS와 동일 (host, path) 조합 → Istio
+# MULTIPLE_VIRTUAL_SERVICES_FOR_HOST. ApplicationSet entry 추가 전 단일 VS에서
+# weight 분배(Java 100 / Go 0) 방식으로 통합 필요. Option A 채택.
+# Swagger 라우팅(/api/docs/stadium/*)은 Go 미구현 전제로 누락 — Java 전용 유지.
 gateway:
   enabled: true
   hosts:
@@ -33,7 +41,7 @@ gateway:
   httpRoutes:
     - match:
         - uri:
-            exact: "/api/v1/stadiums"
+            prefix: "/api/v1/stadiums"
         - uri:
             prefix: "/api/v1/baseball-teams"
       route:
@@ -42,6 +50,9 @@ gateway:
             port:
               number: 8080
 
+# TODO(tuning): cron 윈도우/replica/threshold는 ticketing-go 값 그대로 복제.
+# stadium은 read-heavy 메타 서비스(Redis 캐시 hit율 높음)이므로 부하 관측 후
+# 윈도우 좁히기 또는 desiredReplicas/threshold 차등화 검토.
 autoscaling:
   enabled: true
   minReplicas: 2
@@ -58,11 +69,13 @@ autoscaling:
           desiredReplicas: "4"
       - type: prometheus
         metadata:
-          serverAddress: http://mimir-prod-query-frontend.monitoring.svc:8080/prometheus
+          serverAddress: http://mimir-prod-query-frontend.monitoring.svc.cluster.local:8080/prometheus
           metricName: http_rps_stadium_go
           query: sum(rate(http_server_request_duration_seconds_count{service_name="goti-stadium-go"}[1m]))
           threshold: "50"
 
+# TODO(verify): /healthz가 DB/Redis ping 포함 시 RDS 풀 초기화에 3~5s 소요
+# 가능 → liveness 재시작 루프 위험. 코드 확인 후 필요 시 liveness만 10s로 조정.
 probes:
   liveness:
     httpGet:
@@ -118,6 +131,7 @@ env:
   # --- OTel ---
   - name: STADIUM_OTEL_ENABLED
     value: "true"
+  # FQDN .cluster.local 명시 — Istio sidecar/DNS proxy 환경 resolve 안전성
   - name: STADIUM_OTEL_ENDPOINT
     value: "http://otel-collector.monitoring.svc.cluster.local:4317"
   - name: STADIUM_OTEL_SERVICE_NAME
@@ -134,6 +148,8 @@ configMap:
 # --- Istio 보안/네트워크 정책 ---
 istioPolicy:
   # ticketing(Java) + ticketing-go(Go) 양쪽 호출자 허용 (Phase 6.5 공존 기간)
+  # TODO(phase 7 / Step 4b): Java ticketing deprecation 후 from-ticketing 규칙
+  # 제거. Java SA 잔존 시 공격 표면 확대.
   authorizationPolicy:
     enabled: true
     allowFrom:
@@ -155,17 +171,20 @@ istioPolicy:
               - operation:
                   paths: ["/api/v1/stadiums*", "/api/v1/baseball-teams*"]
                   methods: ["GET"]
+  # TODO(consistency): Java goti-stadium values에는 issuer 미설정. JWT iss claim
+  # 실제 발급 값 확인 후 Java values에도 동일 issuer 추가해 일관성 확보.
   requestAuthentication:
     enabled: true
     issuer: "goti-user-service"
     jwks: '{"keys":[{"alg":"RS256","kty":"RSA","kid":"goti-jwt-key-1","e":"AQAB","use":"sig","n":"tXlfiSkDgSujDP6wUyQc57RrUGkTK6x3Fe-W5VhZhBumzDDoRNglcZ3C9AY_iF9GdlZOgcUdKLEVplLuEZGQpHUdA5CwgzQkwNXs242Mgo6QyHGdbDXZXEhe42vl1gcdgnahY7UQLcWGUr6--Fuc5G2LMW6rlTGwagT05SKzGRbTRef3gt8D8_hdsp654vnrdW2ReRQltnffHR9XL8buuKIduGW5vfiCVtNRFsaiT_o0SA86a5gK9qmXUGJIDPLc9onZ3v6G8gtFOES4MmR0elT2VTf22tM0GeIhnDOrjVRBa5I-M6c4OTMDrmeHKhUJygj-rjfNT5effpQzUz0_Xw"}]}'
+  # 의도: stadium은 public read API (경기장/팀 메타데이터 조회) — 비로그인 접근 허용.
+  # AuthorizationPolicy.allowFrom으로 mesh 내부 호출자(GET only) 별도 제한.
+  # 향후 쓰기 메서드 추가 시 chart의 jwtAuthorizationPolicy에 method 분리 필요.
   jwtAuthorizationPolicy:
     enabled: true
     excludePaths:
-      - "/api/v1/stadiums"
-      - "/api/v1/stadiums/*"
-      - "/api/v1/baseball-teams"
-      - "/api/v1/baseball-teams/*"
+      - "/api/v1/stadiums*"
+      - "/api/v1/baseball-teams*"
       - "/healthz"
       - "/readyz"
       - "/metrics"

--- a/environments/prod/goti-stadium-go/values.yaml
+++ b/environments/prod/goti-stadium-go/values.yaml
@@ -1,0 +1,173 @@
+nameOverride: goti-stadium-go
+
+service:
+  type: ClusterIP
+  port: 8080
+  name: http
+
+serviceMonitor:
+  enabled: true
+  port: http
+  path: /metrics
+  interval: 15s
+  release: kube-prometheus-stack-prod
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 1000m
+    memory: 256Mi
+
+pdb:
+  enabled: true
+  minAvailable: 1
+
+gateway:
+  enabled: true
+  hosts:
+    - "go-ti.shop"
+    - "api.go-ti.shop"
+  gatewayRef: "istio-system/goti-shared-gateway"
+  httpRoutes:
+    - match:
+        - uri:
+            exact: "/api/v1/stadiums"
+        - uri:
+            prefix: "/api/v1/baseball-teams"
+      route:
+        - destination:
+            host: goti-stadium-go-prod
+            port:
+              number: 8080
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 10
+  keda:
+    enabled: true
+    cooldownPeriod: 300
+    triggers:
+      - type: cron
+        metadata:
+          timezone: "Asia/Seoul"
+          start: "30 10 * * *"
+          end: "0 13 * * *"
+          desiredReplicas: "4"
+      - type: prometheus
+        metadata:
+          serverAddress: http://mimir-prod-query-frontend.monitoring.svc:8080/prometheus
+          metricName: http_rps_stadium_go
+          query: sum(rate(http_server_request_duration_seconds_count{service_name="goti-stadium-go"}[1m]))
+          threshold: "50"
+
+probes:
+  liveness:
+    httpGet:
+      path: /healthz
+      port: http
+    initialDelaySeconds: 3
+    periodSeconds: 10
+    failureThreshold: 3
+  readiness:
+    httpGet:
+      path: /readyz
+      port: http
+    initialDelaySeconds: 3
+    periodSeconds: 5
+    failureThreshold: 3
+
+podAnnotations:
+  sidecar.istio.io/inject: "true"
+  # ElastiCache Redis TLS — Istio sidecar 우회
+  traffic.sidecar.istio.io/excludeOutboundPorts: "6379"
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  fsGroup: 65532
+
+securityContext:
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop: ["ALL"]
+  seccompProfile:
+    type: RuntimeDefault
+
+# 환경변수: STADIUM_ prefix (Viper가 config.Load("stadium")에서 자동 생성)
+# envFrom 사용하지 않음 — 개별 매핑으로 명시적 관리
+env:
+  # --- 인프라 (Secret에서 주입) ---
+  - name: STADIUM_DATABASE_URL
+    valueFrom:
+      secretKeyRef:
+        name: goti-stadium-go-prod-secrets
+        key: STADIUM_DATABASE_URL
+  - name: STADIUM_REDIS_URL
+    valueFrom:
+      secretKeyRef:
+        name: goti-stadium-go-prod-secrets
+        key: STADIUM_REDIS_URL
+  - name: STADIUM_JWT_PUBLIC_KEY_PEM
+    valueFrom:
+      secretKeyRef:
+        name: goti-stadium-go-prod-secrets
+        key: STADIUM_JWT_PUBLIC_KEY_PEM
+  # --- OTel ---
+  - name: STADIUM_OTEL_ENABLED
+    value: "true"
+  - name: STADIUM_OTEL_ENDPOINT
+    value: "http://otel-collector.monitoring.svc.cluster.local:4317"
+  - name: STADIUM_OTEL_SERVICE_NAME
+    value: "goti-stadium-go"
+  # OTel SDK 표준 환경변수 (Go SDK가 직접 참조)
+  - name: OTEL_SERVICE_NAME
+    value: "goti-stadium-go"
+  - name: OTEL_EXPORTER_OTLP_ENDPOINT
+    value: "http://otel-collector.monitoring.svc.cluster.local:4317"
+
+configMap:
+  enabled: false
+
+# --- Istio 보안/네트워크 정책 ---
+istioPolicy:
+  # ticketing(Java) + ticketing-go(Go) 양쪽 호출자 허용 (Phase 6.5 공존 기간)
+  authorizationPolicy:
+    enabled: true
+    allowFrom:
+      - name: from-ticketing
+        rules:
+          - from:
+              - source:
+                  principals: ["cluster.local/ns/goti/sa/goti-ticketing-prod"]
+            to:
+              - operation:
+                  paths: ["/api/v1/stadiums*", "/api/v1/baseball-teams*"]
+                  methods: ["GET"]
+      - name: from-ticketing-go
+        rules:
+          - from:
+              - source:
+                  principals: ["cluster.local/ns/goti/sa/goti-ticketing-go-prod"]
+            to:
+              - operation:
+                  paths: ["/api/v1/stadiums*", "/api/v1/baseball-teams*"]
+                  methods: ["GET"]
+  requestAuthentication:
+    enabled: true
+    issuer: "goti-user-service"
+    jwks: '{"keys":[{"alg":"RS256","kty":"RSA","kid":"goti-jwt-key-1","e":"AQAB","use":"sig","n":"tXlfiSkDgSujDP6wUyQc57RrUGkTK6x3Fe-W5VhZhBumzDDoRNglcZ3C9AY_iF9GdlZOgcUdKLEVplLuEZGQpHUdA5CwgzQkwNXs242Mgo6QyHGdbDXZXEhe42vl1gcdgnahY7UQLcWGUr6--Fuc5G2LMW6rlTGwagT05SKzGRbTRef3gt8D8_hdsp654vnrdW2ReRQltnffHR9XL8buuKIduGW5vfiCVtNRFsaiT_o0SA86a5gK9qmXUGJIDPLc9onZ3v6G8gtFOES4MmR0elT2VTf22tM0GeIhnDOrjVRBa5I-M6c4OTMDrmeHKhUJygj-rjfNT5effpQzUz0_Xw"}]}'
+  jwtAuthorizationPolicy:
+    enabled: true
+    excludePaths:
+      - "/api/v1/stadiums"
+      - "/api/v1/stadiums/*"
+      - "/api/v1/baseball-teams"
+      - "/api/v1/baseball-teams/*"
+      - "/healthz"
+      - "/readyz"
+      - "/metrics"
+  destinationRule:
+    enabled: true

--- a/scripts/patch-jwks.sh
+++ b/scripts/patch-jwks.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# patch-jwks.sh — prod 8개 values.yaml의 jwks 필드를 일괄 치환.
+#
+# Usage:
+#   JWKS='{"keys":[...]}' ./scripts/patch-jwks.sh
+#
+# 설계 결정:
+# - yq 대신 sed line-replace 사용 — yq v4가 빈 줄/포맷을 재작성해서
+#   idempotent 실패 (JWKS 값 동일인데 YAML 포맷 변경됨).
+# - 대상 라인 패턴: `^    jwks: '.*'$` (4-space 들여쓰기 고정).
+# - 매칭된 파일에 1개 라인만 있어야 함 (sed가 전역 치환해도 안전하지만 guard).
+# - idempotent: 동일 JWKS면 파일 내용 변경 없음 (sed는 결과 동일 시 no-op).
+#
+# 이식성:
+# - GNU sed / BSD sed 모두 `-i.bak` 패턴으로 동작 (macOS + ubuntu-latest 호환).
+
+set -euo pipefail
+
+if [[ -z "${JWKS:-}" ]]; then
+  echo "error: JWKS env 변수 필수" >&2
+  exit 1
+fi
+
+# 유효성: JSON 파싱 가능한지 (python 한 줄)
+python3 -c "import json,sys; json.loads(sys.argv[1])" "$JWKS" 2>/dev/null || {
+  echo "error: JWKS가 유효한 JSON이 아님" >&2
+  exit 1
+}
+
+# sed replacement 특수문자(&, |, \) 이스케이프. JWKS는 single-quote로 감싸므로
+# JWKS 내부에 single quote가 있으면 안 됨 (base64url/JSON에는 없음).
+if [[ "$JWKS" == *"'"* ]]; then
+  echo "error: JWKS에 single quote 포함 — values.yaml 포맷 충돌" >&2
+  exit 1
+fi
+ESCAPED=$(printf '%s' "$JWKS" | sed -e 's/[\\&|]/\\&/g')
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FILES=(
+  "environments/prod/goti-payment/values.yaml"
+  "environments/prod/goti-queue/values.yaml"
+  "environments/prod/goti-resale/values.yaml"
+  "environments/prod/goti-stadium/values.yaml"
+  "environments/prod/goti-stadium-go/values.yaml"
+  "environments/prod/goti-ticketing/values.yaml"
+  "environments/prod/goti-ticketing-go/values.yaml"
+  "environments/prod/goti-user/values.yaml"
+)
+
+cd "$REPO_ROOT"
+
+for f in "${FILES[@]}"; do
+  if [[ ! -f "$f" ]]; then
+    echo "error: 대상 파일 없음: $f" >&2
+    exit 1
+  fi
+
+  # 대상 라인 존재 확인 (정확히 1개여야 함)
+  COUNT=$(grep -c "^    jwks: '" "$f" || true)
+  if [[ "$COUNT" != "1" ]]; then
+    echo "error: $f — jwks 라인 개수가 1이 아님 (found: $COUNT)" >&2
+    exit 1
+  fi
+
+  # 4-space 들여쓰기 jwks 라인 전체 교체
+  sed -i.bak "s|^    jwks: '.*'$|    jwks: '${ESCAPED}'|" "$f"
+  rm -f "${f}.bak"
+
+  echo "✓ patched: $f"
+done
+
+echo "done: ${#FILES[@]} files"

--- a/scripts/pem-to-jwks.py
+++ b/scripts/pem-to-jwks.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""
+PEM(RSA public key) → JWKS(JSON) 변환.
+
+JWKS 자동화 파이프라인 (ADR-0010 Rev 2, Option E) 내부에서 사용.
+Istio RequestAuthentication.jwks 필드에 넣을 single-line JSON 생성.
+
+Why:
+- user-service가 JWT 서명 시 박는 kid와 JWKS의 kid가 일치해야 Istio 검증 성공.
+- 현재 Goti는 kid 고정 문자열 패턴 (Phase A). 회전 시 kid를 수동 증가.
+- PEM은 SSM(/prod/server/JWT_RSA_PUBLIC_KEY)이 단일 진실의 원천.
+
+Output:
+- values.yaml의 현재 포맷과 **바이트 일치** 필수.
+- JSON 키 순서: alg, kty, kid, e, use, n (insertion order 유지)
+- separators=(',',':') → 공백 없음
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from jwcrypto import jwk
+
+
+def _normalize_pem(pem_bytes: bytes) -> bytes:
+    """AWS SSM `--output text`가 개행을 리터럴 `\\n`으로 흘릴 때 실개행 복원.
+
+    Why: SSM SecureString에 PEM을 넣으면 개행이 `\\n` 리터럴로 보존되는데
+    `aws ssm get-parameter --output text`는 이걸 그대로 stdout에 흘린다.
+    jwcrypto는 MalformedFraming 에러. workflow 재현성을 위해 스크립트가 직접 복원.
+    이미 실개행이 있는 PEM에는 no-op."""
+    text = pem_bytes.decode("utf-8", errors="strict")
+    if "\\n" in text and "\n" not in text:
+        text = text.replace("\\n", "\n")
+    return text.encode("utf-8")
+
+
+def pem_to_jwks(pem_bytes: bytes, kid: str, alg: str = "RS256", use: str = "sig") -> str:
+    """PEM 공개키 → single-line JWKS JSON 문자열."""
+    pem_bytes = _normalize_pem(pem_bytes)
+    key = jwk.JWK.from_pem(pem_bytes)
+    if key["kty"] != "RSA":
+        raise ValueError(f"RSA 키만 지원: kty={key['kty']}")
+
+    # 키 순서 고정: alg, kty, kid, e, use, n (현재 values.yaml 포맷)
+    entry = {
+        "alg": alg,
+        "kty": "RSA",
+        "kid": kid,
+        "e": key["e"],
+        "use": use,
+        "n": key["n"],
+    }
+    jwks = {"keys": [entry]}
+    return json.dumps(jwks, separators=(",", ":"))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="PEM → JWKS 변환")
+    parser.add_argument("pem_file", type=Path, help="RSA 공개키 PEM 파일 경로")
+    parser.add_argument("--kid", default="goti-jwt-key-1", help="JWT kid (default: goti-jwt-key-1)")
+    parser.add_argument("--alg", default="RS256", help="서명 알고리즘 (default: RS256)")
+    parser.add_argument("--use", default="sig", help="키 용도 (default: sig)")
+    args = parser.parse_args()
+
+    if not args.pem_file.exists():
+        print(f"error: PEM 파일 없음: {args.pem_file}", file=sys.stderr)
+        return 1
+
+    pem_bytes = args.pem_file.read_bytes()
+    jwks_str = pem_to_jwks(pem_bytes, kid=args.kid, alg=args.alg, use=args.use)
+    print(jwks_str)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 관련 이슈
- Closes #
- 선행 PR: Team-Ikujo/Goti-Terraform#9 (JWT_KID SSM 파라미터 신설)

## 개요

ADR-0010 Rev 2 Option E 구현. SSM `/prod/server/JWT_RSA_PUBLIC_KEY` (PEM) + `/prod/server/JWT_KID` 를 진실의 원천으로 하여 8개 prod values.yaml의 \`istioPolicy.requestAuthentication.jwks\` 를 자동 동기화한다.

**해결하는 문제**: Istio JWKS가 8개 values에 하드코딩되어 키 회전 시 수동 8곳 수정 → 누락 한 건이면 해당 서비스 JWT 검증 실패. 실제 2026-04-04 키 불일치 사고 발생 이력.

## 작업 내용

- [x] \`scripts/pem-to-jwks.py\` — jwcrypto로 PEM → JWKS JSON 변환 (kid/alg/use 입력)
- [x] \`scripts/patch-jwks.sh\` — 8 values의 jwks 라인 sed line-replace (idempotent)
- [x] \`.github/workflows/rotate-jwks.yml\` — workflow_dispatch + repository_dispatch(jwks-rotate) + daily cron

## 설계 결정

| 결정 | 채택 | 기각 사유 |
|------|------|----------|
| yq vs sed line-replace | **sed** | yq v4가 빈 줄/포맷 재작성 → idempotent 깨짐 |
| kid 전략 | **고정 문자열 + SSM 참조 (Phase A)** | RFC 7638 thumbprint는 user-service 서명 로직 동기 전환 필요 → Phase B |
| PR 생성 도구 | **\`gh pr create\`** | peter-evans/create-pull-request보다 레포 기존 패턴(harbor-failover.yml)과 일관 |
| automerge | **미적용 (1차)** | 동작 검증 후 Phase 2에서 추가 |

## 이전 시행착오 반영

- SSM \`--output text\`가 개행을 리터럴 \`\\n\` 으로 흘림 → \`pem-to-jwks.py\` 내부 \`_normalize_pem()\` 에서 자동 복원
- yq 포맷 재작성 이슈 → sed line-replace로 전환, \`-i.bak\` 으로 GNU/BSD 호환

## Blast Radius

- **직접 변경**: 신규 파일 3개 (workflow + 스크립트 2개)
- **간접 영향**: workflow가 만드는 PR이 머지되어야 values.yaml이 변경됨 (기본 no-op — 현재 JWKS와 SSM PEM 파생 JWKS가 동일)
- **다운타임**: 없음 (JWKS 값 동일 → Istio CR 변경 없음)
- **롤백**: workflow 비활성화 또는 파일 revert

## 순서 주의

**선행**: Team-Ikujo/Goti-Terraform#9 머지 + \`terraform apply\` 필수. 그 전에 workflow 실행 시 SSM JWT_KID 조회 실패.

## 로컬 PoC 결과 (검증됨)

- ✅ PEM → JWKS 바이트 일치 (현재 values의 JWKS와 동일)
- ✅ patch-jwks.sh idempotent (동일 JWKS 재주입 시 \`git diff\` 0줄)

## 테스트

- [ ] \`helm lint\` 통과 (8 서비스)
- [ ] \`helm template\` 렌더링 검증 (8 서비스)
- [ ] 선행 PR 머지 + apply 후 \`workflow_dispatch\` 수동 실행 — 첫 실행은 no-op (PR 생성 안 됨) 기대
- [ ] Kind 로컬 클러스터 배포 검증 (해당 없음 — prod 전용)
- [ ] ArgoCD sync 확인 (해당 없음 — 이번 PR은 workflow만 추가)

## 후속 작업 (별도 이슈)

- user-service 서명 로직이 SSM \`JWT_KID\` 참조하도록 변경 (Phase B 완성)
- Renovate automerge 규칙 추가 (동작 안정화 후)
- Phase B: RFC 7638 thumbprint 전환 ADR