### PR TITLE
[CHORE] prod Go 이미지 태그 업데이트: prod-7-5577103

### DIFF
--- a/environments/prod-gcp/goti-payment/values.yaml
+++ b/environments/prod-gcp/goti-payment/values.yaml
@@ -1,25 +1,21 @@
 nameOverride: goti-payment
 replicaCount: 2
-
 image:
-  repository: "asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/goti-payment-go"
-  tag: "bootstrap-20260414-servicesfix"
+  repository: "harbor.go-ti.shop/prod/goti-payment-go"
+  tag: "prod-7-5577103"
   pullPolicy: IfNotPresent
-
-imagePullSecrets: []  # GKE Workload Identity → Artifact Registry 자동 인증
-
-service:
+imagePullSecrets:
+  - name: harbor-creds
+service: # GKE Workload Identity → Artifact Registry 자동 인증
   type: ClusterIP
   port: 8080
   name: http
-
 serviceMonitor:
   enabled: true
   port: http
   path: /metrics
   interval: 15s
   release: kube-prometheus-stack-prod-gcp
-
 probes:
   liveness:
     httpGet:
@@ -35,7 +31,6 @@ probes:
     initialDelaySeconds: 3
     periodSeconds: 5
     failureThreshold: 3
-
 resources:
   requests:
     cpu: 50m
@@ -43,17 +38,14 @@ resources:
   limits:
     cpu: 200m
     memory: 128Mi
-
 podAnnotations:
   sidecar.istio.io/inject: "true"
   # Memorystore Redis TLS+AUTH — Istio mTLS와 충돌하므로 sidecar 우회
   traffic.sidecar.istio.io/excludeOutboundPorts: "6379"
-
 podSecurityContext:
   runAsNonRoot: true
   runAsUser: 65532
   fsGroup: 65532
-
 securityContext:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
@@ -61,7 +53,6 @@ securityContext:
     drop: ["ALL"]
   seccompProfile:
     type: RuntimeDefault
-
 env:
   # --- 인프라 (Secret에서 주입) ---
   - name: PAYMENT_DATABASE_URL
@@ -95,10 +86,8 @@ env:
     value: "http://goti-ticketing-prod-gcp.goti.svc.cluster.local:8080"
   - name: PAYMENT_SERVICES_RESALE
     value: "http://goti-resale-prod-gcp.goti.svc.cluster.local:8080"
-
 configMap:
   enabled: false
-
 gateway:
   enabled: true
   hosts:
@@ -115,7 +104,6 @@ gateway:
             host: goti-payment-prod-gcp
             port:
               number: 8080
-
 autoscaling:
   enabled: true
   minReplicas: 2
@@ -129,14 +117,13 @@ autoscaling:
           timezone: "Asia/Seoul"
           start: "30 10 * * *"
           end: "0 13 * * *"
-          desiredReplicas: "2"  # Go는 cold start 빠름 (Java 4 → Go 2)
+          desiredReplicas: "2" # Go는 cold start 빠름 (Java 4 → Go 2)
       - type: prometheus
         metadata:
           serverAddress: http://mimir-prod-query-frontend.monitoring.svc:8080/prometheus
           metricName: http_rps_payment_go
           query: sum(rate(http_server_request_duration_seconds_count{service_name="goti-payment-go"}[1m]))
           threshold: "30"
-
 externalSecret:
   enabled: true
   refreshInterval: "1h"
@@ -148,7 +135,6 @@ externalSecret:
     nameRewriteSource: "^goti-prod-server-(.*)$"
     overrideNameRegexp: "^goti-prod-payment-"
     overrideNameRewriteSource: "^goti-prod-payment-(.*)$"
-
 # --- Istio 보안/네트워크 정책 ---
 istioPolicy:
   # resale → payment (양도 결제/환불)

--- a/environments/prod-gcp/goti-queue/values.yaml
+++ b/environments/prod-gcp/goti-queue/values.yaml
@@ -3,26 +3,22 @@
 # RequestAuthentication.jwksUri 참조 방식으로 자동화 예정.
 # 메모리: project_jwks_automation_todo.md
 nameOverride: goti-queue
-
 image:
