### PR TITLE
[CHORE] prod Go 이미지 태그 업데이트: prod-10-a2b7aea

### DIFF
--- a/environments/prod-gcp/goti-payment/values.yaml
+++ b/environments/prod-gcp/goti-payment/values.yaml
@@ -2,7 +2,7 @@ nameOverride: goti-payment
 replicaCount: 0
 image:
   repository: "harbor.go-ti.shop/prod/goti-payment-go"
-  tag: "prod-7-5577103"
+  tag: "prod-10-a2b7aea"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod-gcp/goti-queue/values.yaml
+++ b/environments/prod-gcp/goti-queue/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 0
 nameOverride: goti-queue
 image:
   repository: "harbor.go-ti.shop/prod/goti-queue-go"
-  tag: "prod-7-5577103" # linux/amd64 buildx 재빌드 (기존 bootstrap-20260413은 arm64로 잘못 푸시됨). CD 실행 시 gcp-N-SHA 로 auto-update
+  tag: "prod-10-a2b7aea" # linux/amd64 buildx 재빌드 (기존 bootstrap-20260413은 arm64로 잘못 푸시됨). CD 실행 시 gcp-N-SHA 로 auto-update
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod-gcp/goti-resale/values.yaml
+++ b/environments/prod-gcp/goti-resale/values.yaml
@@ -2,7 +2,7 @@ nameOverride: goti-resale
 replicaCount: 0
 image:
   repository: "harbor.go-ti.shop/prod/goti-resale-go"
-  tag: "prod-7-5577103"
+  tag: "prod-10-a2b7aea"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod-gcp/goti-stadium/values.yaml
+++ b/environments/prod-gcp/goti-stadium/values.yaml
@@ -2,7 +2,7 @@ nameOverride: goti-stadium
 replicaCount: 0
 image:
   repository: "harbor.go-ti.shop/prod/goti-stadium-go"
-  tag: "prod-7-5577103"
+  tag: "prod-10-a2b7aea"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds
@@ -149,6 +149,5 @@ istioPolicy:
           - "istio-system/*"
           - "./*"
           - "monitoring/*"
-
 autoscaling:
   enabled: false

--- a/environments/prod-gcp/goti-ticketing/values.yaml
+++ b/environments/prod-gcp/goti-ticketing/values.yaml
@@ -2,7 +2,7 @@ nameOverride: goti-ticketing
 replicaCount: 0
 image:
   repository: "harbor.go-ti.shop/prod/goti-ticketing-go"
-  tag: "prod-6-5577103"
+  tag: "prod-10-a2b7aea"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod-gcp/goti-user/values.yaml
+++ b/environments/prod-gcp/goti-user/values.yaml
@@ -2,7 +2,7 @@ nameOverride: goti-user
 replicaCount: 0
 image:
   repository: "harbor.go-ti.shop/prod/goti-user-go"
-  tag: "prod-9-b6519b5"
+  tag: "prod-10-a2b7aea"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-payment-go/values.yaml
+++ b/environments/prod/goti-payment-go/values.yaml
@@ -159,7 +159,7 @@ istioPolicy:
     enabled: true
 image:
   repository: harbor.go-ti.shop/prod/goti-payment-go
-  tag: prod-7-5577103
+  tag: prod-10-a2b7aea
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-queue-go/values.yaml
+++ b/environments/prod/goti-queue-go/values.yaml
@@ -151,7 +151,7 @@ istioPolicy:
     enabled: true
 image:
   repository: harbor.go-ti.shop/prod/goti-queue-go
-  tag: prod-7-5577103
+  tag: prod-10-a2b7aea
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-resale-go/values.yaml
+++ b/environments/prod/goti-resale-go/values.yaml
@@ -173,7 +173,7 @@ istioPolicy:
     enabled: true
 image:
   repository: harbor.go-ti.shop/prod/goti-resale-go
-  tag: prod-7-5577103
+  tag: prod-10-a2b7aea
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-stadium-go/values.yaml
+++ b/environments/prod/goti-stadium-go/values.yaml
@@ -188,7 +188,7 @@ istioPolicy:
     enabled: true
 image:
   repository: harbor.go-ti.shop/prod/goti-stadium-go
-  tag: prod-7-5577103
+  tag: prod-10-a2b7aea
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-ticketing-go/values.yaml
+++ b/environments/prod/goti-ticketing-go/values.yaml
@@ -219,7 +219,7 @@ istioPolicy:
     enabled: true
 image:
   repository: harbor.go-ti.shop/prod/goti-ticketing-go
-  tag: prod-6-5577103
+  tag: prod-10-a2b7aea
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-user-go/values.yaml
+++ b/environments/prod/goti-user-go/values.yaml
@@ -206,7 +206,7 @@ istioPolicy:
     enabled: true
 image:
   repository: harbor.go-ti.shop/prod/goti-user-go
-  tag: prod-9-b6519b5
+  tag: prod-10-a2b7aea
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds


### PR DESCRIPTION
## 변경 사항
- 이미지 태그: `prod-10-a2b7aea`
- 레지스트리: `harbor.go-ti.shop/prod/`
- 업데이트된 서비스: `{"include":[{"service":"user"},{"service":"stadium"},{"service":"ticketing"},{"service":"payment"},{"service":"resale"},{"service":"queue"}]}`
- 대상 환경: AWS prod (`environments/prod/goti-*-go/`) + GCP prod (`environments/prod-gcp/goti-*/`)

## 트리거
- 레포: `ressKim-io/Goti-go`
- 브랜치: `deploy/prod`
- 커밋: a2b7aeadea014bad6e49460bcb8785f77141da52
- 워크플로우: [#10](https://github.com/ressKim-io/Goti-go/actions/runs/24340965103)