### PR TITLE
[CHORE] prod-gcp falco 일시 비활성화 (CPU quota 압박)

### DIFF
--- a/clusters/prod-gcp/bootstrap/root-app.yaml
+++ b/clusters/prod-gcp/bootstrap/root-app.yaml
@@ -81,6 +81,7 @@ spec:
 #      network-policies/**                   → GCP 버전은 goti-gcp-infra에서 처리
 #      external-secrets/config-application.yaml → AWS SSM 기반 config
 #      gcp/**                                → raw manifest, goti-gcp-infra에서 처리
+#      falco/**                              → 일시 비활성화 (CPU quota 압박, CPUS_ALL_REGIONS 16 한도, 2026-04-13~)
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -97,7 +98,7 @@ spec:
     directory:
       recurse: true
       include: "*application.yaml"
-      exclude: "{karpenter/**,metrics-server/**,storage/**,network-policies/**,external-secrets/config-application.yaml,gcp/**}"
+      exclude: "{karpenter/**,metrics-server/**,storage/**,network-policies/**,external-secrets/config-application.yaml,gcp/**,falco/**}"
   destination:
     server: "https://kubernetes.default.svc"
     namespace: argocd


### PR DESCRIPTION
## 관련 이슈
- CPU quota `CPUS_ALL_REGIONS` = 16 한도에 걸려 노드 scale-up 불가
- GCP 무료→유료 전환 직후 기본 quota, 증설 요청 pending

## 개요
prod-gcp 클러스터 falco DaemonSet 제거로 CPU 약 600m 확보. queue, monitoring pod 스케줄링 공간 확보용.

## 작업 내용
- `clusters/prod-gcp/bootstrap/root-app.yaml` 의 `goti-gcp-infra-ops` exclude 패턴에 `falco/**` 추가
- AWS prod는 별도 root-app 사용 → 영향 없음

## 영향
- (+) CPU 여유 ~600m 확보
- (−) runtime 보안(syscall 이상행위 탐지) 일시 중단. prod-gcp는 아직 외부 트래픽 없음
- CPU quota 증설되면 exclude 패턴에서 `falco/**` 제거 → 자동 복구

## 테스트
- [ ] merge 후 ArgoCD에서 `falco` Application 자동 prune 확인
- [ ] falco daemonset 제거 확인: `kubectl get ds -n falco`
- [ ] queue pod Running 전환 확인