### PR TITLE
[CHORE] Queue maxCapacity 300→1000 — ticketing 수용량 측정 우선

### DIFF
--- a/environments/prod/goti-queue/values.yaml
+++ b/environments/prod/goti-queue/values.yaml
@@ -66,7 +66,7 @@ env:
         name: goti-queue-prod-secrets
         key: REDIS_AUTH_TOKEN
   - name: QUEUE_MAX_CAPACITY
-    value: "300"
+    value: "1000"
 envFrom:
   - secretRef:
       name: goti-queue-prod-secrets


### PR DESCRIPTION
## #️⃣ 관련 이슈
- 관련: capacity planning 부하테스트 (Team-Ikujo/Goti-monitoring#68)

## 🔎 개요
부하테스트에서 대기열(300)이 ticketing(pod=2) 앞에서 먼저 포화되면 ticketing 자체의 capacity를 측정할 수 없음. 사용자 요구: **"대기열 터지는 것보다 티켓팅 수용량 측정이 더 중요"**.

## 📋 작업 내용
\`environments/prod/goti-queue/values.yaml\` QUEUE_MAX_CAPACITY 300 → 1000

## Blast Radius
- Redis 메모리 사용: active-users SET 크기 300 → 1000 (영향 미미)
- Queue pod 부하: heartbeat/cleanup 로직이 active 사용자 수에 비례 — 모니터링 필요
- 다운타임: 없음 (Deployment 롤링)

## ✅ 검증
- [ ] ArgoCD sync 후 \`env QUEUE_MAX_CAPACITY=1000\` 확인
- [ ] 100 VU smoke로 기능 정상 확인
- [ ] 1500 VU 본 테스트

## ↩️ 롤백
\`git revert\` → 원복 (300)

## 📌 후속
capacity 측정 완료 후 실전 기준에 맞게 값 재조정 예정