### PR TITLE
[FEAT] Karpenter NodePool spot 활성화 + overprovision (SDD-0007 PR-2)

### DIFF
--- a/infrastructure/prod/karpenter/config/nodepool.yaml
+++ b/infrastructure/prod/karpenter/config/nodepool.yaml
@@ -1,44 +1,52 @@
-# apiVersion: karpenter.sh/v1
-# kind: NodePool
-# metadata:
-#   name: goti-app
-# spec:
-#   template:
-#     spec:
-#       nodeClassRef:
-#         group: karpenter.k8s.aws
-#         kind: EC2NodeClass
-#         name: goti-app
-#       requirements:
-#         - key: karpenter.sh/capacity-type
-#           operator: In
-#           values: ["on-demand"]  # Red Team 대비: spot 회수로 인한 서비스 중단 방지 (이후 spot 복원)
-#         - key: node.kubernetes.io/instance-type
-#           operator: In
-#           values:
-#             # 주력 (현재 Spot NodeGroup과 동일)
-#             - t3a.xlarge   # 4c/16G
-#             - t3.xlarge    # 4c/16G
-#             # 대체 (Spot 재고 부족 시 fallback)
-#             - t3a.large    # 2c/8G
-#             - t3.large     # 2c/8G
-#             # 버스트용 (티켓팅 급증 대비)
-#             - m5a.xlarge   # 4c/16G, 네트워크 성능 우수
-#             - m5.xlarge    # 4c/16G
-#             - c5a.xlarge   # 4c/8G, CPU 집약 작업용
-#             - c5.xlarge    # 4c/8G
-#         - key: topology.kubernetes.io/zone
-#           operator: In
-#           values: ["ap-northeast-2a", "ap-northeast-2b", "ap-northeast-2c"]
-#       # Spot NodeGroup과 동일한 taint — 앱 Pod만 여기에 스케줄
-#       taints:
-#         - key: node-role
-#           value: spot
-#           effect: NoSchedule
-#   limits:
-#     cpu: "100"
-#     memory: 400Gi
-#   disruption:
-#     consolidationPolicy: WhenEmptyOrUnderutilized
-#     # Java JVM 워밍업 + 티켓팅 트래픽 안정화 시까지 성급한 노드 반납 방지 (5m → 15m)
-#     consolidateAfter: 15m
+# Karpenter NodePool — Spot-only burst capacity (SDD-0007 PR-2).
+# 기존 Spot NodeGroup(maxSize=8, t3.large only)의 burst 한계 보완.
+# Spot 중단 처리: application.yaml 의 settings.interruptionQueue (goti-prod-karpenter SQS) 사용.
+# 다중 instance type(6종) + 다중 AZ(3개)로 동시 회수 blast radius 제한.
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: goti-app
+spec:
+  template:
+    metadata:
+      labels:
+        pool: app-spot
+    spec:
+      nodeClassRef:
+        group: karpenter.k8s.aws
+        kind: EC2NodeClass
+        name: goti-app
+      requirements:
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["spot"]
+        - key: node.kubernetes.io/instance-type
+          operator: In
+          values:
+            # 주력 (4c/16G)
+            - t3a.xlarge
+            - t3.xlarge
+            - m5a.xlarge
+            - m5.xlarge
+            # CPU 집약 (4c/8G) — JSON marshal/JWT verify 등 ticketing 워크로드 적합
+            - c5a.xlarge
+            - c5.xlarge
+        - key: topology.kubernetes.io/zone
+          operator: In
+          values: ["ap-northeast-2a", "ap-northeast-2b", "ap-northeast-2c"]
+      taints:
+        # 기존 Spot NodeGroup과 동일 — 앱 Pod toleration 그대로 재사용
+        - key: node-role
+          value: spot
+          effect: NoSchedule
+  limits:
+    # 비용 폭증 방지 상한 — Karpenter가 limit 도달 시 신규 노드 생성 중지
+    cpu: "100"
+    memory: 400Gi
+  disruption:
+    consolidationPolicy: WhenEmptyOrUnderutilized
+    # prod 안정성: 워밍업 + 트래픽 안정화 시까지 성급한 노드 반납 방지
+    consolidateAfter: 15m
+    budgets:
+      # Karpenter 자발적 축출은 동시 1대만. spot 강제 회수와는 별개.
+      - nodes: "1"

--- a/infrastructure/prod/karpenter/config/nodepool.yaml
+++ b/infrastructure/prod/karpenter/config/nodepool.yaml
@@ -44,9 +44,10 @@ spec:
     cpu: "100"
     memory: 400Gi
   disruption:
-    consolidationPolicy: WhenEmptyOrUnderutilized
-    # prod 안정성: 워밍업 + 트래픽 안정화 시까지 성급한 노드 반납 방지
-    consolidateAfter: 15m
+    # CR-004: 초기 안정화 단계는 WhenEmpty (Underutilized 재배치로 인한 Go/JVM 재기동 비용 회피).
+    # 2~4주 운영 후 비용 최적화 단계에서 WhenEmptyOrUnderutilized로 전환 검토.
+    consolidationPolicy: WhenEmpty
+    consolidateAfter: 30m
     budgets:
       # Karpenter 자발적 축출은 동시 1대만. spot 강제 회수와는 별개.
       - nodes: "1"

