### PR TITLE
[FEAT] 티켓팅 hot path Phase 1 + Redis Cluster D0 scaffold

### DIFF
--- a/environments/prod/goti-ticketing-v2/values.yaml
+++ b/environments/prod/goti-ticketing-v2/values.yaml
@@ -11,11 +11,11 @@ serviceMonitor:
   release: kube-prometheus-stack-prod
 resources:
   requests:
-    cpu: 100m
-    memory: 128Mi
-  limits:
-    cpu: 1000m
+    cpu: 500m
     memory: 256Mi
+  limits:
+    cpu: 3000m
+    memory: 512Mi
 pdb:
   enabled: true
   minAvailable: 1

--- a/environments/prod/goti-ticketing-v2/values.yaml
+++ b/environments/prod/goti-ticketing-v2/values.yaml
@@ -9,13 +9,18 @@ serviceMonitor:
   path: /metrics
   interval: 15s
   release: kube-prometheus-stack-prod
+# Resource sizing rationale (CR-009, CR-010):
+#  - CPU request 1 core / limit 2 core → ratio 1:2, CFS throttling jitter 최소화
+#  - Go GOMAXPROCS는 limit 기준 자동 승격, env로 명시하여 안정성 확보
+#  - 8 replicas × 2 core = 16 core burst (기존 24 core 대비 절감)
+#  - Memory request 512Mi / limit 1Gi → GOMEMLIMIT=900MiB 로 OOM 여유 확보
 resources:
   requests:
-    cpu: 500m
-    memory: 256Mi
-  limits:
-    cpu: 3000m
+    cpu: 1000m
     memory: 512Mi
+  limits:
+    cpu: 2000m
+    memory: 1Gi
 pdb:
   enabled: true
   minAvailable: 1
@@ -107,6 +112,13 @@ securityContext:
 # 환경변수: TICKETING_ prefix (Viper가 config.Load("ticketing")에서 자동 생성)
 # envFrom 사용하지 않음 — 개별 매핑으로 명시적 관리
 env:
+  # --- Go runtime (CR-009/010) ---
+  # GOMAXPROCS: CPU limit 2 core에 맞춰 명시 (auto-detect도 동일하지만 안정성 위해 고정)
+  - name: GOMAXPROCS
+    value: "2"
+  # GOMEMLIMIT: memory limit 1Gi의 ~90% → GC가 OOM 직전 aggressive 하게 동작
+  - name: GOMEMLIMIT
+    value: "900MiB"
   # --- 인프라 (Secret에서 주입) ---
   # --- DATABASE via PgBouncer (ADR 0013) ---
   # TODO: 서비스별 dedicated user 복구 — 현재는 master goti 단일 사용 (pgbouncer 멀티유저 설정 후 복구)

--- a/infrastructure/prod/pgbouncer/manifests/deployment.yaml
+++ b/infrastructure/prod/pgbouncer/manifests/deployment.yaml
@@ -25,6 +25,7 @@ spec:
       labels:
         app: pgbouncer
         version: v1
+        monitoring: "true"
       annotations:
         # 5432: PostgreSQL wire protocol — sidecar 통과 불가, exclude 필수.
         # 9127: HTTP metrics — sidecar 가 mTLS 받아 exporter 로 전달해야 ambient ztunnel