-  repository: "asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/goti-queue-go"
-  tag: "bootstrap-20260414-amd64"  # linux/amd64 buildx 재빌드 (기존 bootstrap-20260413은 arm64로 잘못 푸시됨). CD 실행 시 gcp-N-SHA 로 auto-update
+  repository: "harbor.go-ti.shop/prod/goti-queue-go"
+  tag: "prod-7-5577103" # linux/amd64 buildx 재빌드 (기존 bootstrap-20260413은 arm64로 잘못 푸시됨). CD 실행 시 gcp-N-SHA 로 auto-update
   pullPolicy: IfNotPresent
-
-imagePullSecrets: []  # GKE Workload Identity → Artifact Registry 자동 인증
-
-service:
+imagePullSecrets:
+  - name: harbor-creds
+service: # GKE Workload Identity → Artifact Registry 자동 인증
   type: ClusterIP
   port: 8080
   name: http
-
 serviceMonitor:
   enabled: true
   port: http
   path: /metrics
   interval: 15s
   release: kube-prometheus-stack-prod-gcp
-
 resources:
   requests:
     cpu: 100m
@@ -30,11 +26,9 @@ resources:
   limits:
     cpu: 1000m
     memory: 256Mi
-
 pdb:
   enabled: true
   minAvailable: 1
-
 # prod-gcp에는 Java goti-queue가 배포돼 있지 않으므로 VS 충돌 없음 → 즉시 활성화.
 gateway:
   enabled: true
@@ -57,7 +51,6 @@ gateway:
             host: goti-queue-prod-gcp
             port:
               number: 8080
-
 autoscaling:
   enabled: true
   minReplicas: 2
@@ -79,7 +72,6 @@ autoscaling:
           metricName: http_rps_queue_go
           query: sum(rate(http_server_request_duration_seconds_count{service_name="goti-queue-go"}[1m]))
           threshold: "50"
-
 probes:
   liveness:
     httpGet:
@@ -95,17 +87,14 @@ probes:
     initialDelaySeconds: 3
     periodSeconds: 5
     failureThreshold: 3
-
 podAnnotations:
   sidecar.istio.io/inject: "true"
   # Memorystore Redis TLS+AUTH — Istio mTLS와 충돌하므로 sidecar 우회
   traffic.sidecar.istio.io/excludeOutboundPorts: "6379"
-
 podSecurityContext:
   runAsNonRoot: true
   runAsUser: 65532
   fsGroup: 65532
-
 securityContext:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
@@ -113,7 +102,6 @@ securityContext:
     drop: ["ALL"]
   seccompProfile:
     type: RuntimeDefault
-
 # 환경변수: QUEUE_ prefix (Viper가 config.Load("queue")에서 자동 생성)
 env:
   # --- 인프라 (Secret에서 주입) ---
@@ -155,10 +143,8 @@ env:
     value: "goti-queue-go"
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
     value: "http://otel-collector.monitoring.svc.cluster.local:4317"
-
 configMap:
   enabled: false
-
 externalSecret:
   enabled: true
   refreshInterval: "1h"
@@ -170,7 +156,6 @@ externalSecret:
     nameRewriteSource: "^goti-prod-server-(.*)$"
     overrideNameRegexp: "^goti-prod-queue-"
     overrideNameRewriteSource: "^goti-prod-queue-(.*)$"
-
 # --- Istio 보안/네트워크 정책 ---
 istioPolicy:
   # queue는 Gateway로만 접근 (서비스 간 호출 없음)

--- a/environments/prod-gcp/goti-resale/values.yaml
+++ b/environments/prod-gcp/goti-resale/values.yaml
@@ -1,25 +1,21 @@
 nameOverride: goti-resale
 replicaCount: 1
-
 image:
-  repository: "asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/goti-resale-go"
-  tag: "bootstrap-20260414-servicesfix"
+  repository: "harbor.go-ti.shop/prod/goti-resale-go"
+  tag: "prod-7-5577103"
   pullPolicy: IfNotPresent
-
-imagePullSecrets: []  # GKE Workload Identity → Artifact Registry 자동 인증
-
-service:
+imagePullSecrets:
+  - name: harbor-creds
+service: # GKE Workload Identity → Artifact Registry 자동 인증
   type: ClusterIP
   port: 8080
   name: http
-
 serviceMonitor:
   enabled: true
   port: http
   path: /metrics
   interval: 15s
   release: kube-prometheus-stack-prod-gcp
-
 probes:
   liveness:
     httpGet:
