### PR TITLE
[CHORE] prod Go 이미지 태그 업데이트: prod-45-a754533

### DIFF
--- a/environments/prod-gcp/goti-ticketing/values.yaml
+++ b/environments/prod-gcp/goti-ticketing/values.yaml
@@ -2,7 +2,7 @@ nameOverride: goti-ticketing
 replicaCount: 0
 image:
   repository: "harbor.go-ti.shop/prod/goti-ticketing-go"
-  tag: "prod-44-0d6f7b4"
+  tag: "prod-45-a754533"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-ticketing-v2/values.yaml
+++ b/environments/prod/goti-ticketing-v2/values.yaml
@@ -232,7 +232,7 @@ istioPolicy:
     enabled: true
 image:
   repository: harbor.go-ti.shop/prod/goti-ticketing-go
-  tag: prod-44-0d6f7b4
+  tag: prod-45-a754533
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds


### PR DESCRIPTION
## 변경 사항
- 이미지 태그: `prod-45-a754533`
- 레지스트리: `harbor.go-ti.shop/prod/`
- 업데이트된 서비스: `{"include":[{"service":"ticketing"}]}`
- 대상 환경: AWS prod (`environments/prod/goti-*-go/`) + GCP prod (`environments/prod-gcp/goti-*/`)

## 트리거
- 레포: `ressKim-io/Goti-go`
- 브랜치: `deploy/prod`
- 커밋: a75453380494d094a778acf885e7c208fb5f6c94
- 워크플로우: [#45](https://github.com/ressKim-io/Goti-go/actions/runs/24387693193)