### PR TITLE
[FIX] goti-ticketing viperfix 이미지 태그 교체

### DIFF
--- a/environments/prod-gcp/goti-ticketing/values.yaml
+++ b/environments/prod-gcp/goti-ticketing/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 2
 
 image:
   repository: "asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/goti-ticketing-go"
-  tag: "bootstrap-20260413"
+  tag: "bootstrap-20260414-viperfix"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []  # GKE Workload Identity → Artifact Registry 자동 인증


### PR DESCRIPTION
## 관련 이슈
- Goti-go PR: ressKim-io/Goti-go#fix/ticketing-viper-defaults (병합 전)
- 원 패닉: `panic: non-positive interval for NewTicker`

## 근본 원인
`pkg/config/config.go setDefaults()`에 `ticketing.*` 기본값이 누락되어 viper AutomaticEnv()가 env var를 읽지 못함 → `HoldExpiryIntervalMs=0` → `time.NewTicker(0)` panic.

664a39f 에서 env var만 주입했던 시도가 무효했던 이유.

## 작업 내용
- [x] Goti-go `pkg/config/config.go` 에 ticketing.* 10개 default 추가 + guard 추가 (별도 PR)
- [x] `linux/amd64` buildx 로 `bootstrap-20260414-viperfix` 태그 GAR 푸시
- [x] `environments/prod-gcp/goti-ticketing/values.yaml` tag 업데이트

## 테스트
- [ ] ArgoCD sync → pod Running (CrashLoop 해소)
- [ ] `kubectl logs goti-ticketing-... goti-server` 에서 scheduler 정상 시작 로그