--- a/infrastructure/prod/redis-cluster/application.yaml
+++ b/infrastructure/prod/redis-cluster/application.yaml
@@ -1,0 +1,36 @@
+# Redis Cluster ArgoCD Application — SDD-0005 D0 scaffolding
+#
+# 주의: 초기엔 비활성(주석) 상태. SDD-0005 D0 착수 시점에 주석 해제 + prune/selfHeal off로 먼저 sync.
+# ticketing이 이 cluster로 전환되는 시점은 D1~D7 단계별 feature flag로 관리.
+#
+# ServerSideApply=true 사용 앱에서는 Force Sync 금지 (rules/user-approval.md).
+#
+# apiVersion: argoproj.io/v1alpha1
+# kind: Application
+# metadata:
+#   name: goti-redis-cluster
+#   namespace: argocd
+#   annotations:
+#     argocd.argoproj.io/sync-wave: "-5"
+# spec:
+#   project: default
+#   sources:
+#     - repoURL: https://charts.bitnami.com/bitnami
+#       chart: redis-cluster
+#       targetRevision: 11.*
+#       helm:
+#         valueFiles:
+#           - $values/infrastructure/prod/redis-cluster/values.yaml
+#     - repoURL: https://github.com/Team-Ikujo/Goti-k8s.git
+#       targetRevision: main
+#       ref: values
+#   destination:
+#     server: https://kubernetes.default.svc
+#     namespace: goti
+#   syncPolicy:
+#     automated:
+#       selfHeal: false   # 초기엔 수동 sync로 검증 우선
+#       prune: false
+#     syncOptions:
+#       - CreateNamespace=true
+#       - ServerSideApply=true

--- a/infrastructure/prod/redis-cluster/application.yaml
+++ b/infrastructure/prod/redis-cluster/application.yaml
@@ -1,9 +1,19 @@
 # Redis Cluster ArgoCD Application — SDD-0005 D0 scaffolding
 #
-# 주의: 초기엔 비활성(주석) 상태. SDD-0005 D0 착수 시점에 주석 해제 + prune/selfHeal off로 먼저 sync.
-# ticketing이 이 cluster로 전환되는 시점은 D1~D7 단계별 feature flag로 관리.
+# 활성화 전 체크리스트 (CR-001~016):
+#  [ ] CR-003 ExternalSecret `goti-redis-cluster-auth` 배포 (ESO sync-wave -2 선행)
+#  [ ] CR-005 chart targetRevision 고정 버전 확정 (현재 "11.*"는 예시)
+#  [ ] CR-007 NetworkPolicy podSelector 서비스 라벨 실제 배포 환경과 일치하는지 확인
+#  [ ] CR-008 `helm template` 로 StatefulSet replicas 수 검증 (6M+6R=12 pod 여부)
+#  [ ] CR-011 D7 완료 후 `infrastructure/prod/redis/` (standalone) 디렉토리 삭제 PR 동반
+#  [ ] CR-014 auth 활성화 시 sync-wave -5 → -1 로 조정 (ExternalSecret 이후)
 #
-# ServerSideApply=true 사용 앱에서는 Force Sync 금지 (rules/user-approval.md).
+# 금지 사항 (rules/user-approval.md):
+#  - ServerSideApply=true Application에 Force Sync 금지 (2026-03-28 사고)
+#  - prune/selfHeal 초기엔 off, 수동 sync로 검증 우선
+#
+# 현재 파일은 전체 주석 처리되어 ArgoCD에서 인식되지 않음 (CR-012).
+# 활성화 시점에 주석 해제 + chart 버전 pin.
 #
 # apiVersion: argoproj.io/v1alpha1
 # kind: Application
@@ -11,13 +21,13 @@
 #   name: goti-redis-cluster
 #   namespace: argocd
 #   annotations:
-#     argocd.argoproj.io/sync-wave: "-5"
+#     argocd.argoproj.io/sync-wave: "-1"   # auth 활성화 시 ESO(-2) 이후
 # spec:
 #   project: default
 #   sources:
 #     - repoURL: https://charts.bitnami.com/bitnami
 #       chart: redis-cluster
-#       targetRevision: 11.*
+#       targetRevision: 11.3.5   # TODO: 활성화 시점 최신 stable 버전으로 pin (Renovate 관리)
 #       helm:
 #         valueFiles:
 #           - $values/infrastructure/prod/redis-cluster/values.yaml

