### PR TITLE
[CHORE] prod Go 이미지 태그 업데이트: prod-30-0e318ee

### DIFF
--- a/environments/prod-gcp/goti-payment/values.yaml
+++ b/environments/prod-gcp/goti-payment/values.yaml
@@ -2,7 +2,7 @@ nameOverride: goti-payment
 replicaCount: 0
 image:
   repository: "harbor.go-ti.shop/prod/goti-payment-go"
-  tag: "prod-28-82159d8"
+  tag: "prod-30-0e318ee"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod-gcp/goti-queue/values.yaml
+++ b/environments/prod-gcp/goti-queue/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 0
 nameOverride: goti-queue
 image:
   repository: "harbor.go-ti.shop/prod/goti-queue-go"
-  tag: "prod-12-c96e1d8" # linux/amd64 buildx 재빌드 (기존 bootstrap-20260413은 arm64로 잘못 푸시됨). CD 실행 시 gcp-N-SHA 로 auto-update
+  tag: "prod-30-0e318ee" # linux/amd64 buildx 재빌드 (기존 bootstrap-20260413은 arm64로 잘못 푸시됨). CD 실행 시 gcp-N-SHA 로 auto-update
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod-gcp/goti-resale/values.yaml
+++ b/environments/prod-gcp/goti-resale/values.yaml
@@ -2,7 +2,7 @@ nameOverride: goti-resale
 replicaCount: 0
 image:
   repository: "harbor.go-ti.shop/prod/goti-resale-go"
-  tag: "prod-12-c96e1d8"
+  tag: "prod-30-0e318ee"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod-gcp/goti-stadium/values.yaml
+++ b/environments/prod-gcp/goti-stadium/values.yaml
@@ -2,7 +2,7 @@ nameOverride: goti-stadium
 replicaCount: 0
 image:
   repository: "harbor.go-ti.shop/prod/goti-stadium-go"
-  tag: "prod-12-c96e1d8"
+  tag: "prod-30-0e318ee"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod-gcp/goti-ticketing/values.yaml
+++ b/environments/prod-gcp/goti-ticketing/values.yaml
@@ -2,7 +2,7 @@ nameOverride: goti-ticketing
 replicaCount: 0
 image:
   repository: "harbor.go-ti.shop/prod/goti-ticketing-go"
-  tag: "prod-29-4328b31"
+  tag: "prod-30-0e318ee"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod-gcp/goti-user/values.yaml
+++ b/environments/prod-gcp/goti-user/values.yaml
@@ -2,7 +2,7 @@ nameOverride: goti-user
 replicaCount: 0
 image:
   repository: "harbor.go-ti.shop/prod/goti-user-go"
-  tag: "prod-17-c5f5d1d"
+  tag: "prod-30-0e318ee"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-payment-go/values.yaml
+++ b/environments/prod/goti-payment-go/values.yaml
@@ -161,7 +161,7 @@ istioPolicy:
     enabled: true
 image:
   repository: harbor.go-ti.shop/prod/goti-payment-go
-  tag: prod-28-82159d8
+  tag: prod-30-0e318ee
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-queue-go/values.yaml
+++ b/environments/prod/goti-queue-go/values.yaml
@@ -153,7 +153,7 @@ istioPolicy:
     enabled: true
 image:
   repository: harbor.go-ti.shop/prod/goti-queue-go
-  tag: prod-12-c96e1d8
+  tag: prod-30-0e318ee
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-resale-go/values.yaml
+++ b/environments/prod/goti-resale-go/values.yaml
@@ -175,7 +175,7 @@ istioPolicy:
     enabled: true
 image:
   repository: harbor.go-ti.shop/prod/goti-resale-go
-  tag: prod-12-c96e1d8
+  tag: prod-30-0e318ee
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-stadium-go/values.yaml
+++ b/environments/prod/goti-stadium-go/values.yaml
@@ -190,7 +190,7 @@ istioPolicy:
     enabled: true
 image:
   repository: harbor.go-ti.shop/prod/goti-stadium-go
-  tag: prod-12-c96e1d8
+  tag: prod-30-0e318ee
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-ticketing-go/values.yaml
+++ b/environments/prod/goti-ticketing-go/values.yaml
@@ -221,7 +221,7 @@ istioPolicy:
     enabled: true
 image:
   repository: harbor.go-ti.shop/prod/goti-ticketing-go
-  tag: prod-29-4328b31
+  tag: prod-30-0e318ee
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-user-go/values.yaml
+++ b/environments/prod/goti-user-go/values.yaml
@@ -214,7 +214,7 @@ istioPolicy:
     enabled: true
 image:
   repository: harbor.go-ti.shop/prod/goti-user-go
-  tag: prod-17-c5f5d1d
+  tag: prod-30-0e318ee
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds


### PR DESCRIPTION
## 변경 사항
- 이미지 태그: `prod-30-0e318ee`
- 레지스트리: `harbor.go-ti.shop/prod/`
- 업데이트된 서비스: `{"include":[{"service":"user"},{"service":"stadium"},{"service":"ticketing"},{"service":"payment"},{"service":"resale"},{"service":"queue"}]}`
- 대상 환경: AWS prod (`environments/prod/goti-*-go/`) + GCP prod (`environments/prod-gcp/goti-*/`)

## 트리거
- 레포: `ressKim-io/Goti-go`
- 브랜치: `deploy/prod`
- 커밋: 0e318ee907b7306b4dad10b009619828cea9ac4c
- 워크플로우: [#30](https://github.com/ressKim-io/Goti-go/actions/runs/24374583700)