### PR TITLE
[CHORE] prod Go 이미지 태그 업데이트: prod-9-b6519b5

### DIFF
--- a/environments/prod-gcp/goti-user/values.yaml
+++ b/environments/prod-gcp/goti-user/values.yaml
@@ -2,7 +2,7 @@ nameOverride: goti-user
 replicaCount: 0
 image:
   repository: "harbor.go-ti.shop/prod/goti-user-go"
-  tag: "prod-7-5577103"
+  tag: "prod-9-b6519b5"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-user-go/values.yaml
+++ b/environments/prod/goti-user-go/values.yaml
@@ -206,7 +206,7 @@ istioPolicy:
     enabled: true
 image:
   repository: harbor.go-ti.shop/prod/goti-user-go
-  tag: prod-7-5577103
+  tag: prod-9-b6519b5
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds


### PR DESCRIPTION
## 변경 사항
- 이미지 태그: `prod-9-b6519b5`
- 레지스트리: `harbor.go-ti.shop/prod/`
- 업데이트된 서비스: `{"include":[{"service":"user"}]}`
- 대상 환경: AWS prod (`environments/prod/goti-*-go/`) + GCP prod (`environments/prod-gcp/goti-*/`)

## 트리거
- 레포: `ressKim-io/Goti-go`
- 브랜치: `deploy/prod`
- 커밋: b6519b5408a67e8ff8a869023ba60ab922cdf808
- 워크플로우: [#9](https://github.com/ressKim-io/Goti-go/actions/runs/24340668271)