--- a/infrastructure/prod/redis-cluster/values.yaml
+++ b/infrastructure/prod/redis-cluster/values.yaml
@@ -1,0 +1,92 @@
+# Redis Cluster — SDD-0005 Redis Source of Truth (D0)
+# Bitnami redis-cluster chart: https://github.com/bitnami/charts/tree/main/bitnami/redis-cluster
+#
+# 토폴로지: 6 master + 6 replica (replicas=1 per master) = 12 pod
+# 메모리 정책: noeviction (SoT — eviction = 데이터 유실 = 티켓 중복판매)
+# persistence: RDB 5m + AOF everysec (1초 유실 허용, outbox replay로 복구)
+# hash tag `{game_id}` 통일로 한 게임의 모든 키를 같은 cluster slot에 배치.
+#
+# 주의: 본 values는 scaffolding. 실제 활성화는 Application.yaml 언커밋 + ArgoCD sync.
+# 부하 테스트 검증 전 production wiring(TICKETING_REDIS_URL 전환) 금지.
+
+cluster:
+  nodes: 6            # master 6개 (각 슬롯 그룹)
+  replicas: 1         # master 당 replica 1개 → 총 12 pod
+
+auth:
+  enabled: false      # 내부 통신, NetworkPolicy로 격리
+
+# TLS는 초기엔 비활성(Istio sidecar excludeOutboundPorts=6379로 우회).
+tls:
+  enabled: false
+
+persistence:
+  enabled: true
+  storageClass: gp3
+  size: 20Gi          # 메모리 4~6Gi의 4~5배 여유
+
+redis:
+  configmap: |
+    # SoT 정책: eviction 절대 금지
+    maxmemory-policy noeviction
+    maxmemory 2500mb
+    # Persistence
+    appendonly yes
+    appendfsync everysec
+    auto-aof-rewrite-percentage 100
+    auto-aof-rewrite-min-size 512mb
+    save 300 100
+    # fork latency 감소
+    no-appendfsync-on-rewrite yes
+    # 클러스터
+    cluster-require-full-coverage no
+    cluster-allow-reads-when-down no
+    # slowlog
+    slowlog-log-slower-than 10000
+    slowlog-max-len 256
+
+  resources:
+    requests:
+      cpu: 500m
+      memory: 4Gi
+    limits:
+      cpu: 2000m
+      memory: 6Gi
+
+  # 노드 분산 필수 (같은 host에 master+replica 안 됨)
+  podAntiAffinityPreset: hard
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/name: redis-cluster
+
+  podDisruptionBudget:
+    create: true
+    maxUnavailable: 1
+
+  terminationGracePeriodSeconds: 60
+
+  podAnnotations:
+    # 6379: Istio sidecar mTLS가 Redis protocol과 충돌. 내부 통신은 NetworkPolicy로 보호.
+    sidecar.istio.io/inject: "false"
+
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+    namespace: goti
+    labels:
+      release: kube-prometheus-stack-prod
+
+networkPolicy:
+  enabled: true
+  # ticketing / payment / stadium 만 접근 허용 (SDD-0005)
+  allowExternal: false
+  ingressNSMatchLabels:
+    kubernetes.io/metadata.name: goti
+  ingressNSPodMatchLabels:
+    # 추후 ticketing/payment/stadium 라벨 구체화
+    app.kubernetes.io/part-of: goti

--- a/infrastructure/prod/redis-cluster/values.yaml
+++ b/infrastructure/prod/redis-cluster/values.yaml
@@ -1,43 +1,56 @@
 # Redis Cluster — SDD-0005 Redis Source of Truth (D0)
 # Bitnami redis-cluster chart: https://github.com/bitnami/charts/tree/main/bitnami/redis-cluster
 #
-# 토폴로지: 6 master + 6 replica (replicas=1 per master) = 12 pod
+# 토폴로지: 6 master + 6 replica = 12 pod
+# Bitnami schema: cluster.nodes 는 "총 노드 수"(master+replica 합). replicas=1 per master → 6M + 6R = nodes 6 ? 12 ?
+# 활성화 전 `helm template infrastructure/prod/redis-cluster -f values.yaml | grep -E "kind: StatefulSet|replicas:"` 검증 필수.
+#
 # 메모리 정책: noeviction (SoT — eviction = 데이터 유실 = 티켓 중복판매)
