### PR TITLE
[FIX] GCP AuthorizationPolicy principal SA suffix 정정

### DIFF
--- a/environments/prod-gcp/goti-payment/values.yaml
+++ b/environments/prod-gcp/goti-payment/values.yaml
@@ -159,7 +159,7 @@ istioPolicy:
         rules:
           - from:
               - source:
-                  principals: ["cluster.local/ns/goti/sa/goti-resale-prod"]
+                  principals: ["cluster.local/ns/goti/sa/goti-resale-prod-gcp"]
             to:
               - operation:
                   paths: ["/api/v1/resales/payments", "/api/v1/resales/payments/*"]

--- a/environments/prod-gcp/goti-resale/values.yaml
+++ b/environments/prod-gcp/goti-resale/values.yaml
@@ -153,7 +153,7 @@ istioPolicy:
         rules:
           - from:
               - source:
-                  principals: ["cluster.local/ns/goti/sa/goti-payment-prod"]
+                  principals: ["cluster.local/ns/goti/sa/goti-payment-prod-gcp"]
             to:
               - operation:
                   paths: ["/api/v1/resales/orders/*"]
@@ -162,7 +162,7 @@ istioPolicy:
         rules:
           - from:
               - source:
-                  principals: ["cluster.local/ns/goti/sa/goti-ticketing-prod"]
+                  principals: ["cluster.local/ns/goti/sa/goti-ticketing-prod-gcp"]
             to:
               - operation:
                   paths: ["/api/v1/resales/listings/count"]

--- a/environments/prod-gcp/goti-stadium/values.yaml
+++ b/environments/prod-gcp/goti-stadium/values.yaml
@@ -134,7 +134,7 @@ istioPolicy:
         rules:
           - from:
               - source:
-                  principals: ["cluster.local/ns/goti/sa/goti-ticketing-prod"]
+                  principals: ["cluster.local/ns/goti/sa/goti-ticketing-prod-gcp"]
             to:
               - operation:
                   paths: ["/api/v1/stadiums*", "/api/v1/baseball-teams*"]

--- a/environments/prod-gcp/goti-ticketing/values.yaml
+++ b/environments/prod-gcp/goti-ticketing/values.yaml
@@ -193,7 +193,7 @@ istioPolicy:
         rules:
           - from:
               - source:
-                  principals: ["cluster.local/ns/goti/sa/goti-payment-prod"]
+                  principals: ["cluster.local/ns/goti/sa/goti-payment-prod-gcp"]
             to:
               - operation:
                   paths: ["/api/v1/orders/*"]
@@ -202,7 +202,7 @@ istioPolicy:
         rules:
           - from:
               - source:
-                  principals: ["cluster.local/ns/goti/sa/goti-resale-prod"]
+                  principals: ["cluster.local/ns/goti/sa/goti-resale-prod-gcp"]
             to:
               - operation:
                   paths: ["/api/v1/tickets/resales/*", "/internal/*"]


### PR DESCRIPTION
## 개요
GCP env SA 실제 이름은 `goti-*-prod-gcp`인데 AuthorizationPolicy principal이 `goti-*-prod`로 되어 있어 모든 내부 호출이 403 RBAC denied로 실패.

## 작업
- stadium: from-ticketing principal
- payment: from-resale principal
- resale: from-payment, from-ticketing principals
- ticketing: from-payment, from-resale principals

## 검증
- merge + sync 후 `/api/v1/games/schedules?today=false` 200 확인