@@ -35,7 +31,6 @@ probes:
     initialDelaySeconds: 3
     periodSeconds: 5
     failureThreshold: 3
-
 resources:
   requests:
     cpu: 50m
@@ -43,17 +38,14 @@ resources:
   limits:
     cpu: 200m
     memory: 128Mi
-
 podAnnotations:
   sidecar.istio.io/inject: "true"
   # Memorystore Redis TLS+AUTH — Istio mTLS와 충돌하므로 sidecar 우회
   traffic.sidecar.istio.io/excludeOutboundPorts: "6379"
-
 podSecurityContext:
   runAsNonRoot: true
   runAsUser: 65532
   fsGroup: 65532
-
 securityContext:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
@@ -61,7 +53,6 @@ securityContext:
     drop: ["ALL"]
   seccompProfile:
     type: RuntimeDefault
-
 env:
   # --- 인프라 (Secret에서 주입) ---
   - name: RESALE_DATABASE_URL
@@ -95,10 +86,8 @@ env:
     value: "goti-resale-go"
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
     value: "http://otel-collector.monitoring.svc.cluster.local:4317"
-
 configMap:
   enabled: false
-
 gateway:
   enabled: true
   hosts:
@@ -115,7 +104,6 @@ gateway:
             host: goti-resale-prod-gcp
             port:
               number: 8080
-
 autoscaling:
   enabled: true
   minReplicas: 1
@@ -130,7 +118,6 @@ autoscaling:
           metricName: http_rps_resale_go
           query: sum(rate(http_server_request_duration_seconds_count{service_name="goti-resale-go"}[1m]))
           threshold: "20"
-
 externalSecret:
   enabled: true
   refreshInterval: "1h"
@@ -142,7 +129,6 @@ externalSecret:
     nameRewriteSource: "^goti-prod-server-(.*)$"
     overrideNameRegexp: "^goti-prod-resale-"
     overrideNameRewriteSource: "^goti-prod-resale-(.*)$"
-
 # --- Istio 보안/네트워크 정책 ---
 istioPolicy:
   # payment → resale (양도 완료/거래 조회), ticketing → resale (마이페이지 양도 조회)

--- a/environments/prod-gcp/goti-stadium/values.yaml
+++ b/environments/prod-gcp/goti-stadium/values.yaml
@@ -1,25 +1,21 @@
 nameOverride: goti-stadium
 replicaCount: 1
-
 image:
-  repository: "asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/goti-stadium-go"
-  tag: "bootstrap-20260413"
+  repository: "harbor.go-ti.shop/prod/goti-stadium-go"
+  tag: "prod-7-5577103"
   pullPolicy: IfNotPresent
-
-imagePullSecrets: []  # GKE Workload Identity → Artifact Registry 자동 인증
-
-service:
+imagePullSecrets:
+  - name: harbor-creds
+service: # GKE Workload Identity → Artifact Registry 자동 인증
   type: ClusterIP
   port: 8080
   name: http
-
 serviceMonitor:
   enabled: true
   port: http
   path: /metrics
   interval: 15s
   release: kube-prometheus-stack-prod-gcp
-
 probes:
   liveness:
     httpGet:
@@ -35,7 +31,6 @@ probes:
     initialDelaySeconds: 3
     periodSeconds: 5
     failureThreshold: 3
-
 resources:
   requests:
     cpu: 50m
@@ -43,17 +38,14 @@ resources:
   limits:
     cpu: 200m
     memory: 128Mi
-
 podAnnotations:
   sidecar.istio.io/inject: "true"
   # Memorystore Redis TLS+AUTH — Istio mTLS와 충돌하므로 sidecar 우회
   traffic.sidecar.istio.io/excludeOutboundPorts: "6379"
-
 podSecurityContext:
   runAsNonRoot: true
   runAsUser: 65532
   fsGroup: 65532
-
 securityContext:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
@@ -61,7 +53,6 @@ securityContext:
     drop: ["ALL"]
   seccompProfile:
     type: RuntimeDefault
-
 env:
   # --- 인프라 (Secret에서 주입) ---
   - name: STADIUM_DATABASE_URL
@@ -90,10 +81,8 @@ env:
     value: "goti-stadium-go"
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
     value: "http://otel-collector.monitoring.svc.cluster.local:4317"
