### PR TITLE
[FIX] prod-gcp VS gatewayRef namespace + destination host 교정

### DIFF
--- a/environments/prod-gcp/goti-payment/values.yaml
+++ b/environments/prod-gcp/goti-payment/values.yaml
@@ -100,14 +100,14 @@ gateway:
     - "go-ti.shop"
     - "api.go-ti.shop"
     - "gcp-api.go-ti.shop"
-  gatewayRef: "istio-system/goti-shared-gateway"
+  gatewayRef: "istio-ingress/goti-shared-gateway"
   httpRoutes:
     - match:
         - uri:
             prefix: "/api/v1/payments"
       route:
         - destination:
-            host: goti-payment-prod
+            host: goti-payment-prod-gcp
             port:
               number: 8080
 

--- a/environments/prod-gcp/goti-queue-gate/values.yaml
+++ b/environments/prod-gcp/goti-queue-gate/values.yaml
@@ -68,14 +68,14 @@ gateway:
     - "go-ti.shop"
     - "api.go-ti.shop"
     - "gcp-api.go-ti.shop"
-  gatewayRef: "istio-system/goti-shared-gateway"
+  gatewayRef: "istio-ingress/goti-shared-gateway"
   httpRoutes:
     - match:
         - uri:
             prefix: "/gate"
       route:
         - destination:
-            host: goti-queue-gate-prod
+            host: goti-queue-gate-prod-gcp
             port:
               number: 8080
 

--- a/environments/prod-gcp/goti-queue/values.yaml
+++ b/environments/prod-gcp/goti-queue/values.yaml
@@ -42,7 +42,7 @@ gateway:
     - "go-ti.shop"
     - "api.go-ti.shop"
     - "gcp-api.go-ti.shop"
-  gatewayRef: "istio-system/goti-shared-gateway"
+  gatewayRef: "istio-ingress/goti-shared-gateway"
   httpRoutes:
     - match:
         - uri:
@@ -54,7 +54,7 @@ gateway:
         retryOn: 5xx,reset,connect-failure
       route:
         - destination:
-            host: goti-queue-prod
+            host: goti-queue-prod-gcp
             port:
               number: 8080
 

--- a/environments/prod-gcp/goti-resale/values.yaml
+++ b/environments/prod-gcp/goti-resale/values.yaml
@@ -105,14 +105,14 @@ gateway:
     - "go-ti.shop"
     - "api.go-ti.shop"
     - "gcp-api.go-ti.shop"
-  gatewayRef: "istio-system/goti-shared-gateway"
+  gatewayRef: "istio-ingress/goti-shared-gateway"
   httpRoutes:
     - match:
         - uri:
             prefix: "/api/v1/resales"
       route:
         - destination:
-            host: goti-resale-prod
+            host: goti-resale-prod-gcp
             port:
               number: 8080
 

--- a/environments/prod-gcp/goti-stadium/values.yaml
+++ b/environments/prod-gcp/goti-stadium/values.yaml
@@ -100,7 +100,7 @@ gateway:
     - "go-ti.shop"
     - "api.go-ti.shop"
     - "gcp-api.go-ti.shop"
-  gatewayRef: "istio-system/goti-shared-gateway"
+  gatewayRef: "istio-ingress/goti-shared-gateway"
   httpRoutes:
     - match:
         - uri:
@@ -109,7 +109,7 @@ gateway:
             prefix: "/api/v1/baseball-teams"
       route:
         - destination:
-            host: goti-stadium-prod
+            host: goti-stadium-prod-gcp
             port:
               number: 8080
 

--- a/environments/prod-gcp/goti-ticketing/values.yaml
+++ b/environments/prod-gcp/goti-ticketing/values.yaml
@@ -124,7 +124,7 @@ gateway:
     - "go-ti.shop"
     - "api.go-ti.shop"
     - "gcp-api.go-ti.shop"
-  gatewayRef: "istio-system/goti-shared-gateway"
+  gatewayRef: "istio-ingress/goti-shared-gateway"
   httpRoutes:
     - match:
         - uri:
@@ -147,7 +147,7 @@ gateway:
             prefix: "/api/v1/stadiums/"
       route:
         - destination:
-            host: goti-ticketing-prod
+            host: goti-ticketing-prod-gcp
             port:
               number: 8080
 

--- a/environments/prod-gcp/goti-user/values.yaml
+++ b/environments/prod-gcp/goti-user/values.yaml
@@ -148,7 +148,7 @@ gateway:
     - "go-ti.shop"
     - "api.go-ti.shop"
     - "gcp-api.go-ti.shop"
-  gatewayRef: "istio-system/goti-shared-gateway"
+  gatewayRef: "istio-ingress/goti-shared-gateway"
   httpRoutes:
     - match:
         - uri:
@@ -159,7 +159,7 @@ gateway:
             prefix: "/api/v1/test"
       route:
         - destination:
-            host: goti-user-prod
+            host: goti-user-prod-gcp
             port:
               number: 8080
 


### PR DESCRIPTION
## 문제
Cloudflare → Istio 경로 요청이 전부 404. 원인 2가지:
1. `gatewayRef: istio-system/goti-shared-gateway` → 실제 `istio-ingress` namespace
2. `destination.host: goti-{svc}-prod` → 실제 Service `goti-{svc}-prod-gcp` (Helm release name 기반)

## 테스트
- [ ] merge+sync 후 `curl https://gcp-api.go-ti.shop/api/v1/baseball-teams` → 200
- [ ] 각 서비스 route prefix 확인