### PR TITLE
[CHORE] prod Go 이미지 태그 업데이트: prod-39-c6ac3b3

### DIFF
--- a/environments/prod-gcp/goti-payment/values.yaml
+++ b/environments/prod-gcp/goti-payment/values.yaml
@@ -2,7 +2,7 @@ nameOverride: goti-payment
 replicaCount: 0
 image:
   repository: "harbor.go-ti.shop/prod/goti-payment-go"
-  tag: "prod-38-18d0b20"
+  tag: "prod-39-c6ac3b3"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod-gcp/goti-queue/values.yaml
+++ b/environments/prod-gcp/goti-queue/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 0
 nameOverride: goti-queue
 image:
   repository: "harbor.go-ti.shop/prod/goti-queue-go"
-  tag: "prod-38-18d0b20" # linux/amd64 buildx 재빌드 (기존 bootstrap-20260413은 arm64로 잘못 푸시됨). CD 실행 시 gcp-N-SHA 로 auto-update
+  tag: "prod-39-c6ac3b3" # linux/amd64 buildx 재빌드 (기존 bootstrap-20260413은 arm64로 잘못 푸시됨). CD 실행 시 gcp-N-SHA 로 auto-update
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod-gcp/goti-resale/values.yaml
+++ b/environments/prod-gcp/goti-resale/values.yaml
@@ -2,7 +2,7 @@ nameOverride: goti-resale
 replicaCount: 0
 image:
   repository: "harbor.go-ti.shop/prod/goti-resale-go"
-  tag: "prod-38-18d0b20"
+  tag: "prod-39-c6ac3b3"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod-gcp/goti-stadium/values.yaml
+++ b/environments/prod-gcp/goti-stadium/values.yaml
@@ -2,7 +2,7 @@ nameOverride: goti-stadium
 replicaCount: 0
 image:
   repository: "harbor.go-ti.shop/prod/goti-stadium-go"
-  tag: "prod-38-18d0b20"
+  tag: "prod-39-c6ac3b3"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod-gcp/goti-ticketing/values.yaml
+++ b/environments/prod-gcp/goti-ticketing/values.yaml
@@ -2,7 +2,7 @@ nameOverride: goti-ticketing
 replicaCount: 0
 image:
   repository: "harbor.go-ti.shop/prod/goti-ticketing-go"
-  tag: "prod-38-18d0b20"
+  tag: "prod-39-c6ac3b3"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod-gcp/goti-user/values.yaml
+++ b/environments/prod-gcp/goti-user/values.yaml
@@ -2,7 +2,7 @@ nameOverride: goti-user
 replicaCount: 0
 image:
   repository: "harbor.go-ti.shop/prod/goti-user-go"
-  tag: "prod-38-18d0b20"
+  tag: "prod-39-c6ac3b3"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-payment-v2/values.yaml
+++ b/environments/prod/goti-payment-v2/values.yaml
@@ -95,7 +95,7 @@ env:
   - name: PAYMENT_DATABASE_URL
     value: "host=pgbouncer.goti.svc port=5432 user=goti password=$(DB_PASSWORD) dbname=goti_payment sslmode=disable"
   - name: PAYMENT_DATABASE_PGBOUNCER_COMPAT
-    value: "true" 
+    value: "true"
   - name: PAYMENT_REDIS_URL
     valueFrom:
       secretKeyRef:
@@ -167,7 +167,7 @@ istioPolicy:
     enabled: true
 image:
   repository: harbor.go-ti.shop/prod/goti-payment-go
-  tag: prod-38-18d0b20
+  tag: prod-39-c6ac3b3
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-queue-v2/values.yaml
+++ b/environments/prod/goti-queue-v2/values.yaml
@@ -105,7 +105,7 @@ env:
   - name: QUEUE_DATABASE_URL
     value: "host=pgbouncer.goti.svc port=5432 user=goti password=$(DB_PASSWORD) dbname=goti_queue sslmode=disable"
   - name: QUEUE_DATABASE_PGBOUNCER_COMPAT
-    value: "true" 
+    value: "true"
   - name: QUEUE_REDIS_URL
     valueFrom:
       secretKeyRef:
