### PR TITLE
[FEAT] goti-queue-go prod-gcp 배포 추가

### DIFF
--- a/environments/prod-gcp/goti-queue/values.yaml
+++ b/environments/prod-gcp/goti-queue/values.yaml
@@ -1,0 +1,193 @@
+# TODO(jwks-automation): user-service JWT 키 회전 시 본 파일 inline jwks를
+# 모든 Go 서비스(현재 6개)와 수동 동기화 필요. ConfigMap 또는
+# RequestAuthentication.jwksUri 참조 방식으로 자동화 예정.
+# 메모리: project_jwks_automation_todo.md
+nameOverride: goti-queue
+
+image:
+  repository: "asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/goti-queue-go"
+  tag: "bootstrap-20260413"  # CD 실행 시 gcp-N-SHA 로 auto-update
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []  # GKE Workload Identity → Artifact Registry 자동 인증
+
+service:
+  type: ClusterIP
+  port: 8080
+  name: http
+
+serviceMonitor:
+  enabled: true
+  port: http
+  path: /metrics
+  interval: 15s
+  release: kube-prometheus-stack-prod-gcp
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 1000m
+    memory: 256Mi
+
+pdb:
+  enabled: true
+  minAvailable: 1
+
+# prod-gcp에는 Java goti-queue가 배포돼 있지 않으므로 VS 충돌 없음 → 즉시 활성화.
+gateway:
+  enabled: true
+  hosts:
+    - "go-ti.shop"
+    - "api.go-ti.shop"
+  gatewayRef: "istio-system/goti-shared-gateway"
+  httpRoutes:
+    - match:
+        - uri:
+            prefix: "/api/v1/queue"
+      timeout: 10s
+      retries:
+        attempts: 2
+        perTryTimeout: 5s
+        retryOn: 5xx,reset,connect-failure
+      route:
+        - destination:
+            host: goti-queue-prod
+            port:
+              number: 8080
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 10
+  keda:
+    enabled: true
+    cooldownPeriod: 300
+    triggers:
+      # 경기 시간대 사전 scale-up (CDN 대기열 특성상 시작 전 대량 진입)
+      - type: cron
+        metadata:
+          timezone: "Asia/Seoul"
+          start: "30 10 * * *"
+          end: "0 13 * * *"
+          desiredReplicas: "4"
+      - type: prometheus
+        metadata:
+          serverAddress: http://mimir-prod-query-frontend.monitoring.svc.cluster.local:8080/prometheus
+          metricName: http_rps_queue_go
+          query: sum(rate(http_server_request_duration_seconds_count{service_name="goti-queue-go"}[1m]))
+          threshold: "50"
+
+probes:
+  liveness:
+    httpGet:
+      path: /healthz
+      port: http
+    initialDelaySeconds: 3
+    periodSeconds: 10
+    failureThreshold: 3
+  readiness:
+    httpGet:
+      path: /readyz
+      port: http
+    initialDelaySeconds: 3
+    periodSeconds: 5
+    failureThreshold: 3
+
+podAnnotations:
+  sidecar.istio.io/inject: "true"
+  # Memorystore Redis TLS+AUTH — Istio mTLS와 충돌하므로 sidecar 우회
+  traffic.sidecar.istio.io/excludeOutboundPorts: "6379"
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  fsGroup: 65532
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop: ["ALL"]
+  seccompProfile:
+    type: RuntimeDefault
+
+# 환경변수: QUEUE_ prefix (Viper가 config.Load("queue")에서 자동 생성)
+env:
+  # --- 인프라 (Secret에서 주입) ---
+  - name: QUEUE_DATABASE_URL
+    valueFrom:
+      secretKeyRef:
+        name: goti-queue-prod-gcp-secrets
+        key: DATASOURCE_URL
+  - name: QUEUE_REDIS_URL
+    valueFrom:
+      secretKeyRef:
+        name: goti-queue-prod-gcp-secrets
+        key: REDIS_URL
+  - name: QUEUE_JWT_PUBLIC_KEY_PEM
+    valueFrom:
+      secretKeyRef:
+        name: goti-queue-prod-gcp-secrets
+        key: JWT_PUBLIC_KEY_PEM
+  # --- DB pool (Cloud SQL 공유, Go 6서비스) ---
+  - name: QUEUE_DATABASE_MAX_CONNS
+    value: "3"
+  - name: QUEUE_DATABASE_MIN_CONNS
+    value: "1"
+  - name: QUEUE_DATABASE_MAX_CONN_IDLE_TIME_SEC
+    value: "30"
+  - name: QUEUE_DATABASE_MAX_CONN_LIFETIME_SEC
+    value: "1800"
+  # --- 애플리케이션 ---
+  - name: QUEUE_MAX_CAPACITY
+    value: "3000"
+  # --- OTel ---
+  - name: QUEUE_OTEL_ENABLED
+    value: "true"
+  - name: QUEUE_OTEL_ENDPOINT
+    value: "http://otel-collector.monitoring.svc.cluster.local:4317"
+  - name: QUEUE_OTEL_SERVICE_NAME
+    value: "goti-queue-go"
+  - name: OTEL_SERVICE_NAME
+    value: "goti-queue-go"
+  - name: OTEL_EXPORTER_OTLP_ENDPOINT
+    value: "http://otel-collector.monitoring.svc.cluster.local:4317"
+
+configMap:
+  enabled: false
+
+externalSecret:
+  enabled: true
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: gcp-store
+    kind: ClusterSecretStore
+  remoteRef:
+    nameRegexp: "^goti-prod-server-"
+    nameRewriteSource: "^goti-prod-server-(.*)$"
+    overrideNameRegexp: "^goti-prod-queue-"
+    overrideNameRewriteSource: "^goti-prod-queue-(.*)$"
+
+# --- Istio 보안/네트워크 정책 ---
+istioPolicy:
+  # queue는 Gateway로만 접근 (서비스 간 호출 없음)
+  authorizationPolicy:
+    enabled: false
+  requestAuthentication:
+    enabled: true
+    issuer: "goti-user-service"
+    jwks: '{"keys":[{"alg":"RS256","kty":"RSA","kid":"goti-jwt-key-1","e":"AQAB","use":"sig","n":"tXlfiSkDgSujDP6wUyQc57RrUGkTK6x3Fe-W5VhZhBumzDDoRNglcZ3C9AY_iF9GdlZOgcUdKLEVplLuEZGQpHUdA5CwgzQkwNXs242Mgo6QyHGdbDXZXEhe42vl1gcdgnahY7UQLcWGUr6--Fuc5G2LMW6rlTGwagT05SKzGRbTRef3gt8D8_hdsp654vnrdW2ReRQltnffHR9XL8buuKIduGW5vfiCVtNRFsaiT_o0SA86a5gK9qmXUGJIDPLc9onZ3v6G8gtFOES4MmR0elT2VTf22tM0GeIhnDOrjVRBa5I-M6c4OTMDrmeHKhUJygj-rjfNT5effpQzUz0_Xw"}]}'
+  jwtAuthorizationPolicy:
+    enabled: false
+  destinationRule:
+    enabled: true
+  sidecar:
+    enabled: true
+    egress:
+      - hosts:
+          - "istio-system/*"
+          - "./*"
+          - "monitoring/*"
+          - "~/*.googleapis.com"

