### PR TITLE
[CHORE] prod Go 이미지 태그 업데이트: prod-17-c5f5d1d

### DIFF
--- a/environments/prod-gcp/goti-user/values.yaml
+++ b/environments/prod-gcp/goti-user/values.yaml
@@ -2,7 +2,7 @@ nameOverride: goti-user
 replicaCount: 0
 image:
   repository: "harbor.go-ti.shop/prod/goti-user-go"
-  tag: "prod-12-c96e1d8"
+  tag: "prod-17-c5f5d1d"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-user-go/values.yaml
+++ b/environments/prod/goti-user-go/values.yaml
@@ -209,7 +209,7 @@ istioPolicy:
     enabled: true
 image:
   repository: harbor.go-ti.shop/prod/goti-user-go
-  tag: prod-12-c96e1d8
+  tag: prod-17-c5f5d1d
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds


### PR DESCRIPTION
## 변경 사항
- 이미지 태그: `prod-17-c5f5d1d`
- 레지스트리: `harbor.go-ti.shop/prod/`
- 업데이트된 서비스: `{"include":[{"service":"user"}]}`
- 대상 환경: AWS prod (`environments/prod/goti-*-go/`) + GCP prod (`environments/prod-gcp/goti-*/`)

## 트리거
- 레포: `ressKim-io/Goti-go`
- 브랜치: `deploy/prod`
- 커밋: c5f5d1def7bbaf3f625da25b0fe11507240a1c6f
- 워크플로우: [#17](https://github.com/ressKim-io/Goti-go/actions/runs/24344728570)