### PR TITLE
[CHORE] prod Go 이미지 태그 업데이트: prod-40-ad8b68d

### DIFF
--- a/environments/prod-gcp/goti-payment/values.yaml
+++ b/environments/prod-gcp/goti-payment/values.yaml
@@ -2,7 +2,7 @@ nameOverride: goti-payment
 replicaCount: 0
 image:
   repository: "harbor.go-ti.shop/prod/goti-payment-go"
-  tag: "prod-39-c6ac3b3"
+  tag: "prod-40-ad8b68d"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod-gcp/goti-queue/values.yaml
+++ b/environments/prod-gcp/goti-queue/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 0
 nameOverride: goti-queue
 image:
   repository: "harbor.go-ti.shop/prod/goti-queue-go"
-  tag: "prod-39-c6ac3b3" # linux/amd64 buildx 재빌드 (기존 bootstrap-20260413은 arm64로 잘못 푸시됨). CD 실행 시 gcp-N-SHA 로 auto-update
+  tag: "prod-40-ad8b68d" # linux/amd64 buildx 재빌드 (기존 bootstrap-20260413은 arm64로 잘못 푸시됨). CD 실행 시 gcp-N-SHA 로 auto-update
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod-gcp/goti-resale/values.yaml
+++ b/environments/prod-gcp/goti-resale/values.yaml
@@ -2,7 +2,7 @@ nameOverride: goti-resale
 replicaCount: 0
 image:
   repository: "harbor.go-ti.shop/prod/goti-resale-go"
-  tag: "prod-39-c6ac3b3"
+  tag: "prod-40-ad8b68d"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod-gcp/goti-stadium/values.yaml
+++ b/environments/prod-gcp/goti-stadium/values.yaml
@@ -2,7 +2,7 @@ nameOverride: goti-stadium
 replicaCount: 0
 image:
   repository: "harbor.go-ti.shop/prod/goti-stadium-go"
-  tag: "prod-39-c6ac3b3"
+  tag: "prod-40-ad8b68d"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod-gcp/goti-ticketing/values.yaml
+++ b/environments/prod-gcp/goti-ticketing/values.yaml
@@ -2,7 +2,7 @@ nameOverride: goti-ticketing
 replicaCount: 0
 image:
   repository: "harbor.go-ti.shop/prod/goti-ticketing-go"
-  tag: "prod-39-c6ac3b3"
+  tag: "prod-40-ad8b68d"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod-gcp/goti-user/values.yaml
+++ b/environments/prod-gcp/goti-user/values.yaml
@@ -2,7 +2,7 @@ nameOverride: goti-user
 replicaCount: 0
 image:
   repository: "harbor.go-ti.shop/prod/goti-user-go"
-  tag: "prod-39-c6ac3b3"
+  tag: "prod-40-ad8b68d"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-payment-v2/values.yaml
+++ b/environments/prod/goti-payment-v2/values.yaml
@@ -167,7 +167,7 @@ istioPolicy:
     enabled: true
 image:
   repository: harbor.go-ti.shop/prod/goti-payment-go
-  tag: prod-39-c6ac3b3
+  tag: prod-40-ad8b68d
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-queue-v2/values.yaml
+++ b/environments/prod/goti-queue-v2/values.yaml
@@ -161,7 +161,7 @@ istioPolicy:
     enabled: true
 image:
   repository: harbor.go-ti.shop/prod/goti-queue-go
-  tag: prod-39-c6ac3b3
+  tag: prod-40-ad8b68d
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-resale-v2/values.yaml
+++ b/environments/prod/goti-resale-v2/values.yaml
@@ -181,7 +181,7 @@ istioPolicy:
     enabled: true
 image:
   repository: harbor.go-ti.shop/prod/goti-resale-go
-  tag: prod-39-c6ac3b3
+  tag: prod-40-ad8b68d
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-stadium-v2/values.yaml
+++ b/environments/prod/goti-stadium-v2/values.yaml
@@ -198,7 +198,7 @@ istioPolicy:
     enabled: true
 image:
   repository: harbor.go-ti.shop/prod/goti-stadium-go
-  tag: prod-39-c6ac3b3
+  tag: prod-40-ad8b68d
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-ticketing-v2/values.yaml
+++ b/environments/prod/goti-ticketing-v2/values.yaml
@@ -232,7 +232,7 @@ istioPolicy:
     enabled: true
 image:
   repository: harbor.go-ti.shop/prod/goti-ticketing-go
-  tag: prod-39-c6ac3b3
+  tag: prod-40-ad8b68d
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-user-v2/values.yaml
+++ b/environments/prod/goti-user-v2/values.yaml
@@ -240,7 +240,7 @@ istioPolicy:
     enabled: true
 image:
   repository: harbor.go-ti.shop/prod/goti-user-go
-  tag: prod-39-c6ac3b3
+  tag: prod-40-ad8b68d
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds


### PR DESCRIPTION
## 변경 사항
- 이미지 태그: `prod-40-ad8b68d`
- 레지스트리: `harbor.go-ti.shop/prod/`
- 업데이트된 서비스: `{"include":[{"service":"user"},{"service":"stadium"},{"service":"ticketing"},{"service":"payment"},{"service":"resale"},{"service":"queue"}]}`
- 대상 환경: AWS prod (`environments/prod/goti-*-go/`) + GCP prod (`environments/prod-gcp/goti-*/`)

## 트리거
- 레포: `ressKim-io/Goti-go`
- 브랜치: `deploy/prod`
- 커밋: ad8b68d7c0fb40aec634c121431e87b78fe44c57
- 워크플로우: [#40](https://github.com/ressKim-io/Goti-go/actions/runs/24384305600)