### PR TITLE
[FIX] prod-gcp inter-service URL 교정 + payment 누락 env 추가 (WIP)

### DIFF
--- a/environments/prod-gcp/goti-payment/values.yaml
+++ b/environments/prod-gcp/goti-payment/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 2
 
 image:
   repository: "asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/goti-payment-go"
-  tag: "bootstrap-20260413"
+  tag: "bootstrap-20260414-servicesfix"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []  # GKE Workload Identity → Artifact Registry 자동 인증

--- a/environments/prod-gcp/goti-payment/values.yaml
+++ b/environments/prod-gcp/goti-payment/values.yaml
@@ -90,6 +90,11 @@ env:
     value: "goti-payment-go"
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
     value: "http://otel-collector.monitoring.svc.cluster.local:4317"
+  # --- 서비스 간 통신 (payment → ticketing, resale) ---
+  - name: PAYMENT_SERVICES_TICKETING
+    value: "http://goti-ticketing-prod-gcp.goti.svc.cluster.local:8080"
+  - name: PAYMENT_SERVICES_RESALE
+    value: "http://goti-resale-prod-gcp.goti.svc.cluster.local:8080"
 
 configMap:
   enabled: false

--- a/environments/prod-gcp/goti-resale/values.yaml
+++ b/environments/prod-gcp/goti-resale/values.yaml
@@ -81,9 +81,9 @@ env:
         key: JWT_PUBLIC_KEY_PEM
   # --- 서비스 간 통신 ---
   - name: RESALE_SERVICES_TICKETING
-    value: "http://goti-ticketing-prod.goti.svc.cluster.local:8080"
+    value: "http://goti-ticketing-prod-gcp.goti.svc.cluster.local:8080"
   - name: RESALE_SERVICES_PAYMENT
-    value: "http://goti-payment-prod.goti.svc.cluster.local:8080"
+    value: "http://goti-payment-prod-gcp.goti.svc.cluster.local:8080"
   # --- OTel ---
   - name: RESALE_OTEL_ENABLED
     value: "true"

--- a/environments/prod-gcp/goti-resale/values.yaml
+++ b/environments/prod-gcp/goti-resale/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 
 image:
   repository: "asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/goti-resale-go"
-  tag: "bootstrap-20260413"
+  tag: "bootstrap-20260414-servicesfix"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []  # GKE Workload Identity → Artifact Registry 자동 인증

--- a/environments/prod-gcp/goti-ticketing/values.yaml
+++ b/environments/prod-gcp/goti-ticketing/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 2
 
 image:
   repository: "asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/goti-ticketing-go"
-  tag: "bootstrap-20260414-viperfix"
+  tag: "bootstrap-20260414-servicesfix"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []  # GKE Workload Identity → Artifact Registry 자동 인증

--- a/environments/prod-gcp/goti-ticketing/values.yaml
+++ b/environments/prod-gcp/goti-ticketing/values.yaml
@@ -98,11 +98,11 @@ env:
     value: "5000"
   # --- 서비스 간 통신 ---
   - name: TICKETING_SERVICES_STADIUM
-    value: "http://goti-stadium-prod.goti.svc.cluster.local:8080"
+    value: "http://goti-stadium-prod-gcp.goti.svc.cluster.local:8080"
   - name: TICKETING_SERVICES_PAYMENT
-    value: "http://goti-payment-prod.goti.svc.cluster.local:8080"
+    value: "http://goti-payment-prod-gcp.goti.svc.cluster.local:8080"
   - name: TICKETING_SERVICES_RESALE
-    value: "http://goti-resale-prod.goti.svc.cluster.local:8080"
+    value: "http://goti-resale-prod-gcp.goti.svc.cluster.local:8080"
   # --- OTel ---
   - name: TICKETING_OTEL_ENABLED
     value: "true"


### PR DESCRIPTION
## 상태: WIP — 이미지 재빌드 대기
Goti-go PR #3 merged (services.* viper defaults). 본 PR은 values 수정만.
이미지 태그 `bootstrap-20260414-servicesfix` 빌드 후 values tag 업데이트 + merge 필요.

## 수정
1. ticketing/resale values의 내부 호출 URL `goti-X-prod` → `goti-X-prod-gcp`
2. payment values에 `PAYMENT_SERVICES_TICKETING/RESALE` 신규 추가 (완전 누락이었음)

## 다음 세션 작업
- [ ] Docker Desktop 켜고 `ticketing`, `payment`, `resale` 3개 이미지 amd64 buildx push
- [ ] 3개 values.yaml image.tag → `bootstrap-20260414-servicesfix` 업데이트 후 커밋
- [ ] ArgoCD sync 확인
- [ ] `/api/v1/games/schedules?today=false` 200 확인