### PR TITLE
[CHORE] prod Go 이미지 태그 업데이트: prod-37-486fbde

### DIFF
--- a/environments/prod-gcp/goti-ticketing/values.yaml
+++ b/environments/prod-gcp/goti-ticketing/values.yaml
@@ -2,7 +2,7 @@ nameOverride: goti-ticketing
 replicaCount: 0
 image:
   repository: "harbor.go-ti.shop/prod/goti-ticketing-go"
-  tag: "prod-34-0dea0b2"
+  tag: "prod-37-486fbde"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-ticketing-v2/values.yaml
+++ b/environments/prod/goti-ticketing-v2/values.yaml
@@ -226,7 +226,7 @@ istioPolicy:
     enabled: true
 image:
   repository: harbor.go-ti.shop/prod/goti-ticketing-go
-  tag: prod-34-0dea0b2
+  tag: prod-37-486fbde
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds


### PR DESCRIPTION
## 변경 사항
- 이미지 태그: `prod-37-486fbde`
- 레지스트리: `harbor.go-ti.shop/prod/`
- 업데이트된 서비스: `{"include":[{"service":"ticketing"}]}`
- 대상 환경: AWS prod (`environments/prod/goti-*-go/`) + GCP prod (`environments/prod-gcp/goti-*/`)

## 트리거
- 레포: `ressKim-io/Goti-go`
- 브랜치: `deploy/prod`
- 커밋: 486fbde4084510b729a51c60df1ee2bcb9593f86
- 워크플로우: [#37](https://github.com/ressKim-io/Goti-go/actions/runs/24380436187)