### PR TITLE
[FEAT] AWS prod Java→Go cutover (6 서비스)

### DIFF
--- a/environments/prod/goti-payment-go/values-aws.yaml
+++ b/environments/prod/goti-payment-go/values-aws.yaml
@@ -1,7 +1,6 @@
-replicaCount: 0
+replicaCount: 2
 image:
   repository: "harbor.go-ti.shop/prod/goti-payment-go"
-  tag: "prod-1-0000000"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds
@@ -22,3 +21,7 @@ istioPolicy:
           - "./*"
           - "monitoring/*"
           - "*.amazonaws.com"
+
+# Cutover: Go 활성화
+gateway:
+  enabled: true

--- a/environments/prod/goti-payment/values-aws.yaml
+++ b/environments/prod/goti-payment/values-aws.yaml
@@ -1,4 +1,4 @@
-replicaCount: 2
+replicaCount: 0
 image:
   repository: "harbor.go-ti.shop/prod/goti-payment"
   tag: "prod-52-c0a6964"
@@ -24,3 +24,7 @@ istioPolicy:
           - "monitoring/*"
           - "kafka/*"
           - "~/*.amazonaws.com"
+
+# Cutover: Java 비활성, Go 라우팅 take-over
+gateway:
+  enabled: false

--- a/environments/prod/goti-queue-go/values-aws.yaml
+++ b/environments/prod/goti-queue-go/values-aws.yaml
@@ -1,8 +1,7 @@
 # SG1: 0% weight 첫 배포 — replicaCount: 0 (Java goti-queue-prod 무영향 보장)
-replicaCount: 0
+replicaCount: 2
 image:
   repository: "harbor.go-ti.shop/prod/goti-queue-go"
-  tag: "prod-1-0000000"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds
@@ -23,3 +22,7 @@ istioPolicy:
           - "./*"
           - "monitoring/*"
           - "*.amazonaws.com"
+
+# Cutover: Go 활성화
+gateway:
+  enabled: true

--- a/environments/prod/goti-queue/values-aws.yaml
+++ b/environments/prod/goti-queue/values-aws.yaml
@@ -1,4 +1,4 @@
-replicaCount: 2
+replicaCount: 0
 image:
   repository: "harbor.go-ti.shop/prod/goti-queue"
   tag: "prod-52-c0a6964"
@@ -23,3 +23,7 @@ istioPolicy:
           - "./*"
           - "monitoring/*"
           - "~/*.amazonaws.com"
+
+# Cutover: Java 비활성, Go 라우팅 take-over
+gateway:
+  enabled: false

--- a/environments/prod/goti-resale-go/values-aws.yaml
+++ b/environments/prod/goti-resale-go/values-aws.yaml
@@ -1,7 +1,6 @@
-replicaCount: 0
+replicaCount: 1
 image:
   repository: "harbor.go-ti.shop/prod/goti-resale-go"
-  tag: "prod-1-0000000"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds
@@ -22,3 +21,7 @@ istioPolicy:
           - "./*"
           - "monitoring/*"
           - "*.amazonaws.com"
+
+# Cutover: Go 활성화
+gateway:
+  enabled: true

--- a/environments/prod/goti-resale/values-aws.yaml
+++ b/environments/prod/goti-resale/values-aws.yaml
@@ -1,4 +1,4 @@
-replicaCount: 1
+replicaCount: 0
 image:
   repository: "harbor.go-ti.shop/prod/goti-resale"
   tag: "prod-52-c0a6964"
@@ -24,3 +24,7 @@ istioPolicy:
           - "monitoring/*"
           - "kafka/*"
           - "~/*.amazonaws.com"
+
+# Cutover: Java 비활성, Go 라우팅 take-over
+gateway:
+  enabled: false

--- a/environments/prod/goti-stadium-go/values-aws.yaml
+++ b/environments/prod/goti-stadium-go/values-aws.yaml
@@ -1,8 +1,7 @@
 # SG1: 0% weight 첫 배포 — replicaCount: 0 (Java goti-stadium-prod 무영향 보장)
-replicaCount: 0
+replicaCount: 1
 image:
   repository: "harbor.go-ti.shop/prod/goti-stadium-go"
