### PR TITLE
[FIX] goti-queue-go amd64 이미지 태그 교체

### DIFF
--- a/environments/prod-gcp/goti-queue/values.yaml
+++ b/environments/prod-gcp/goti-queue/values.yaml
@@ -6,7 +6,7 @@ nameOverride: goti-queue
 
 image:
   repository: "asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/goti-queue-go"
-  tag: "bootstrap-20260413"  # CD 실행 시 gcp-N-SHA 로 auto-update
+  tag: "bootstrap-20260414-amd64"  # linux/amd64 buildx 재빌드 (기존 bootstrap-20260413은 arm64로 잘못 푸시됨). CD 실행 시 gcp-N-SHA 로 auto-update
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []  # GKE Workload Identity → Artifact Registry 자동 인증


### PR DESCRIPTION
## 관련 이슈
- Follow-up of #198

## 개요
#198 머지 후 `goti-queue-prod-gcp` pod가 `ErrImagePull: no match for platform in manifest`로 실패. 원인: Mac(arm64)에서 `docker build`로 수동 푸시한 `bootstrap-20260413` 이미지가 arm64 manifest였음. GKE 노드(amd64)와 불일치.

## 작업 내용
- [x] `docker buildx --platform linux/amd64` 로 재빌드 → `bootstrap-20260414-amd64` 태그로 GAR 푸시 완료
- [x] values.yaml image.tag 업데이트

## 왜 새 태그?
Artifact Registry에 **tag immutability** 활성화 → 기존 `bootstrap-20260413` 덮어쓰기 불가.

## 테스트
- [ ] ArgoCD sync → pod Running 확인
- [ ] `/healthz`, `/readyz` 응답