### PR TITLE
[CHORE] Queue maxCapacity 1000→3000 — 5000 VU 측정

### DIFF
--- a/environments/prod/goti-queue/values.yaml
+++ b/environments/prod/goti-queue/values.yaml
@@ -66,7 +66,7 @@ env:
         name: goti-queue-prod-secrets
         key: REDIS_AUTH_TOKEN
   - name: QUEUE_MAX_CAPACITY
-    value: "1000"
+    value: "3000"
 envFrom:
   - secretRef:
       name: goti-queue-prod-secrets


### PR DESCRIPTION
1000 active에서 ticketing 부하 cap. 5000 VU 테스트에서 ticketing 진짜 한계 측정 위해 3000으로 확대.