### PR TITLE
[FIX] AWS Go 내부 호출 URL → Go 서비스

### DIFF
--- a/environments/prod/goti-ticketing-go/values.yaml
+++ b/environments/prod/goti-ticketing-go/values.yaml
@@ -142,11 +142,11 @@ env:
     value: "1800"
   # --- 서비스 간 통신 ---
   - name: TICKETING_SERVICES_STADIUM
-    value: "http://goti-stadium-prod.goti.svc.cluster.local:8080"
+    value: "http://goti-stadium-go-prod.goti.svc.cluster.local:8080"
   - name: TICKETING_SERVICES_PAYMENT
-    value: "http://goti-payment-prod.goti.svc.cluster.local:8080"
+    value: "http://goti-payment-go-prod.goti.svc.cluster.local:8080"
   - name: TICKETING_SERVICES_RESALE
-    value: "http://goti-resale-prod.goti.svc.cluster.local:8080"
+    value: "http://goti-resale-go-prod.goti.svc.cluster.local:8080"
   # --- OTel ---
   - name: TICKETING_OTEL_ENABLED
     value: "true"


### PR DESCRIPTION
Java 0 replicas 상태에서 ticketing→stadium 503 해결.