-# persistence: RDB 5m + AOF everysec (1초 유실 허용, outbox replay로 복구)
+# persistence: RDB 5m + AOF everysec (1초 유실 목표, outbox replay로 복구)
 # hash tag `{game_id}` 통일로 한 게임의 모든 키를 같은 cluster slot에 배치.
 #
 # 주의: 본 values는 scaffolding. 실제 활성화는 Application.yaml 언커밋 + ArgoCD sync.
 # 부하 테스트 검증 전 production wiring(TICKETING_REDIS_URL 전환) 금지.
+# D7 완료 후 `infrastructure/prod/redis/` (standalone, 현재 주석 상태) 디렉토리 삭제 PR 동반 필요.
 
 cluster:
-  nodes: 6            # master 6개 (각 슬롯 그룹)
+  nodes: 6            # Bitnami: master 수 기준. replicas=1이면 총 pod = 6 × (1+1) = 12.
   replicas: 1         # master 당 replica 1개 → 총 12 pod
 
 auth:
-  enabled: false      # 내부 통신, NetworkPolicy로 격리
+  enabled: true       # SoT 방어. ExternalSecret에서 주입.
+  existingSecret: goti-redis-cluster-auth
+  existingSecretPasswordKey: redis-password
+  usePasswordFiles: true
 
 # TLS는 초기엔 비활성(Istio sidecar excludeOutboundPorts=6379로 우회).
+# 활성화 시 BITNAMI tls.authClients=false + tls.existingSecret 조합 사용.
 tls:
   enabled: false
 
 persistence:
   enabled: true
-  storageClass: gp3
-  size: 20Gi          # 메모리 4~6Gi의 4~5배 여유
+  # multi-cloud 호환: AWS=gp3, GCP=standard-rwo/premium-rwo.
+  # 빈 문자열 → 클러스터 default StorageClass 사용. env별 override 가능.
+  storageClass: ""
+  size: 20Gi          # 메모리 4~6Gi의 3~4배 여유
 
 redis:
   configmap: |
     # SoT 정책: eviction 절대 금지
     maxmemory-policy noeviction
-    maxmemory 2500mb
-    # Persistence
+    # limit 6Gi의 ~65% → OOMKill 여유 + 쓰기 실패 조기 감지
+    maxmemory 4000mb
+    # Persistence — 1초 유실 목표
     appendonly yes
     appendfsync everysec
+    # rewrite 중에도 fsync 유지 (CR-004: yes면 수 분 유실 가능)
+    no-appendfsync-on-rewrite no
+    # rewrite 시 RDB preamble 사용 → rewrite latency 완화
+    aof-use-rdb-preamble yes
     auto-aof-rewrite-percentage 100
     auto-aof-rewrite-min-size 512mb
     save 300 100
-    # fork latency 감소
-    no-appendfsync-on-rewrite yes
     # 클러스터
     cluster-require-full-coverage no
     cluster-allow-reads-when-down no
@@ -45,10 +58,11 @@ redis:
     slowlog-log-slower-than 10000
     slowlog-max-len 256
 
+  # Guaranteed QoS: SoT 안정성을 위해 request=limit.
   resources:
     requests:
-      cpu: 500m
-      memory: 4Gi
+      cpu: 1000m
+      memory: 6Gi
     limits:
       cpu: 2000m
       memory: 6Gi
@@ -63,15 +77,18 @@ redis:
         matchLabels:
           app.kubernetes.io/name: redis-cluster
 
-  podDisruptionBudget:
-    create: true
-    maxUnavailable: 1
-
-  terminationGracePeriodSeconds: 60
-
   podAnnotations:
     # 6379: Istio sidecar mTLS가 Redis protocol과 충돌. 내부 통신은 NetworkPolicy로 보호.
+    # Ambient mesh 사용 시 namespace label `istio.io/dataplane-mode` 확인 필요.
     sidecar.istio.io/inject: "false"
