### PR TITLE
[FIX] prod-gcp goti-istio-policy 추가 (403 RBAC 해결)

### DIFF
--- a/gitops/prod-gcp/applicationsets/goti-istio-policy.yaml
+++ b/gitops/prod-gcp/applicationsets/goti-istio-policy.yaml
@@ -1,0 +1,36 @@
+# Goti namespace Istio 정책 (prod-gcp)
+# deny-all + allow rules + ServiceEntry를 하나의 Helm chart로 원자적 배포.
+# AWS prod와 동일 chart, values만 GCP 오버라이드 (Gateway SA namespace 차이).
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: goti-istio-policy-gcp
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/compare-options: ServerSideDiff=true
+spec:
+  project: goti
+  sources:
+    - repoURL: "https://github.com/Team-Ikujo/Goti-k8s.git"
+      targetRevision: main
+      path: "infrastructure/prod/istio/goti-policy"
+      helm:
+        valueFiles:
+          - values.yaml
+          - values-gcp.yaml
+  destination:
+    server: "https://kubernetes.default.svc"
+    namespace: goti
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    retry:
+      limit: 5
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 3m
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/infrastructure/prod/istio/goti-policy/values-gcp.yaml
+++ b/infrastructure/prod/istio/goti-policy/values-gcp.yaml
@@ -1,0 +1,7 @@
+# GCP prod 오버라이드: Istio Gateway가 istio-ingress namespace에 배포되어
+# SA principal이 AWS(istio-system)와 다름. allowGateway ALLOW가 매칭되지
+# 않아 default-deny → 403 RBAC access denied 발생.
+
+allowGateway:
+  enabled: true
+  gatewaySA: "cluster.local/ns/istio-ingress/sa/istio-gateway"


### PR DESCRIPTION
## 문제
Cloudflare 경유 모든 API 요청 403 RBAC access denied. 직접 LB 경유도 동일.

## 근본 원인
1. `goti-istio-policy` ApplicationSet이 prod-gcp 부재 → `allow-istio-gateway` AP 미생성
2. goti-common chart가 `from-mesh-internal` ALLOW 자동 생성 → Istio default-deny 활성화
3. Gateway→서비스 트래픽 허용하는 ALLOW 없음 → 거부

## 수정
- 신규 `gitops/prod-gcp/applicationsets/goti-istio-policy.yaml` (AWS prod 버전 복제)
- 신규 `infrastructure/prod/istio/goti-policy/values-gcp.yaml`: Gateway SA namespace `istio-system` → `istio-ingress` (GCP 차이점)

## 테스트
- [ ] merge+sync 후 `allow-istio-gateway` AP 생성 확인
- [ ] `curl https://gcp-api.go-ti.shop/api/v1/auth/login` 403 해소 확인