-
 configMap:
   enabled: false
-
 gateway:
   enabled: true
   hosts:
@@ -112,7 +101,6 @@ gateway:
             host: goti-stadium-prod-gcp
             port:
               number: 8080
-
 externalSecret:
   enabled: true
   refreshInterval: "1h"
@@ -124,7 +112,6 @@ externalSecret:
     nameRewriteSource: "^goti-prod-server-(.*)$"
     overrideNameRegexp: "^goti-prod-stadium-"
     overrideNameRewriteSource: "^goti-prod-stadium-(.*)$"
-
 # --- Istio 보안/네트워크 정책 ---
 istioPolicy:
   authorizationPolicy:

--- a/environments/prod-gcp/goti-user/values.yaml
+++ b/environments/prod-gcp/goti-user/values.yaml
@@ -1,25 +1,21 @@
 nameOverride: goti-user
 replicaCount: 2
-
 image:
-  repository: "asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/goti-user-go"
-  tag: "bootstrap-20260413"
+  repository: "harbor.go-ti.shop/prod/goti-user-go"
+  tag: "prod-7-5577103"
   pullPolicy: IfNotPresent
-
-imagePullSecrets: []  # GKE Workload Identity → Artifact Registry 자동 인증
-
-service:
+imagePullSecrets:
+  - name: harbor-creds
+service: # GKE Workload Identity → Artifact Registry 자동 인증
   type: ClusterIP
   port: 8080
   name: http
-
 serviceMonitor:
   enabled: true
   port: http
   path: /metrics
   interval: 15s
   release: kube-prometheus-stack-prod-gcp
-
 probes:
   liveness:
     httpGet:
@@ -35,7 +31,6 @@ probes:
     initialDelaySeconds: 3
     periodSeconds: 5
     failureThreshold: 3
-
 resources:
   requests:
     cpu: 50m
@@ -43,17 +38,14 @@ resources:
   limits:
     cpu: 200m
     memory: 128Mi
-
 podAnnotations:
   sidecar.istio.io/inject: "true"
   # Memorystore Redis TLS+AUTH — Istio mTLS와 충돌하므로 sidecar 우회
   traffic.sidecar.istio.io/excludeOutboundPorts: "6379"
-
 podSecurityContext:
   runAsNonRoot: true
   runAsUser: 65532
   fsGroup: 65532
-
 securityContext:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
@@ -61,7 +53,6 @@ securityContext:
     drop: ["ALL"]
   seccompProfile:
     type: RuntimeDefault
-
 env:
   # --- 인프라 (Secret에서 주입) ---
   - name: USER_DATABASE_URL
@@ -138,10 +129,8 @@ env:
     value: "goti-user-go"
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
     value: "http://otel-collector.monitoring.svc.cluster.local:4317"
-
 configMap:
   enabled: false
-
 gateway:
   enabled: true
   hosts:
@@ -162,7 +151,6 @@ gateway:
             host: goti-user-prod-gcp
             port:
               number: 8080
-
 autoscaling:
   enabled: true
   minReplicas: 3
@@ -176,14 +164,13 @@ autoscaling:
           timezone: "Asia/Seoul"
           start: "50 10 * * *"
           end: "0 13 * * *"
-          desiredReplicas: "3"  # Go는 cold start 빠름 (Java 5 → Go 3)
+          desiredReplicas: "3" # Go는 cold start 빠름 (Java 5 → Go 3)
       - type: prometheus
         metadata:
           serverAddress: http://mimir-prod-query-frontend.monitoring.svc:8080/prometheus
           metricName: http_rps_user_go
           query: sum(rate(http_server_request_duration_seconds_count{service_name="goti-user-go"}[1m]))
           threshold: "40"
-
 externalSecret:
   enabled: true
   refreshInterval: "1h"
@@ -195,7 +182,6 @@ externalSecret:
     nameRewriteSource: "^goti-prod-server-(.*)$"
     overrideNameRegexp: "^goti-prod-user-"
     overrideNameRewriteSource: "^goti-prod-user-(.*)$"
-
 # --- Istio 보안/네트워크 정책 ---
 istioPolicy:
   authorizationPolicy:
@@ -228,7 +214,7 @@ istioPolicy:
           - "istio-system/*"
           - "./*"
           - "monitoring/*"