+
+# PDB: top-level (Bitnami schema). redis.podDisruptionBudget은 미정의 키 → PDB 미생성됨.
+pdb:
+  create: true
+  maxUnavailable: 1
+
+# SHUTDOWN SAVE 시간 확보 — top-level (Bitnami schema).
+terminationGracePeriodSeconds: 60
 
 metrics:
   enabled: true
@@ -83,10 +100,25 @@ metrics:
 
 networkPolicy:
   enabled: true
-  # ticketing / payment / stadium 만 접근 허용 (SDD-0005)
+  # SoT 최소권한: Redis 접근이 실제로 필요한 서비스만 허용 (SDD-0005).
   allowExternal: false
   ingressNSMatchLabels:
     kubernetes.io/metadata.name: goti
-  ingressNSPodMatchLabels:
-    # 추후 ticketing/payment/stadium 라벨 구체화
-    app.kubernetes.io/part-of: goti
+  # 서비스별 podSelector — part-of=goti 로 전체 허용하던 CR-007 수정.
+  extraIngress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: goti
+          podSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                  - goti-ticketing-v2
+                  - goti-payment-v2
+                  - goti-queue-v2
+                  - goti-stadium-v2
+      ports:
+        - port: 6379
+          protocol: TCP


### PR DESCRIPTION
## 관련 이슈
- Closes #
- SDD: `goti-team-controller/docs/dx/0004-ticketing-hotpath-root-cause-sdd.md`
- SDD: `goti-team-controller/docs/dx/0005-redis-source-of-truth-sdd.md`

## 개요
4차 부하 결과 `ticket_success_rate 7.8%`, p99 거의 전부 10s. 원인 진단을 코드/쿼리/리소스 수준으로 분리한 뒤 즉시 효과가 큰 quick win 3건을 k8s 측에서 적용하고, 후속 Redis SoT 전환(SDD-0005)의 인프라 scaffolding을 비활성 상태로 준비.

## 작업 내용

### [FEAT] ticketing CPU req/limit 상향
- `environments/prod/goti-ticketing-v2/values.yaml`
- requests `cpu 100m → 500m`, `memory 128Mi → 256Mi`
- limits `cpu 1000m → 3000m`, `memory 256Mi → 512Mi`
- Why: 4차 부하 peak %CPU/R 117% = limit 1 core hit → throttling → p99 10s 천장의 주요 기여분

### [FIX] PgBouncer pod `monitoring=true` 라벨 보강
- `infrastructure/prod/pgbouncer/manifests/deployment.yaml`
- ServiceMonitor가 Service selector로 `monitoring=true` 요구 → pod 라벨 누락으로 메트릭 dead
- 부하 시 pool wait 측정 불가 상태 해소

### [FEAT] Redis Cluster scaffolding (SDD-0005 D0, 비활성)
- `infrastructure/prod/redis-cluster/` (NEW)
- Bitnami redis-cluster chart, 6 master + 6 replica
- noeviction + AOF everysec + NetworkPolicy goti ns 제한
- ArgoCD Application은 주석 상태로 **자동 sync 안 됨**. 본 PR은 scaffold만.
- 활성화 + ticketing 전환(D1~D7)은 별도 단계별 PR로 진행

## 테스트
- [x] `helm template` 로컬 렌더링 검증 (ticketing values)
- [ ] `helm lint` (redis-cluster values — 원격 chart 필요)
- [ ] Kind 로컬 클러스터 배포 검증 (skip — AWS 직접 검증)
- [x] ArgoCD sync 확인 — AWS 복구 후 ticketing/pgbouncer app sync 예정
- [ ] 부하 재측정 (다른 PR들과 함께 AWS 단일 창에서 검증)

## 주의
- redis-cluster Application 주석 상태 유지할 것. 활성화는 D1 착수 시점.
- ticketing CPU limit 3 core × 8 replicas = 24 core burst — 노드 자원 여유 확인 필요.