### PR TITLE
[FIX] ticketing stadium-paths 이미지 태그 반영

### DIFF
--- a/environments/prod-gcp/goti-ticketing/values.yaml
+++ b/environments/prod-gcp/goti-ticketing/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 2
 
 image:
   repository: "asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/goti-ticketing-go"
-  tag: "bootstrap-20260414-servicesfix"
+  tag: "bootstrap-20260414-stadiumpaths"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []  # GKE Workload Identity → Artifact Registry 자동 인증


### PR DESCRIPTION
## 개요
Goti-go PR #4 반영. ticketing → stadium 내부 호출 경로/필드 정렬.

## 작업
- `goti-ticketing` tag: `bootstrap-20260414-servicesfix` → `bootstrap-20260414-stadiumpaths`

## 검증
- merge + sync 후 `/api/v1/games/schedules?today=false` 200 확인