--- a/gitops/prod-gcp/applicationsets/goti-msa-appset.yaml
+++ b/gitops/prod-gcp/applicationsets/goti-msa-appset.yaml
@@ -23,6 +23,9 @@ spec:
           - service: resale
             namespace: goti
             valuesFile: environments/prod-gcp/goti-resale/values.yaml
+          - service: queue
+            namespace: goti
+            valuesFile: environments/prod-gcp/goti-queue/values.yaml
   template:
     metadata:
       name: "goti-{{service}}-prod-gcp"


### PR DESCRIPTION
## 관련 이슈
- Closes #

## 개요
GCP prod-gcp 환경에서 `goti-queue` 서비스가 완전히 누락된 상태 복구. `/api/v1/queue/*` API 전부 404 상태였음. Go 포팅은 `Goti-go/cmd/queue/main.go` + `internal/queue/` 로 이미 완료된 상태여서 Helm values + ApplicationSet 엔트리만 추가하면 됨.

## 작업 내용
- [x] `environments/prod-gcp/goti-queue/values.yaml` 신규
  - AWS prod `goti-queue-go/values.yaml` 기반
  - image repo: `asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/goti-queue-go`
  - tag: `bootstrap-20260413` (placeholder — CD 워크플로 `cd-queue-gcp.yml`이 `gcp-N-SHA`로 자동 PR 업데이트)
  - `gateway.enabled=true`: prod-gcp에 Java goti-queue 미배포 → VS 충돌 없음
  - VS destination: `goti-queue-prod:8080`, prefix `/api/v1/queue`, timeout 10s, retries 2x5s
  - KEDA: cron(Asia/Seoul 10:30-13:00 desiredReplicas=4) + prometheus(http_rps_queue_go threshold=50)
  - Memorystore Redis TLS 대응: `traffic.sidecar.istio.io/excludeOutboundPorts: "6379"`
  - ESO: `gcp-store` ClusterSecretStore에서 `goti-prod-server-*` → `goti-prod-queue-*` rewrite
  - Istio: RequestAuthentication 활성화 (inline JWKS, 다른 Go 서비스와 동일 키), authorizationPolicy/jwtAuthorizationPolicy=false (CDN 대기열 특성상 미인증 `global-status` 포함)
- [x] `gitops/prod-gcp/applicationsets/goti-msa-appset.yaml` 에 `queue` 엔트리 추가

## 블록/의존성
1. **선행**: Goti-go `deploy/queue-gcp` 브랜치 push → `cd-queue-gcp.yml` 실행 → GAR에 이미지 푸시 → Goti-k8s 자동 PR(`chore/queue-go-gcp-N-SHA`) 생성
2. 본 PR 머지 후 → 선행 CD 자동 PR(tag 교체) 머지 → ArgoCD sync → pod Running

## 테스트
- [ ] `helm lint` 통과
- [ ] `helm template` 렌더링 검증
- [ ] ArgoCD sync 확인 (merge 후)
- [ ] `kubectl get pods -n goti -l app.kubernetes.io/name=goti-queue` Running
- [ ] `/healthz`, `/readyz`, `/metrics` 응답
- [ ] `curl https://api.go-ti.shop/api/v1/queue/<gameId>/global-status` (no-auth)
- [ ] Grafana `http_rps_queue_go` 메트릭 수집 확인