--- a/infrastructure/prod/karpenter/config/overprovision.yaml
+++ b/infrastructure/prod/karpenter/config/overprovision.yaml
@@ -1,0 +1,58 @@
+# Overprovision pause Deployment (SDD-0007 PR-2).
+# Why: Karpenter 새 노드 프로비저닝 60~90s 지연을 burst 전에 흡수.
+# pause pod가 노드 1대를 미리 선점 → 실제 워크로드 pod 도착 시 priority 차이로 즉시 밀려나며 자리 양보.
+# 비용: spot t3a.xlarge 1대 ≈ $0.04/hr × 24h = $1/day.
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: goti-overprovision
+value: -1
+globalDefault: false
+description: "Karpenter burst overprovision용 — 실제 워크로드보다 항상 낮은 우선순위"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: goti-overprovision
+  namespace: goti
+  labels:
+    app: goti-overprovision
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: goti-overprovision
+  template:
+    metadata:
+      labels:
+        app: goti-overprovision
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      priorityClassName: goti-overprovision
+      tolerations:
+        # Karpenter NodePool 과 기존 Spot NodeGroup 모두 호환되는 toleration
+        - key: node-role
+          operator: Equal
+          value: spot
+          effect: NoSchedule
+      containers:
+        - name: pause
+          image: registry.k8s.io/pause:3.10
+          # CPU 1 core + 512Mi 메모리 선점 → ticketing pod 1대 자리 확보
+          resources:
+            requests:
+              cpu: 1000m
+              memory: 512Mi
+            limits:
+              cpu: 1000m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 65532
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault

--- a/infrastructure/prod/karpenter/config/overprovision.yaml
+++ b/infrastructure/prod/karpenter/config/overprovision.yaml
@@ -14,7 +14,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: goti-overprovision
-  namespace: goti
+  # CR-002: Application destination.namespace=karpenter 와 일치 (manifest namespace 우선이지만 tracking 통일)
+  namespace: karpenter
   labels:
     app: goti-overprovision
 spec:
@@ -30,8 +31,11 @@ spec:
         sidecar.istio.io/inject: "false"
     spec:
       priorityClassName: goti-overprovision
+      # CR-001: 반드시 Karpenter NodePool에만 스케줄. 기존 Spot NodeGroup에 가면
+      # Karpenter burst가 트리거되지 않아 overprovision 의도 무효화.
+      nodeSelector:
+        pool: app-spot
       tolerations:
-        # Karpenter NodePool 과 기존 Spot NodeGroup 모두 호환되는 toleration
         - key: node-role
           operator: Equal
           value: spot


### PR DESCRIPTION
## 관련 이슈
- SDD-0007 PR-2 (plan: goti-team-controller `~/.claude/plans/misty-seeking-orbit.md`)
- 선행: PR #258 (goti-common chart KEDA advanced 필드)
- 후속: PR-3 (v2 services KEDA tuning)

## 개요
4차 부하에서 Spot NodeGroup maxSize=8 × t3.large 2vCPU = **16 core 상한**으로 burst 시 pod pending 발생. nodepool.yaml 이 전체 주석 상태였던 것 발견. spot-only로 활성화하고 overprovision pause pod로 burst 흡수.

## 작업 내용

### NodePool 활성화 (`infrastructure/prod/karpenter/config/nodepool.yaml`)
- `capacity-type: spot` (학습 환경 비용 절감 60~90%)
- 다중 instance type 6종: `t3a/t3.xlarge`, `m5a/m5.xlarge`, `c5a/c5.xlarge`
- 다중 AZ 3개: `ap-northeast-2a/b/c`
- limits: `cpu=100, memory=400Gi`
- `consolidateAfter: 15m`, `disruption.budgets nodes=1`
- taint: 기존 Spot NodeGroup과 동일 (`node-role=spot:NoSchedule`)

### Overprovision (`infrastructure/prod/karpenter/config/overprovision.yaml` 신규)
- PriorityClass `goti-overprovision` value=-1
- pause:3.10 1 replica, CPU 1 core / Memory 512Mi 선점
- Karpenter 노드 프로비저닝 60~90s 지연 흡수
- 비용 ≈ \$1/day

## Spot 중단 처리
`application.yaml:26` 에 `settings.interruptionQueue: 'goti-prod-karpenter'` SQS 이미 설정됨. AWS 2분 전 spot interruption notice → SQS → Karpenter graceful drain. **aws-node-termination-handler 별도 배포 불필요**.

## 테스트
- [x] YAML 구문 검증
- [ ] ArgoCD sync 후 `kubectl get nodepool goti-app -o yaml` 확인
- [ ] `kubectl get nodes -l pool=app-spot` 또는 `karpenter.sh/capacity-type=spot` 새 노드 관찰
- [ ] 부하 시 `karpenter_nodeclaims_created_total` Grafana 추이 확인
- [ ] (선택) spot 강제 회수 chaos test

## 리스크
- spot 동시 회수 최악 케이스 → 다중 instance type/AZ mix로 완화. 극단 시 NodePool limits 내 자동 재스케줄.
- overprovision pod 1대 = spot t3a.xlarge 1대 비용 (~\$1/day)