-          - "~/*.googleapis.com"   # OAuth (Google)
-          - "~/*.naver.com"        # OAuth (Naver)
-          - "~/*.kakao.com"        # OAuth (Kakao)
-          - "~/*.nurigo.com"       # SMS (CoolSMS)
+          - "~/*.googleapis.com" # OAuth (Google)
+          - "~/*.naver.com" # OAuth (Naver)
+          - "~/*.kakao.com" # OAuth (Kakao)
+          - "~/*.nurigo.com" # SMS (CoolSMS)

--- a/environments/prod/goti-payment-go/values.yaml
+++ b/environments/prod/goti-payment-go/values.yaml
@@ -1,19 +1,16 @@
 # TODO(jwks-automation): user-service JWT 키 회전 시 본 파일 inline jwks를
 # 모든 Go 서비스와 수동 동기화 필요. 메모리: project_jwks_automation_todo.md
 nameOverride: goti-payment-go
-
 service:
   type: ClusterIP
   port: 8080
   name: http
-
 serviceMonitor:
   enabled: true
   port: http
   path: /metrics
   interval: 15s
   release: kube-prometheus-stack-prod
-
 resources:
   requests:
     cpu: 100m
@@ -21,11 +18,9 @@ resources:
   limits:
     cpu: 1000m
     memory: 256Mi
-
 pdb:
   enabled: true
   minAvailable: 1
-
 # CRITICAL: Java goti-payment VS와 동일 (host, path) 조합 → Istio
 # MULTIPLE_VIRTUAL_SERVICES_FOR_HOST. gateway.enabled=false로 유지.
 # cutover 시 Java values의 gateway.enabled=false로 전환 후 본 파일 true.
@@ -45,7 +40,6 @@ gateway:
             host: goti-payment-go-prod
             port:
               number: 8080
-
 autoscaling:
   enabled: true
   minReplicas: 2
@@ -60,7 +54,6 @@ autoscaling:
           metricName: http_rps_payment_go
           query: sum(rate(http_server_request_duration_seconds_count{service_name="goti-payment-go"}[1m]))
           threshold: "30"
-
 probes:
   liveness:
     httpGet:
@@ -76,23 +69,19 @@ probes:
     initialDelaySeconds: 3
     periodSeconds: 5
     failureThreshold: 3
-
 podAnnotations:
   sidecar.istio.io/inject: "true"
   traffic.sidecar.istio.io/excludeOutboundPorts: "6379"
-
 podSecurityContext:
   runAsNonRoot: true
   runAsUser: 65532
   fsGroup: 65532
-
 securityContext:
   readOnlyRootFilesystem: true
   capabilities:
     drop: ["ALL"]
   seccompProfile:
     type: RuntimeDefault
-
 # 환경변수: PAYMENT_ prefix (Viper가 config.Load("payment")에서 자동 생성)
 env:
   # --- 인프라 (Secret에서 주입) ---
@@ -136,10 +125,8 @@ env:
     value: "goti-payment-go"
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
     value: "http://otel-collector.monitoring.svc.cluster.local:4317"
-
 configMap:
   enabled: false
-
 # --- Istio 보안/네트워크 정책 ---
 # TODO(phase 7): Java resale deprecation 후 from-resale 규칙을 resale-go SA로 변경.
 # 공존 기간 동안은 양쪽 SA 모두 허용.
@@ -170,3 +157,9 @@ istioPolicy:
       - "/metrics"
   destinationRule:
     enabled: true
+image:
+  repository: harbor.go-ti.shop/prod/goti-payment-go
+  tag: prod-7-5577103
+  pullPolicy: IfNotPresent
+imagePullSecrets:
+  - name: harbor-creds

--- a/environments/prod/goti-queue-go/values.yaml
+++ b/environments/prod/goti-queue-go/values.yaml
@@ -3,19 +3,16 @@
 # RequestAuthentication.jwksUri 참조 방식으로 자동화 예정.
 # 메모리: project_jwks_automation_todo.md
 nameOverride: goti-queue-go
-
 service:
   type: ClusterIP
   port: 8080
   name: http
-
 serviceMonitor:
   enabled: true
   port: http
   path: /metrics
   interval: 15s
   release: kube-prometheus-stack-prod
-
 resources:
   requests:
     cpu: 100m
