### PR TITLE
[CHORE] prod Go 이미지 태그 업데이트: prod-28-82159d8

### DIFF
--- a/environments/prod-gcp/goti-payment/values.yaml
+++ b/environments/prod-gcp/goti-payment/values.yaml
@@ -2,7 +2,7 @@ nameOverride: goti-payment
 replicaCount: 0
 image:
   repository: "harbor.go-ti.shop/prod/goti-payment-go"
-  tag: "prod-19-a3ab08b"
+  tag: "prod-28-82159d8"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-payment-go/values.yaml
+++ b/environments/prod/goti-payment-go/values.yaml
@@ -159,7 +159,7 @@ istioPolicy:
     enabled: true
 image:
   repository: harbor.go-ti.shop/prod/goti-payment-go
-  tag: prod-19-a3ab08b
+  tag: prod-28-82159d8
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds


### PR DESCRIPTION
## 변경 사항
- 이미지 태그: `prod-28-82159d8`
- 레지스트리: `harbor.go-ti.shop/prod/`
- 업데이트된 서비스: `{"include":[{"service":"payment"}]}`
- 대상 환경: AWS prod (`environments/prod/goti-*-go/`) + GCP prod (`environments/prod-gcp/goti-*/`)

## 트리거
- 레포: `ressKim-io/Goti-go`
- 브랜치: `deploy/prod`
- 커밋: 82159d8649e5b565978d95780db52979c5f51116
- 워크플로우: [#28](https://github.com/ressKim-io/Goti-go/actions/runs/24348871634)