-  tag: "prod-1-0000000"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds
@@ -26,3 +25,7 @@ istioPolicy:
           - "./*"
           - "monitoring/*"
           - "*.amazonaws.com"
+
+# Cutover: Go 활성화
+gateway:
+  enabled: true

--- a/environments/prod/goti-stadium/values-aws.yaml
+++ b/environments/prod/goti-stadium/values-aws.yaml
@@ -1,4 +1,4 @@
-replicaCount: 1
+replicaCount: 0
 image:
   repository: "harbor.go-ti.shop/prod/goti-stadium"
   tag: "prod-52-c0a6964"
@@ -24,3 +24,7 @@ istioPolicy:
           - "monitoring/*"
           - "kafka/*"
           - "~/*.amazonaws.com"
+
+# Cutover: Java 비활성, Go 라우팅 take-over
+gateway:
+  enabled: false

--- a/environments/prod/goti-ticketing-go/values-aws.yaml
+++ b/environments/prod/goti-ticketing-go/values-aws.yaml
@@ -1,7 +1,6 @@
-replicaCount: 0
+replicaCount: 2
 image:
   repository: "harbor.go-ti.shop/prod/goti-ticketing-go"
-  tag: "prod-1-0000000"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds
@@ -22,3 +21,7 @@ istioPolicy:
           - "./*"
           - "monitoring/*"
           - "~/*.amazonaws.com"
+
+# Cutover: Go 활성화
+gateway:
+  enabled: true

--- a/environments/prod/goti-ticketing/values-aws.yaml
+++ b/environments/prod/goti-ticketing/values-aws.yaml
@@ -1,4 +1,4 @@
-replicaCount: 2
+replicaCount: 0
 image:
   repository: "harbor.go-ti.shop/prod/goti-ticketing"
   tag: "prod-52-c0a6964"
@@ -24,3 +24,7 @@ istioPolicy:
           - "monitoring/*"
           - "kafka/*"
           - "~/*.amazonaws.com"
+
+# Cutover: Java 비활성, Go 라우팅 take-over
+gateway:
+  enabled: false

--- a/environments/prod/goti-user-go/values-aws.yaml
+++ b/environments/prod/goti-user-go/values-aws.yaml
@@ -1,7 +1,6 @@
-replicaCount: 0
+replicaCount: 4
 image:
   repository: "harbor.go-ti.shop/prod/goti-user-go"
-  tag: "prod-1-0000000"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds
@@ -22,3 +21,7 @@ istioPolicy:
           - "./*"
           - "monitoring/*"
           - "*.amazonaws.com"
+
+# Cutover: Go 활성화
+gateway:
+  enabled: true

--- a/environments/prod/goti-user/values-aws.yaml
+++ b/environments/prod/goti-user/values-aws.yaml
@@ -1,4 +1,4 @@
-replicaCount: 4
+replicaCount: 0
 image:
   repository: "harbor.go-ti.shop/prod/goti-user"
   tag: "prod-52-c0a6964"
@@ -28,3 +28,7 @@ istioPolicy:
           - "~/*.kakao.com"
           - "~/*.nurigo.com"
           - "~/*.amazonaws.com"
+
+# Cutover: Java 비활성, Go 라우팅 take-over
+gateway:
+  enabled: false


### PR DESCRIPTION
## 개요
AWS prod에서 Java 스택을 내리고 Go 스택을 활성화.

## 변경
| 서비스 | Java replicaCount | Go replicaCount | Gateway |
|---|---|---|---|
| ticketing | 2→0 | 0→2 | Java false, Go true |
| stadium | 1→0 | 0→1 | 동일 |
| payment | 2→0 | 0→2 | 동일 |
| resale | 1→0 | 0→1 | 동일 |
| user | 4→0 | 0→4 | 동일 |
| queue | 2→0 | 0→2 | 동일 |

Go values-aws.yaml에서 `image.tag` override 제거 → CD 자동갱신된 values.yaml 태그(prod-6/7-5577103) 사용.

## 리스크
Java VS와 Go VS 순간 동시 활성 가능성 → ArgoCD sync 시 wave에 따라 처리. 최악의 경우 MULTIPLE_VIRTUAL_SERVICES_FOR_HOST 잠시 발생 후 자연 resolve.

## 롤백
values-aws.yaml 되돌리고 sync.