@@ -23,11 +20,9 @@ resources:
   limits:
     cpu: 1000m
     memory: 256Mi
-
 pdb:
   enabled: true
   minAvailable: 1
-
 # CRITICAL: Java goti-queue VS와 동일 (host, path) 조합 → Istio
 # MULTIPLE_VIRTUAL_SERVICES_FOR_HOST. replicaCount=0이어도 VS는 생성되므로
 # gateway.enabled=false로 유지. cutover 시점에 다음 중 하나로 활성화:
@@ -53,7 +48,6 @@ gateway:
             host: goti-queue-go-prod
             port:
               number: 8080
-
 autoscaling:
   enabled: true
   minReplicas: 2
@@ -68,7 +62,6 @@ autoscaling:
           metricName: http_rps_queue_go
           query: sum(rate(http_server_request_duration_seconds_count{service_name="goti-queue-go"}[1m]))
           threshold: "50"
-
 probes:
   liveness:
     httpGet:
@@ -84,24 +77,20 @@ probes:
     initialDelaySeconds: 3
     periodSeconds: 5
     failureThreshold: 3
-
 podAnnotations:
   sidecar.istio.io/inject: "true"
   # ElastiCache Redis TLS — Istio sidecar 우회
   traffic.sidecar.istio.io/excludeOutboundPorts: "6379"
-
 podSecurityContext:
   runAsNonRoot: true
   runAsUser: 65532
   fsGroup: 65532
-
 securityContext:
   readOnlyRootFilesystem: true
   capabilities:
     drop: ["ALL"]
   seccompProfile:
     type: RuntimeDefault
-
 # 환경변수: QUEUE_ prefix (Viper가 config.Load("queue")에서 자동 생성)
 # envFrom 사용하지 않음 — 개별 매핑으로 명시적 관리
 env:
@@ -145,10 +134,8 @@ env:
     value: "goti-queue-go"
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
     value: "http://otel-collector.monitoring.svc.cluster.local:4317"
-
 configMap:
   enabled: false
-
 # --- Istio 보안/네트워크 정책 ---
 istioPolicy:
   # queue는 Gateway로만 접근 (서비스 간 호출 없음)
@@ -162,3 +149,9 @@ istioPolicy:
     enabled: false
   destinationRule:
     enabled: true
+image:
+  repository: harbor.go-ti.shop/prod/goti-queue-go
+  tag: prod-7-5577103
+  pullPolicy: IfNotPresent
+imagePullSecrets:
+  - name: harbor-creds

--- a/environments/prod/goti-resale-go/values.yaml
+++ b/environments/prod/goti-resale-go/values.yaml
@@ -1,19 +1,16 @@
 # TODO(jwks-automation): user-service JWT 키 회전 시 본 파일 inline jwks를
 # 모든 Go 서비스와 수동 동기화 필요. 메모리: project_jwks_automation_todo.md
 nameOverride: goti-resale-go
-
 service:
   type: ClusterIP
   port: 8080
   name: http
-
 serviceMonitor:
   enabled: true
   port: http
   path: /metrics
   interval: 15s
   release: kube-prometheus-stack-prod
-
 resources:
   requests:
     cpu: 100m
@@ -21,11 +18,9 @@ resources:
   limits:
     cpu: 1000m
     memory: 256Mi
-
 pdb:
   enabled: true
   minAvailable: 1
-
 # CRITICAL: Java goti-resale VS와 동일 (host, path) 조합 → Istio
 # MULTIPLE_VIRTUAL_SERVICES_FOR_HOST. gateway.enabled=false로 유지.
 # cutover 시 Java values의 gateway.enabled=false로 전환 후 본 파일 true.
@@ -45,7 +40,6 @@ gateway:
             host: goti-resale-go-prod
             port:
               number: 8080
-
 autoscaling:
   enabled: true
   minReplicas: 1
@@ -60,7 +54,6 @@ autoscaling:
           metricName: http_rps_resale_go
           query: sum(rate(http_server_request_duration_seconds_count{service_name="goti-resale-go"}[1m]))
           threshold: "20"
-
 probes:
   liveness:
     httpGet:
@@ -76,23 +69,19 @@ probes:
     initialDelaySeconds: 3
     periodSeconds: 5
     failureThreshold: 3
-
 podAnnotations:
   sidecar.istio.io/inject: "true"
   traffic.sidecar.istio.io/excludeOutboundPorts: "6379"
