### PR TITLE
[CHORE] prod Go 이미지 태그 업데이트: prod-26-a69d504

### DIFF
--- a/environments/prod-gcp/goti-ticketing/values.yaml
+++ b/environments/prod-gcp/goti-ticketing/values.yaml
@@ -2,7 +2,7 @@ nameOverride: goti-ticketing
 replicaCount: 0
 image:
   repository: "harbor.go-ti.shop/prod/goti-ticketing-go"
-  tag: "prod-25-e9e1bf4"
+  tag: "prod-26-a69d504"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-ticketing-go/values.yaml
+++ b/environments/prod/goti-ticketing-go/values.yaml
@@ -219,7 +219,7 @@ istioPolicy:
     enabled: true
 image:
   repository: harbor.go-ti.shop/prod/goti-ticketing-go
-  tag: prod-25-e9e1bf4
+  tag: prod-26-a69d504
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds


### PR DESCRIPTION
## 변경 사항
- 이미지 태그: `prod-26-a69d504`
- 레지스트리: `harbor.go-ti.shop/prod/`
- 업데이트된 서비스: `{"include":[{"service":"ticketing"}]}`
- 대상 환경: AWS prod (`environments/prod/goti-*-go/`) + GCP prod (`environments/prod-gcp/goti-*/`)

## 트리거
- 레포: `ressKim-io/Goti-go`
- 브랜치: `deploy/prod`
- 커밋: a69d504a473950dd45530e6533abc4b90ac7d721
- 워크플로우: [#26](https://github.com/ressKim-io/Goti-go/actions/runs/24348297865)