### PR TITLE
[CHORE] prod Go 이미지 태그 업데이트: prod-6-5577103

### DIFF
--- a/environments/prod-gcp/goti-ticketing/values.yaml
+++ b/environments/prod-gcp/goti-ticketing/values.yaml
@@ -1,25 +1,21 @@
 nameOverride: goti-ticketing
 replicaCount: 2
-
 image:
-  repository: "asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/goti-ticketing-go"
-  tag: "bootstrap-20260414-gamestatus"
+  repository: "harbor.go-ti.shop/prod/goti-ticketing-go"
+  tag: "prod-6-5577103"
   pullPolicy: IfNotPresent
-
-imagePullSecrets: []  # GKE Workload Identity → Artifact Registry 자동 인증
-
-service:
+imagePullSecrets:
+  - name: harbor-creds
+service: # GKE Workload Identity → Artifact Registry 자동 인증
   type: ClusterIP
   port: 8080
   name: http
-
 serviceMonitor:
   enabled: true
   port: http
   path: /metrics
   interval: 15s
   release: kube-prometheus-stack-prod-gcp
-
 probes:
   liveness:
     httpGet:
@@ -35,7 +31,6 @@ probes:
     initialDelaySeconds: 3
     periodSeconds: 5
     failureThreshold: 3
-
 resources:
   requests:
     cpu: 50m
@@ -43,17 +38,14 @@ resources:
   limits:
     cpu: 200m
     memory: 128Mi
-
 podAnnotations:
   sidecar.istio.io/inject: "true"
   # Memorystore Redis TLS+AUTH — Istio mTLS와 충돌하므로 sidecar 우회
   traffic.sidecar.istio.io/excludeOutboundPorts: "6379"
-
 podSecurityContext:
   runAsNonRoot: true
   runAsUser: 65532
   fsGroup: 65532
-
 securityContext:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
@@ -61,7 +53,6 @@ securityContext:
     drop: ["ALL"]
   seccompProfile:
     type: RuntimeDefault
-
 env:
   # --- 인프라 (Secret에서 주입) ---
   - name: TICKETING_DATABASE_URL
@@ -114,10 +105,8 @@ env:
     value: "goti-ticketing-go"
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
     value: "http://otel-collector.monitoring.svc.cluster.local:4317"
-
 configMap:
   enabled: false
-
 gateway:
   enabled: true
   hosts:
@@ -150,7 +139,6 @@ gateway:
             host: goti-ticketing-prod-gcp
             port:
               number: 8080
-
 autoscaling:
   enabled: true
   minReplicas: 2
@@ -164,14 +152,13 @@ autoscaling:
           timezone: "Asia/Seoul"
           start: "30 10 * * *"
           end: "0 13 * * *"
-          desiredReplicas: "3"  # Go는 cold start 빠름 (Java 6 → Go 3)
+          desiredReplicas: "3" # Go는 cold start 빠름 (Java 6 → Go 3)
       - type: prometheus
         metadata:
           serverAddress: http://mimir-prod-query-frontend.monitoring.svc:8080/prometheus
           metricName: http_rps_ticketing_go
           query: sum(rate(http_server_request_duration_seconds_count{service_name="goti-ticketing-go"}[1m]))
           threshold: "50"
-
 externalSecret:
   enabled: true
   refreshInterval: "1h"
@@ -183,7 +170,6 @@ externalSecret:
     nameRewriteSource: "^goti-prod-server-(.*)$"
     overrideNameRegexp: "^goti-prod-ticketing-"
     overrideNameRewriteSource: "^goti-prod-ticketing-(.*)$"
-
 # --- Istio 보안/네트워크 정책 ---
 istioPolicy:
   authorizationPolicy:

--- a/environments/prod/goti-ticketing-go/values.yaml
+++ b/environments/prod/goti-ticketing-go/values.yaml
@@ -1,17 +1,14 @@
 nameOverride: goti-ticketing-go
-
 service:
   type: ClusterIP
   port: 8080
   name: http
-
 serviceMonitor:
   enabled: true
   port: http
   path: /metrics
   interval: 15s
   release: kube-prometheus-stack-prod
-
 resources:
   requests:
     cpu: 100m
@@ -19,11 +16,9 @@ resources:
   limits:
     cpu: 1000m
     memory: 256Mi
-
 pdb:
   enabled: true
   minAvailable: 1
-
 # CRITICAL: Java goti-ticketing VS와 동일 (host, path) 조합 → Istio
 # MULTIPLE_VIRTUAL_SERVICES_FOR_HOST. cutover 전까지 gateway.enabled=false로 유지.
 # cutover 시 Java values의 gateway.enabled=false로 전환 후 본 파일 true.
@@ -58,7 +53,6 @@ gateway:
             host: goti-ticketing-go-prod
             port:
               number: 8080
-
 autoscaling:
   enabled: true
   minReplicas: 2
@@ -79,7 +73,6 @@ autoscaling:
           metricName: http_rps_ticketing_go
           query: sum(rate(http_server_request_duration_seconds_count{service_name="goti-ticketing-go"}[1m]))
           threshold: "50"
-
 probes:
   liveness:
     httpGet:
@@ -95,24 +88,20 @@ probes:
     initialDelaySeconds: 3
     periodSeconds: 5
     failureThreshold: 3
-
 podAnnotations:
   sidecar.istio.io/inject: "true"
   # ElastiCache Redis TLS — Istio sidecar 우회
   traffic.sidecar.istio.io/excludeOutboundPorts: "6379"
-
 podSecurityContext:
   runAsNonRoot: true
   runAsUser: 65532
   fsGroup: 65532
-
 securityContext:
   readOnlyRootFilesystem: true
   capabilities:
     drop: ["ALL"]
   seccompProfile:
     type: RuntimeDefault
-
 # 환경변수: TICKETING_ prefix (Viper가 config.Load("ticketing")에서 자동 생성)
 # envFrom 사용하지 않음 — 개별 매핑으로 명시적 관리
 env:
@@ -170,10 +159,8 @@ env:
     value: "goti-ticketing-go"
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
     value: "http://otel-collector.monitoring.svc.cluster.local:4317"
-
 configMap:
   enabled: false
-
 # --- Istio 보안/네트워크 정책 ---
 istioPolicy:
   authorizationPolicy:
@@ -219,3 +206,9 @@ istioPolicy:
       - "/metrics"
   destinationRule:
     enabled: true
+image:
+  repository: harbor.go-ti.shop/prod/goti-ticketing-go
+  tag: prod-6-5577103
+  pullPolicy: IfNotPresent
+imagePullSecrets:
+  - name: harbor-creds


### PR DESCRIPTION
## 변경 사항
- 이미지 태그: `prod-6-5577103`
- 레지스트리: `harbor.go-ti.shop/prod/`
- 업데이트된 서비스: `{"include":[{"service":"ticketing"}]}`
- 대상 환경: AWS prod (`environments/prod/goti-*-go/`) + GCP prod (`environments/prod-gcp/goti-*/`)

## 트리거
- 레포: `ressKim-io/Goti-go`
- 브랜치: `main`
- 커밋: 55771031ecbe1789a465a740041c002555c89733
- 워크플로우: [#6](https://github.com/ressKim-io/Goti-go/actions/runs/24333147981)