-
 podSecurityContext:
   runAsNonRoot: true
   runAsUser: 65532
   fsGroup: 65532
-
 securityContext:
   readOnlyRootFilesystem: true
   capabilities:
     drop: ["ALL"]
   seccompProfile:
     type: RuntimeDefault
-
 # 환경변수: RESALE_ prefix
 env:
   # --- 인프라 (Secret에서 주입) ---
@@ -136,10 +125,8 @@ env:
     value: "goti-resale-go"
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
     value: "http://otel-collector.monitoring.svc.cluster.local:4317"
-
 configMap:
   enabled: false
-
 # --- Istio 보안/네트워크 정책 ---
 # TODO(phase 7): Java payment/ticketing deprecation 후 from-X 규칙을 -go SA로 변경.
 istioPolicy:
@@ -184,3 +171,9 @@ istioPolicy:
       - "/metrics"
   destinationRule:
     enabled: true
+image:
+  repository: harbor.go-ti.shop/prod/goti-resale-go
+  tag: prod-7-5577103
+  pullPolicy: IfNotPresent
+imagePullSecrets:
+  - name: harbor-creds

--- a/environments/prod/goti-stadium-go/values.yaml
+++ b/environments/prod/goti-stadium-go/values.yaml
@@ -3,19 +3,16 @@
 # 확대 전 ConfigMap 또는 RequestAuthentication.jwksUri 참조 방식으로 자동화.
 # 메모리: project_jwks_automation_todo.md
 nameOverride: goti-stadium-go
-
 service:
   type: ClusterIP
   port: 8080
   name: http
-
 serviceMonitor:
   enabled: true
   port: http
   path: /metrics
   interval: 15s
   release: kube-prometheus-stack-prod
-
 resources:
   requests:
     cpu: 100m
@@ -23,11 +20,9 @@ resources:
   limits:
     cpu: 1000m
     memory: 256Mi
-
 pdb:
   enabled: true
   minAvailable: 1
-
 # CRITICAL: Java goti-stadium VS와 동일 (host, path) 조합 → Istio
 # MULTIPLE_VIRTUAL_SERVICES_FOR_HOST. cutover 전까지 gateway.enabled=false로 유지.
 # cutover 시 Java values의 gateway.enabled=false로 전환 후 본 파일 true.
@@ -49,7 +44,6 @@ gateway:
             host: goti-stadium-go-prod
             port:
               number: 8080
-
 # TODO(tuning): cron 윈도우/replica/threshold는 ticketing-go 값 그대로 복제.
 # stadium은 read-heavy 메타 서비스(Redis 캐시 hit율 높음)이므로 부하 관측 후
 # 윈도우 좁히기 또는 desiredReplicas/threshold 차등화 검토.
@@ -73,7 +67,6 @@ autoscaling:
           metricName: http_rps_stadium_go
           query: sum(rate(http_server_request_duration_seconds_count{service_name="goti-stadium-go"}[1m]))
           threshold: "50"
-
 # TODO(verify): /healthz가 DB/Redis ping 포함 시 RDS 풀 초기화에 3~5s 소요
 # 가능 → liveness 재시작 루프 위험. 코드 확인 후 필요 시 liveness만 10s로 조정.
 probes:
@@ -91,24 +84,20 @@ probes:
     initialDelaySeconds: 3
     periodSeconds: 5
     failureThreshold: 3
-
 podAnnotations:
   sidecar.istio.io/inject: "true"
   # ElastiCache Redis TLS — Istio sidecar 우회
   traffic.sidecar.istio.io/excludeOutboundPorts: "6379"
-
 podSecurityContext:
   runAsNonRoot: true
   runAsUser: 65532
   fsGroup: 65532
-
 securityContext:
   readOnlyRootFilesystem: true
   capabilities:
     drop: ["ALL"]
   seccompProfile:
     type: RuntimeDefault
-
 # 환경변수: STADIUM_ prefix (Viper가 config.Load("stadium")에서 자동 생성)
 # envFrom 사용하지 않음 — 개별 매핑으로 명시적 관리
 env:
@@ -150,10 +139,8 @@ env:
     value: "goti-stadium-go"
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
     value: "http://otel-collector.monitoring.svc.cluster.local:4317"
-
 configMap:
   enabled: false
