### PR TITLE
[CHORE] prod-gcp 모니터링 스택 전체 일시 비활성화

### DIFF
--- a/gitops/prod-gcp/applicationsets/monitoring-appset.yaml
+++ b/gitops/prod-gcp/applicationsets/monitoring-appset.yaml
@@ -13,24 +13,28 @@ spec:
               elements:
                 - env: prod-gcp
           - list:
-              elements:
-                - component: kube-prometheus-stack
-                  chartRepo: https://prometheus-community.github.io/helm-charts
-                  chartName: kube-prometheus-stack
-                  chartVersion: "82.4.3"
-                  valuesFile: values-stacks/prod/kube-prometheus-stack-values.yaml
-                - component: prometheus-blackbox-exporter
-                  chartRepo: https://prometheus-community.github.io/helm-charts
-                  chartName: prometheus-blackbox-exporter
-                  chartVersion: "9.5.0"
-                  valuesFile: values-stacks/prod/blackbox-exporter-values.yaml
-                - component: loki
-                  chartRepo: https://grafana.github.io/helm-charts
-                  chartName: loki
-                  chartVersion: "6.53.0"
-                  valuesFile: values-stacks/prod/loki-values.yaml
-                # tempo/mimir/pyroscope: SSD_TOTAL_GB 300GB 쿼터 헤드룸 확보 위해 bring-up 기간 임시 제거.
-                # 쿼터 상향(≥500GB) 후 복구. 이슈: 2026-04-13 bring-up
+              # 전체 모니터링 스택 일시 비활성화 — 2026-04-13 bring-up
+              # 원인: SSD_TOTAL_GB=300 (free→paid 전환 직후 quota), CPU 압박
+              # server/Go 서비스 동작 검증 우선. quota 증설 후 순차 복구:
+              #   1) SSD 500GB+ 승인 → kube-prometheus-stack, loki 복구
+              #   2) SSD 1000GB+ 승인 → tempo, mimir, pyroscope 복구
+              #   3) otel-collector: app OTel 송신 정상화 후 복구
+              elements: []
+                # - component: kube-prometheus-stack
+                #   chartRepo: https://prometheus-community.github.io/helm-charts
+                #   chartName: kube-prometheus-stack
+                #   chartVersion: "82.4.3"
+                #   valuesFile: values-stacks/prod/kube-prometheus-stack-values.yaml
+                # - component: prometheus-blackbox-exporter
+                #   chartRepo: https://prometheus-community.github.io/helm-charts
+                #   chartName: prometheus-blackbox-exporter
+                #   chartVersion: "9.5.0"
+                #   valuesFile: values-stacks/prod/blackbox-exporter-values.yaml
+                # - component: loki
+                #   chartRepo: https://grafana.github.io/helm-charts
+                #   chartName: loki
+                #   chartVersion: "6.53.0"
+                #   valuesFile: values-stacks/prod/loki-values.yaml
                 # - component: tempo
                 #   chartRepo: https://grafana-community.github.io/helm-charts
                 #   chartName: tempo
@@ -46,16 +50,16 @@ spec:
                 #   chartName: pyroscope
                 #   chartVersion: "1.18.1"
                 #   valuesFile: values-stacks/prod/pyroscope-values.yaml
-                - component: otel-collector-front
-                  chartRepo: https://open-telemetry.github.io/opentelemetry-helm-charts
-                  chartName: opentelemetry-collector
-                  chartVersion: "0.147.1"
-                  valuesFile: values-stacks/prod/otel-collector-front-values.yaml
-                - component: otel-collector-back
-                  chartRepo: https://open-telemetry.github.io/opentelemetry-helm-charts
-                  chartName: opentelemetry-collector
-                  chartVersion: "0.147.1"
-                  valuesFile: values-stacks/prod/otel-collector-back-values.yaml
+                # - component: otel-collector-front
+                #   chartRepo: https://open-telemetry.github.io/opentelemetry-helm-charts
+                #   chartName: opentelemetry-collector
+                #   chartVersion: "0.147.1"
+                #   valuesFile: values-stacks/prod/otel-collector-front-values.yaml
+                # - component: otel-collector-back
+                #   chartRepo: https://open-telemetry.github.io/opentelemetry-helm-charts
+                #   chartName: opentelemetry-collector
+                #   chartVersion: "0.147.1"
+                #   valuesFile: values-stacks/prod/otel-collector-back-values.yaml
   template:
     metadata:
       name: "{{component}}-{{env}}"


### PR DESCRIPTION
## 관련 이슈
- SSD quota 300GB + CPU 압박으로 goti MSA pod 스케줄링 불가 (#198/#199 queue 포함)
- bring-up 기간 app 동작 검증 우선

## 개요
`monitoring-appset.yaml` 의 components list를 전부 comment 처리. ApplicationSet이 빈 리스트를 generate → 기존 monitoring Application들 prune → Loki/Prometheus/Grafana/OTel Collector 등 일괄 제거.

## 작업 내용
- [x] `gitops/prod-gcp/applicationsets/monitoring-appset.yaml` elements: []

## 기대 효과
- CPU ≈ 960m 회수 (monitoring namespace 전체)
- SSD 추가 확보 (Loki/Prometheus PVC 해제)
- goti-queue/payment/user Pending pod 스케줄링 성공

## 복구 계획
SSD quota 증설 단계별로 순차 복구:
1. SSD 500GB+ 승인 → kube-prometheus-stack, loki
2. SSD 1000GB+ 승인 → tempo, mimir, pyroscope
3. app OTel 송신 검증 완료 후 → otel-collector

## 테스트
- [ ] ArgoCD에서 monitoring-stack-gcp ApplicationSet이 Application 전부 prune
- [ ] `kubectl get pods -n monitoring` 비어있음 확인
- [ ] queue pod Running 전환 확인