### PR TITLE
[CHORE] prod Go 이미지 태그 업데이트: prod-23-38a6fce

### DIFF
--- a/environments/prod-gcp/goti-ticketing/values.yaml
+++ b/environments/prod-gcp/goti-ticketing/values.yaml
@@ -2,7 +2,7 @@ nameOverride: goti-ticketing
 replicaCount: 0
 image:
   repository: "harbor.go-ti.shop/prod/goti-ticketing-go"
-  tag: "prod-20-0845b11"
+  tag: "prod-23-38a6fce"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-ticketing-go/values.yaml
+++ b/environments/prod/goti-ticketing-go/values.yaml
@@ -219,7 +219,7 @@ istioPolicy:
     enabled: true
 image:
   repository: harbor.go-ti.shop/prod/goti-ticketing-go
-  tag: prod-20-0845b11
+  tag: prod-23-38a6fce
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds


### PR DESCRIPTION
## 변경 사항
- 이미지 태그: `prod-23-38a6fce`
- 레지스트리: `harbor.go-ti.shop/prod/`
- 업데이트된 서비스: `{"include":[{"service":"ticketing"}]}`
- 대상 환경: AWS prod (`environments/prod/goti-*-go/`) + GCP prod (`environments/prod-gcp/goti-*/`)

## 트리거
- 레포: `ressKim-io/Goti-go`
- 브랜치: `deploy/prod`
- 커밋: 38a6fce5f596d72dffd31a627a1f776340da8128
- 워크플로우: [#23](https://github.com/ressKim-io/Goti-go/actions/runs/24346771577)