### PR TITLE
[FEAT] KEDA advanced 필드 chart 지원 (SDD-0007 PR-1)

### DIFF
--- a/charts/goti-common/Chart.yaml
+++ b/charts/goti-common/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: goti-common
 description: Goti 공통 Helm Library Chart — MSA 전환 대비 공통 템플릿
 type: library
-version: 0.1.0
+version: 0.2.0

--- a/charts/goti-common/templates/_hpa.tpl
+++ b/charts/goti-common/templates/_hpa.tpl
@@ -15,11 +15,13 @@ spec:
   minReplicaCount: {{ .Values.autoscaling.minReplicas }}
   maxReplicaCount: {{ .Values.autoscaling.maxReplicas }}
   cooldownPeriod: {{ .Values.autoscaling.keda.cooldownPeriod | default 60 }}
-  {{- with .Values.autoscaling.keda.pollingInterval }}
-  pollingInterval: {{ . }}
+  {{- /* hasKey: 0 같은 falsy 값을 보존 (with는 0/empty를 skip).
+         특히 idleReplicaCount=0 (scale-to-zero)은 KEDA의 핵심 유효 값. */}}
+  {{- if hasKey .Values.autoscaling.keda "pollingInterval" }}
+  pollingInterval: {{ .Values.autoscaling.keda.pollingInterval }}
   {{- end }}
-  {{- with .Values.autoscaling.keda.idleReplicaCount }}
-  idleReplicaCount: {{ . }}
+  {{- if hasKey .Values.autoscaling.keda "idleReplicaCount" }}
+  idleReplicaCount: {{ .Values.autoscaling.keda.idleReplicaCount }}
   {{- end }}
   {{- with .Values.autoscaling.keda.advanced }}
   advanced:

--- a/charts/goti-common/templates/_hpa.tpl
+++ b/charts/goti-common/templates/_hpa.tpl
@@ -15,6 +15,20 @@ spec:
   minReplicaCount: {{ .Values.autoscaling.minReplicas }}
   maxReplicaCount: {{ .Values.autoscaling.maxReplicas }}
   cooldownPeriod: {{ .Values.autoscaling.keda.cooldownPeriod | default 60 }}
+  {{- with .Values.autoscaling.keda.pollingInterval }}
+  pollingInterval: {{ . }}
+  {{- end }}
+  {{- with .Values.autoscaling.keda.idleReplicaCount }}
+  idleReplicaCount: {{ . }}
+  {{- end }}
+  {{- with .Values.autoscaling.keda.advanced }}
+  advanced:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.autoscaling.keda.fallback }}
+  fallback:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   triggers:
     {{- toYaml .Values.autoscaling.keda.triggers | nindent 4 }}
 {{- else }}

--- a/charts/goti-server/Chart.yaml
+++ b/charts/goti-server/Chart.yaml
@@ -6,5 +6,5 @@ version: 0.1.0
 appVersion: "0.0.1"
 dependencies:
   - name: goti-common
-    version: "0.1.0"
+    version: "0.2.0"
     repository: "file://../goti-common"


### PR DESCRIPTION
## 관련 이슈
- SDD-0007 PR-1 (goti-team-controller plan file)
- 후속: PR-2 (Karpenter spot), PR-3 (v2 services KEDA tuning)

## 개요
goti-common `_hpa.tpl` 이 KEDA ScaledObject spec의 `pollingInterval`, `idleReplicaCount`, `advanced` (HPA behavior), `fallback` 를 렌더링하지 못했음. 후속 PR-3에서 scale-up 반응성 튜닝을 위해 이 필드를 사용하려면 chart 선행 확장 필요.

## 작업 내용
- `charts/goti-common/templates/_hpa.tpl`
- optional 필드 4종 추가 (모두 `with` 블록으로 감싸 비어있으면 렌더링 안 됨)
- 기존 values (ticketing-v2, payment-v2 등) 에 영향 없음

## 테스트
- [x] `helm template charts/goti-server -f environments/prod/goti-ticketing-v2/values.yaml --show-only templates/hpa.yaml` 기존 동일 출력 확인
- [ ] PR-3 merge 후 ScaledObject에 advanced/pollingInterval 반영 `kubectl get scaledobject -o yaml` 로 검증
- [ ] Kind 로컬 배포 검증 (skip — AWS 직접 검증)