@@ -161,7 +161,7 @@ istioPolicy:
     enabled: true
 image:
   repository: harbor.go-ti.shop/prod/goti-queue-go
-  tag: prod-38-18d0b20
+  tag: prod-39-c6ac3b3
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-resale-v2/values.yaml
+++ b/environments/prod/goti-resale-v2/values.yaml
@@ -95,7 +95,7 @@ env:
   - name: RESALE_DATABASE_URL
     value: "host=pgbouncer.goti.svc port=5432 user=goti password=$(DB_PASSWORD) dbname=goti_resale sslmode=disable"
   - name: RESALE_DATABASE_PGBOUNCER_COMPAT
-    value: "true" 
+    value: "true"
   - name: RESALE_REDIS_URL
     valueFrom:
       secretKeyRef:
@@ -181,7 +181,7 @@ istioPolicy:
     enabled: true
 image:
   repository: harbor.go-ti.shop/prod/goti-resale-go
-  tag: prod-38-18d0b20
+  tag: prod-39-c6ac3b3
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-stadium-v2/values.yaml
+++ b/environments/prod/goti-stadium-v2/values.yaml
@@ -112,7 +112,7 @@ env:
   - name: STADIUM_DATABASE_URL
     value: "host=pgbouncer.goti.svc port=5432 user=goti password=$(DB_PASSWORD) dbname=goti_stadium sslmode=disable"
   - name: STADIUM_DATABASE_PGBOUNCER_COMPAT
-    value: "true" 
+    value: "true"
   - name: STADIUM_REDIS_URL
     valueFrom:
       secretKeyRef:
@@ -198,7 +198,7 @@ istioPolicy:
     enabled: true
 image:
   repository: harbor.go-ti.shop/prod/goti-stadium-go
-  tag: prod-38-18d0b20
+  tag: prod-39-c6ac3b3
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-ticketing-v2/values.yaml
+++ b/environments/prod/goti-ticketing-v2/values.yaml
@@ -118,7 +118,7 @@ env:
   - name: TICKETING_DATABASE_URL
     value: "host=pgbouncer.goti.svc port=5432 user=goti password=$(DB_PASSWORD) dbname=goti_ticketing sslmode=disable"
   - name: TICKETING_DATABASE_PGBOUNCER_COMPAT
-    value: "true" 
+    value: "true"
   - name: TICKETING_REDIS_URL
     valueFrom:
       secretKeyRef:
@@ -232,7 +232,7 @@ istioPolicy:
     enabled: true
 image:
   repository: harbor.go-ti.shop/prod/goti-ticketing-go
-  tag: prod-38-18d0b20
+  tag: prod-39-c6ac3b3
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-user-v2/values.yaml
+++ b/environments/prod/goti-user-v2/values.yaml
@@ -99,7 +99,7 @@ env:
   - name: USER_DATABASE_URL
     value: "host=pgbouncer.goti.svc port=5432 user=goti password=$(DB_PASSWORD) dbname=goti_user sslmode=disable"
   - name: USER_DATABASE_PGBOUNCER_COMPAT
-    value: "true" 
+    value: "true"
   - name: USER_REDIS_URL
     valueFrom:
       secretKeyRef:
@@ -240,7 +240,7 @@ istioPolicy:
     enabled: true
 image:
   repository: harbor.go-ti.shop/prod/goti-user-go
-  tag: prod-38-18d0b20
+  tag: prod-39-c6ac3b3
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds


### PR DESCRIPTION
## 변경 사항
- 이미지 태그: `prod-39-c6ac3b3`
- 레지스트리: `harbor.go-ti.shop/prod/`
- 업데이트된 서비스: `{"include":[{"service":"user"},{"service":"stadium"},{"service":"ticketing"},{"service":"payment"},{"service":"resale"},{"service":"queue"}]}`
- 대상 환경: AWS prod (`environments/prod/goti-*-go/`) + GCP prod (`environments/prod-gcp/goti-*/`)

## 트리거
- 레포: `ressKim-io/Goti-go`
- 브랜치: `deploy/prod`
- 커밋: c6ac3b322be1caf7b15eb8931e5b9602476514db
- 워크플로우: [#39](https://github.com/ressKim-io/Goti-go/actions/runs/24384030238)