### PR TITLE
[FIX] payment AuthPolicy from-resale 경로 정정

### DIFF
--- a/environments/prod-gcp/goti-payment/values.yaml
+++ b/environments/prod-gcp/goti-payment/values.yaml
@@ -162,7 +162,7 @@ istioPolicy:
                   principals: ["cluster.local/ns/goti/sa/goti-resale-prod-gcp"]
             to:
               - operation:
-                  paths: ["/api/v1/resales/payments", "/api/v1/resales/payments/*"]
+                  paths: ["/api/v1/payments/resales", "/api/v1/payments/resales/*"]
                   methods: ["POST", "PATCH"]
   requestAuthentication:
     enabled: true


### PR DESCRIPTION
## 개요
Go 코드 `resale/infra/payment_client.go:45,52`는 `/api/v1/payments/resales(/*)` 호출. 기존 AuthPolicy는 `/api/v1/resales/payments`로 segment 순서 반대.

## Fix
`goti-payment/values.yaml:165` paths 순서 swap.

## 검증
resale→payment 실제 호출 시나리오(재판매 결제)는 데이터 부재로 E2E 보류. policy reflect 확인.