### PR TITLE
[CHORE] ticketing KEDA 원복 — capacity test 종료

### DIFF
--- a/environments/prod/goti-ticketing/values-aws.yaml
+++ b/environments/prod/goti-ticketing/values-aws.yaml
@@ -1,8 +1,4 @@
 replicaCount: 2
-# R1 capacity test (2026-04-12): KEDA 일시 비활성화로 pod=2 고정
-# 테스트 종료 후 autoscaling.enabled 줄 제거하여 원복 필요
-autoscaling:
-  enabled: false
 image:
   repository: "harbor.go-ti.shop/prod/goti-ticketing"
   tag: "prod-52-c0a6964"


### PR DESCRIPTION
## 개요
2026-04-12 capacity planning(R1 1500 VU, R2 3000 VU) 측정 종료. 테스트용 `autoscaling.enabled: false` 제거하여 정상 KEDA 동작 상태로 복귀.

## 📊 측정 결론
- Stadium 조회 API가 진짜 병목 (p95 6.8s, 5xx 10.88%)
- Java Hibernate N+1 + 동기 JOIN 추정
- **KEDA threshold 확정은 Stadium Go 전환 후 재측정**으로 미룸

## 📄 상세
`goti-team-controller/docs/load-test/2026-04-12-capacity-planning-keda.md`

## ↩️ 적용 후
- 다음 ASG 기동 시 ticketing KEDA ScaledObject 자동 생성
- Prometheus RPS 기반 trigger (threshold 50) 재활성