### PR TITLE
[FEAT] prod-gcp gateway hosts에 gcp-api.go-ti.shop 추가

### DIFF
--- a/environments/prod-gcp/goti-payment/values.yaml
+++ b/environments/prod-gcp/goti-payment/values.yaml
@@ -99,6 +99,7 @@ gateway:
   hosts:
     - "go-ti.shop"
     - "api.go-ti.shop"
+    - "gcp-api.go-ti.shop"
   gatewayRef: "istio-system/goti-shared-gateway"
   httpRoutes:
     - match:

--- a/environments/prod-gcp/goti-queue-gate/values.yaml
+++ b/environments/prod-gcp/goti-queue-gate/values.yaml
@@ -67,6 +67,7 @@ gateway:
   hosts:
     - "go-ti.shop"
     - "api.go-ti.shop"
+    - "gcp-api.go-ti.shop"
   gatewayRef: "istio-system/goti-shared-gateway"
   httpRoutes:
     - match:

--- a/environments/prod-gcp/goti-queue/values.yaml
+++ b/environments/prod-gcp/goti-queue/values.yaml
@@ -41,6 +41,7 @@ gateway:
   hosts:
     - "go-ti.shop"
     - "api.go-ti.shop"
+    - "gcp-api.go-ti.shop"
   gatewayRef: "istio-system/goti-shared-gateway"
   httpRoutes:
     - match:

--- a/environments/prod-gcp/goti-resale/values.yaml
+++ b/environments/prod-gcp/goti-resale/values.yaml
@@ -104,6 +104,7 @@ gateway:
   hosts:
     - "go-ti.shop"
     - "api.go-ti.shop"
+    - "gcp-api.go-ti.shop"
   gatewayRef: "istio-system/goti-shared-gateway"
   httpRoutes:
     - match:

--- a/environments/prod-gcp/goti-stadium/values.yaml
+++ b/environments/prod-gcp/goti-stadium/values.yaml
@@ -99,6 +99,7 @@ gateway:
   hosts:
     - "go-ti.shop"
     - "api.go-ti.shop"
+    - "gcp-api.go-ti.shop"
   gatewayRef: "istio-system/goti-shared-gateway"
   httpRoutes:
     - match:

--- a/environments/prod-gcp/goti-ticketing/values.yaml
+++ b/environments/prod-gcp/goti-ticketing/values.yaml
@@ -123,6 +123,7 @@ gateway:
   hosts:
     - "go-ti.shop"
     - "api.go-ti.shop"
+    - "gcp-api.go-ti.shop"
   gatewayRef: "istio-system/goti-shared-gateway"
   httpRoutes:
     - match:

--- a/environments/prod-gcp/goti-user/values.yaml
+++ b/environments/prod-gcp/goti-user/values.yaml
@@ -147,6 +147,7 @@ gateway:
   hosts:
     - "go-ti.shop"
     - "api.go-ti.shop"
+    - "gcp-api.go-ti.shop"
   gatewayRef: "istio-system/goti-shared-gateway"
   httpRoutes:
     - match:


### PR DESCRIPTION
## 개요
GCP 전용 DNS hostname `gcp-api.go-ti.shop` 을 Istio VirtualService hosts에 추가. 프로덕션 `api.go-ti.shop` 에 영향 없이 GCP origin 직접 접근 가능.

## 작업 내용
- 7개 MSA values.yaml (stadium/queue-gate/queue/payment/user/resale/ticketing) gateway.hosts 에 추가
- DNS: Cloudflare `gcp-api.go-ti.shop` A 34.22.80.226 Proxied (사용자 설정 완료)

## 테스트
- [ ] ArgoCD sync → VS 업데이트
- [ ] `curl -I https://gcp-api.go-ti.shop/api/v1/stadium/teams` 200
- [ ] 기존 `api.go-ti.shop` 영향 없음 확인