-
 # --- Istio 보안/네트워크 정책 ---
 istioPolicy:
   # ticketing(Java) + ticketing-go(Go) 양쪽 호출자 허용 (Phase 6.5 공존 기간)
@@ -199,3 +186,9 @@ istioPolicy:
       - "/metrics"
   destinationRule:
     enabled: true
+image:
+  repository: harbor.go-ti.shop/prod/goti-stadium-go
+  tag: prod-7-5577103
+  pullPolicy: IfNotPresent
+imagePullSecrets:
+  - name: harbor-creds

--- a/environments/prod/goti-user-go/values.yaml
+++ b/environments/prod/goti-user-go/values.yaml
@@ -1,19 +1,16 @@
 # TODO(jwks-automation): user-service JWT 키 회전 시 본 파일 inline jwks를
 # 모든 Go 서비스와 수동 동기화 필요. 메모리: project_jwks_automation_todo.md
 nameOverride: goti-user-go
-
 service:
   type: ClusterIP
   port: 8080
   name: http
-
 serviceMonitor:
   enabled: true
   port: http
   path: /metrics
   interval: 15s
   release: kube-prometheus-stack-prod
-
 resources:
   requests:
     cpu: 100m
@@ -21,11 +18,9 @@ resources:
   limits:
     cpu: 1000m
     memory: 256Mi
-
 pdb:
   enabled: true
   minAvailable: 1
-
 # CRITICAL: Java goti-user VS와 동일 (host, path) 조합 → Istio
 # MULTIPLE_VIRTUAL_SERVICES_FOR_HOST. gateway.enabled=false로 유지.
 # cutover 시 Java values의 gateway.enabled=false로 전환 후 본 파일 true.
@@ -49,7 +44,6 @@ gateway:
             host: goti-user-go-prod
             port:
               number: 8080
-
 autoscaling:
   enabled: true
   minReplicas: 3
@@ -64,7 +58,6 @@ autoscaling:
           metricName: http_rps_user_go
           query: sum(rate(http_server_request_duration_seconds_count{service_name="goti-user-go"}[1m]))
           threshold: "40"
-
 probes:
   liveness:
     httpGet:
@@ -80,23 +73,19 @@ probes:
     initialDelaySeconds: 3
     periodSeconds: 5
     failureThreshold: 3
-
 podAnnotations:
   sidecar.istio.io/inject: "true"
   traffic.sidecar.istio.io/excludeOutboundPorts: "6379"
-
 podSecurityContext:
   runAsNonRoot: true
   runAsUser: 65532
   fsGroup: 65532
-
 securityContext:
   readOnlyRootFilesystem: true
   capabilities:
     drop: ["ALL"]
   seccompProfile:
     type: RuntimeDefault
-
 # 환경변수: USER_ prefix
 env:
   # --- 인프라 (Secret에서 주입) ---
@@ -143,10 +132,8 @@ env:
     value: "goti-user-go"
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
     value: "http://otel-collector.monitoring.svc.cluster.local:4317"
-
 configMap:
   enabled: false
-
 # --- Istio 보안/네트워크 정책 ---
 istioPolicy:
   # user 서비스는 Gateway로만 접근 (다른 서비스로부터 호출 받지 않음)
@@ -171,3 +158,9 @@ istioPolicy:
       - "/.well-known/*"
   destinationRule:
     enabled: true
+image:
+  repository: harbor.go-ti.shop/prod/goti-user-go
+  tag: prod-7-5577103
+  pullPolicy: IfNotPresent
+imagePullSecrets:
+  - name: harbor-creds


### PR DESCRIPTION
## 변경 사항
- 이미지 태그: `prod-7-5577103`
- 레지스트리: `harbor.go-ti.shop/prod/`
- 업데이트된 서비스: `{"include":[{"service":"user"},{"service":"stadium"},{"service":"payment"},{"service":"resale"},{"service":"queue"}]}`
- 대상 환경: AWS prod (`environments/prod/goti-*-go/`) + GCP prod (`environments/prod-gcp/goti-*/`)

## 트리거
- 레포: `ressKim-io/Goti-go`
- 브랜치: `main`
- 커밋: 55771031ecbe1789a465a740041c002555c89733
- 워크플로우: [#7](https://github.com/ressKim-io/Goti-go/actions/runs/24333360463)