### PR TITLE
[CHORE] R1 capacity test — ticketing KEDA 일시 비활성화 (pod=2 고정)

### DIFF
--- a/environments/prod/goti-ticketing/values-aws.yaml
+++ b/environments/prod/goti-ticketing/values-aws.yaml
@@ -1,4 +1,8 @@
 replicaCount: 2
+# R1 capacity test (2026-04-12): KEDA 일시 비활성화로 pod=2 고정
+# 테스트 종료 후 autoscaling.enabled 줄 제거하여 원복 필요
+autoscaling:
+  enabled: false
 image:
   repository: "harbor.go-ti.shop/prod/goti-ticketing"
   tag: "prod-52-c0a6964"


### PR DESCRIPTION
## #️⃣ 관련 이슈
- 관련: Team-Ikujo/Goti-monitoring#68 (capacity planning 대시보드)

## 🔎 개요
실용적 capacity planning 테스트(R1~R3)의 R1 단계. 명재님 2026-04-11 부하테스트 결과(VU 3000 / pod 2 터짐)를 새 대시보드로 재현하여 원인 관찰.

## 📋 작업 내용
\`environments/prod/goti-ticketing/values-aws.yaml\`
- \`autoscaling.enabled: false\` 추가 (KEDA ScaledObject 제거)
- \`replicaCount: 2\` 유지 (현재값 동일)

## 📊 Blast Radius
- **직접 변경**: AWS prod ticketing만 — GCP 영향 없음
- **간접 영향**: 테스트 중 KEDA 자동 스케일 없음. 부하 급증 시 pod 2로 버티며 터지는 포인트 측정
- **롤백**: \`autoscaling\` 블록 제거 PR → ArgoCD sync → 정상 KEDA 복귀
- **다운타임**: 없음 (ScaledObject만 삭제, Deployment pod 수 동일)

## ✅ 검증
- [ ] ArgoCD sync 후 \`kubectl get scaledobject goti-ticketing-prod -n goti\` 조회 → NotFound
- [ ] \`kubectl get deploy goti-ticketing-prod -n goti\` replicas=2 유지
- [ ] R1 부하테스트 시 pod 수 2 고정 유지 (부하 폭증에도 스케일아웃 없음)

## 📌 후속
R1 결과 따라:
- R2: replicaCount=4 변경 PR
- R3: 최소 pod 수 찾기
- 완료 후: 이 \`autoscaling\` 블록 제거 원복 PR

## 🔗 관련 문서
- \`goti-team-controller/docs/load-test/2026-04-12-capacity-planning-keda.md\` (업데이트 예정)