### PR TITLE
feat(authz): allow Go service principals in Java AuthorizationPolicies

### DIFF
--- a/environments/prod/goti-payment/values.yaml
+++ b/environments/prod/goti-payment/values.yaml
@@ -114,7 +114,9 @@ istioPolicy:
         rules:
           - from:
               - source:
-                  principals: ["cluster.local/ns/goti/sa/goti-resale-prod"]
+                  principals:
+                    - "cluster.local/ns/goti/sa/goti-resale-prod"
+                    - "cluster.local/ns/goti/sa/goti-resale-go-prod"
             to:
               - operation:
                   paths: ["/api/v1/resales/payments", "/api/v1/resales/payments/*"]

--- a/environments/prod/goti-resale/values.yaml
+++ b/environments/prod/goti-resale/values.yaml
@@ -110,7 +110,9 @@ istioPolicy:
         rules:
           - from:
               - source:
-                  principals: ["cluster.local/ns/goti/sa/goti-payment-prod"]
+                  principals:
+                    - "cluster.local/ns/goti/sa/goti-payment-prod"
+                    - "cluster.local/ns/goti/sa/goti-payment-go-prod"
             to:
               - operation:
                   paths: ["/api/v1/resales/orders/*"]
@@ -119,7 +121,9 @@ istioPolicy:
         rules:
           - from:
               - source:
-                  principals: ["cluster.local/ns/goti/sa/goti-ticketing-prod"]
+                  principals:
+                    - "cluster.local/ns/goti/sa/goti-ticketing-prod"
+                    - "cluster.local/ns/goti/sa/goti-ticketing-go-prod"
             to:
               - operation:
                   paths: ["/api/v1/resales/listings/count"]

--- a/environments/prod/goti-stadium/values.yaml
+++ b/environments/prod/goti-stadium/values.yaml
@@ -91,7 +91,9 @@ istioPolicy:
         rules:
           - from:
               - source:
-                  principals: ["cluster.local/ns/goti/sa/goti-ticketing-prod"]
+                  principals:
+                    - "cluster.local/ns/goti/sa/goti-ticketing-prod"
+                    - "cluster.local/ns/goti/sa/goti-ticketing-go-prod"
             to:
               - operation:
                   paths: ["/api/v1/stadiums*", "/api/v1/baseball-teams*"]

--- a/environments/prod/goti-ticketing-go/values.yaml
+++ b/environments/prod/goti-ticketing-go/values.yaml
@@ -170,7 +170,9 @@ istioPolicy:
         rules:
           - from:
               - source:
-                  principals: ["cluster.local/ns/goti/sa/goti-payment-prod"]
+                  principals:
+                    - "cluster.local/ns/goti/sa/goti-payment-prod"
+                    - "cluster.local/ns/goti/sa/goti-payment-go-prod"
             to:
               - operation:
                   paths: ["/api/v1/orders/*"]
@@ -179,7 +181,9 @@ istioPolicy:
         rules:
           - from:
               - source:
-                  principals: ["cluster.local/ns/goti/sa/goti-resale-prod"]
+                  principals:
+                    - "cluster.local/ns/goti/sa/goti-resale-prod"
+                    - "cluster.local/ns/goti/sa/goti-resale-go-prod"
             to:
               - operation:
                   paths: ["/api/v1/tickets/resales/*", "/internal/*"]

--- a/environments/prod/goti-ticketing/values.yaml
+++ b/environments/prod/goti-ticketing/values.yaml
@@ -134,7 +134,9 @@ istioPolicy:
         rules:
           - from:
               - source:
-                  principals: ["cluster.local/ns/goti/sa/goti-payment-prod"]
+                  principals:
+                    - "cluster.local/ns/goti/sa/goti-payment-prod"
+                    - "cluster.local/ns/goti/sa/goti-payment-go-prod"
             to:
               - operation:
                   paths: ["/api/v1/orders/*"]
@@ -143,7 +145,9 @@ istioPolicy:
         rules:
           - from:
               - source:
-                  principals: ["cluster.local/ns/goti/sa/goti-resale-prod"]
+                  principals:
+                    - "cluster.local/ns/goti/sa/goti-resale-prod"
+                    - "cluster.local/ns/goti/sa/goti-resale-go-prod"
             to:
               - operation:
                   paths: ["/api/v1/tickets/resales/*"]


### PR DESCRIPTION
## Summary
하이브리드 상태(Java+Go 공존) 부하테스트 대비 — Java↔Go 상호 호출이 Istio AuthorizationPolicy 레벨에서 FORBIDDEN으로 차단되는 갭 해소.

## 변경 매트릭스
| Target | 추가된 principal |
|---|---|
| ticketing (Java) | payment-go, resale-go |
| ticketing-go | payment-go, resale-go |
| payment (Java) | resale-go |
| resale (Java) | payment-go, ticketing-go |
| stadium (Java) | ticketing-go |

이미 완전 허용된 서비스(payment-go, resale-go, stadium-go)는 변경 없음.

## 변경 파일 (5개, +24/-8)
- environments/prod/goti-ticketing/values.yaml
- environments/prod/goti-ticketing-go/values.yaml
- environments/prod/goti-payment/values.yaml
- environments/prod/goti-resale/values.yaml
- environments/prod/goti-stadium/values.yaml

## 검증
- `helm template` 5서비스 전부 성공
- 렌더링 결과 principals 배열에 Java/Go SA 둘 다 포함 확인

## Test plan
- [ ] ArgoCD sync (goti-ticketing, goti-ticketing-go, goti-payment, goti-resale, goti-stadium)
- [ ] `kubectl get authorizationpolicy -n goti -o yaml | grep -B2 principals` 로 양쪽 SA 적용 확인
- [ ] 부하 테스트 시작 (3천-3천 → 점진 상승) 중 Istio sidecar 403 로그 모니터링
- [ ] 필요시 추가 갭 발견 즉시 hotfix

## 후속
- 부하 중 FORBIDDEN 발생 시 즉시 values 수정 + ArgoCD sync