### PR TITLE
[FEAT] v2 서비스 KEDA 튜닝 + cron prewarm (SDD-0007 PR-3)

### DIFF
--- a/environments/prod/goti-payment-v2/values.yaml
+++ b/environments/prod/goti-payment-v2/values.yaml
@@ -42,18 +42,43 @@ gateway:
               number: 8080
 autoscaling:
   enabled: true
-  minReplicas: 4
-  maxReplicas: 8
+  # SDD-0007 PR-3: ticketing 결제 chain 동기 호출 흡수, prewarm + burst 대응.
+  minReplicas: 6
+  maxReplicas: 16
   keda:
     enabled: true
-    cooldownPeriod: 300
+    pollingInterval: 10
+    cooldownPeriod: 120
+    advanced:
+      horizontalPodAutoscalerConfig:
+        behavior:
+          scaleUp:
+            stabilizationWindowSeconds: 0
+            policies:
+              - { type: Pods, value: 8, periodSeconds: 15 }
+              - { type: Percent, value: 200, periodSeconds: 15 }
+            selectPolicy: Max
+          scaleDown:
+            stabilizationWindowSeconds: 300
+            policies:
+              - { type: Percent, value: 25, periodSeconds: 60 }
     triggers:
+      - type: cron
+        metadata:
+          timezone: "Asia/Seoul"
+          start: "30 09 * * *"
+          end: "0 13 * * *"
+          desiredReplicas: "10"
       - type: prometheus
         metadata:
           serverAddress: http://mimir-prod-query-frontend.monitoring.svc.cluster.local:8080/prometheus
           metricName: http_rps_payment_go
-          query: sum(rate(http_server_request_duration_seconds_count{service_name="goti-payment-v2"}[1m]))
-          threshold: "30"
+          query: sum(rate(http_server_request_duration_seconds_count{service_name="goti-payment-v2"}[30s]))
+          threshold: "20"
+      - type: cpu
+        metricType: Utilization
+        metadata:
+          value: "70"
 probes:
   liveness:
     httpGet:

--- a/environments/prod/goti-payment-v2/values.yaml
+++ b/environments/prod/goti-payment-v2/values.yaml
@@ -53,7 +53,7 @@ autoscaling:
       horizontalPodAutoscalerConfig:
         behavior:
           scaleUp:
-            stabilizationWindowSeconds: 0
+            stabilizationWindowSeconds: 15
             policies:
               - { type: Pods, value: 8, periodSeconds: 15 }
               - { type: Percent, value: 200, periodSeconds: 15 }
@@ -66,14 +66,14 @@ autoscaling:
       - type: cron
         metadata:
           timezone: "Asia/Seoul"
-          start: "30 09 * * *"
+          start: "20 09 * * *"
           end: "0 13 * * *"
           desiredReplicas: "10"
       - type: prometheus
         metadata:
           serverAddress: http://mimir-prod-query-frontend.monitoring.svc.cluster.local:8080/prometheus
           metricName: http_rps_payment_go
-          query: sum(rate(http_server_request_duration_seconds_count{service_name="goti-payment-v2"}[30s]))
+          query: sum(rate(http_server_request_duration_seconds_count{service_name="goti-payment-v2"}[45s]))
           threshold: "20"
       - type: cpu
         metricType: Utilization

--- a/environments/prod/goti-queue-v2/values.yaml
+++ b/environments/prod/goti-queue-v2/values.yaml
@@ -50,7 +50,7 @@ gateway:
               number: 8080
 autoscaling:
   enabled: true
-  # SDD-0007 PR-3: 큐 진입 burst 흡수. Redis-only이라 RDS conn 제약 없음.
+  # SDD-0007 PR-3: 큐 진입 burst 흡수. 주요 로직이 Redis 기반이라 RDS 부하가 상대적으로 적음.
   minReplicas: 4
   maxReplicas: 20
   keda:
@@ -61,7 +61,7 @@ autoscaling:
       horizontalPodAutoscalerConfig:
         behavior:
           scaleUp:
-            stabilizationWindowSeconds: 0
+            stabilizationWindowSeconds: 15
             policies:
               - { type: Pods, value: 8, periodSeconds: 15 }
               - { type: Percent, value: 200, periodSeconds: 15 }
@@ -74,14 +74,14 @@ autoscaling:
       - type: cron
         metadata:
           timezone: "Asia/Seoul"
-          start: "30 09 * * *"
+          start: "20 09 * * *"
           end: "0 13 * * *"
           desiredReplicas: "8"
       - type: prometheus
         metadata:
           serverAddress: http://mimir-prod-query-frontend.monitoring.svc.cluster.local:8080/prometheus
           metricName: http_rps_queue_go
-          query: sum(rate(http_server_request_duration_seconds_count{service_name="goti-queue-v2"}[30s]))
+          query: sum(rate(http_server_request_duration_seconds_count{service_name="goti-queue-v2"}[45s]))
           threshold: "30"
 probes:
   liveness:

--- a/environments/prod/goti-queue-v2/values.yaml
+++ b/environments/prod/goti-queue-v2/values.yaml
@@ -50,18 +50,39 @@ gateway:
               number: 8080
 autoscaling:
   enabled: true
-  minReplicas: 2
-  maxReplicas: 10
+  # SDD-0007 PR-3: 큐 진입 burst 흡수. Redis-only이라 RDS conn 제약 없음.
+  minReplicas: 4
+  maxReplicas: 20
   keda:
     enabled: true
-    cooldownPeriod: 300
+    pollingInterval: 10
+    cooldownPeriod: 120
+    advanced:
+      horizontalPodAutoscalerConfig:
+        behavior:
+          scaleUp:
+            stabilizationWindowSeconds: 0
+            policies:
+              - { type: Pods, value: 8, periodSeconds: 15 }
+              - { type: Percent, value: 200, periodSeconds: 15 }
+            selectPolicy: Max
+          scaleDown:
+            stabilizationWindowSeconds: 300
+            policies:
+              - { type: Percent, value: 25, periodSeconds: 60 }
     triggers:
+      - type: cron
+        metadata:
+          timezone: "Asia/Seoul"
+          start: "30 09 * * *"
+          end: "0 13 * * *"
+          desiredReplicas: "8"
       - type: prometheus
         metadata:
           serverAddress: http://mimir-prod-query-frontend.monitoring.svc.cluster.local:8080/prometheus
           metricName: http_rps_queue_go
-          query: sum(rate(http_server_request_duration_seconds_count{service_name="goti-queue-v2"}[1m]))
-          threshold: "50"
+          query: sum(rate(http_server_request_duration_seconds_count{service_name="goti-queue-v2"}[30s]))
+          threshold: "30"
 probes:
   liveness:
     httpGet:

--- a/environments/prod/goti-resale-v2/values.yaml
+++ b/environments/prod/goti-resale-v2/values.yaml
@@ -46,13 +46,27 @@ autoscaling:
   maxReplicas: 6
   keda:
     enabled: true
-    cooldownPeriod: 180
+    pollingInterval: 10
+    cooldownPeriod: 120
+    advanced:
+      horizontalPodAutoscalerConfig:
+        behavior:
+          scaleUp:
+            stabilizationWindowSeconds: 0
+            policies:
+              - { type: Pods, value: 8, periodSeconds: 15 }
+              - { type: Percent, value: 200, periodSeconds: 15 }
+            selectPolicy: Max
+          scaleDown:
+            stabilizationWindowSeconds: 300
+            policies:
+              - { type: Percent, value: 25, periodSeconds: 60 }
     triggers:
       - type: prometheus
         metadata:
           serverAddress: http://mimir-prod-query-frontend.monitoring.svc.cluster.local:8080/prometheus
           metricName: http_rps_resale_go
-          query: sum(rate(http_server_request_duration_seconds_count{service_name="goti-resale-v2"}[1m]))
+          query: sum(rate(http_server_request_duration_seconds_count{service_name="goti-resale-v2"}[30s]))
           threshold: "20"
 probes:
   liveness:

--- a/environments/prod/goti-resale-v2/values.yaml
+++ b/environments/prod/goti-resale-v2/values.yaml
@@ -52,7 +52,7 @@ autoscaling:
       horizontalPodAutoscalerConfig:
         behavior:
           scaleUp:
-            stabilizationWindowSeconds: 0
+            stabilizationWindowSeconds: 15
             policies:
               - { type: Pods, value: 8, periodSeconds: 15 }
               - { type: Percent, value: 200, periodSeconds: 15 }
@@ -66,7 +66,7 @@ autoscaling:
         metadata:
           serverAddress: http://mimir-prod-query-frontend.monitoring.svc.cluster.local:8080/prometheus
           metricName: http_rps_resale_go
-          query: sum(rate(http_server_request_duration_seconds_count{service_name="goti-resale-v2"}[30s]))
+          query: sum(rate(http_server_request_duration_seconds_count{service_name="goti-resale-v2"}[45s]))
           threshold: "20"
 probes:
   liveness:

--- a/environments/prod/goti-stadium-v2/values.yaml
+++ b/environments/prod/goti-stadium-v2/values.yaml
@@ -60,7 +60,7 @@ autoscaling:
       horizontalPodAutoscalerConfig:
         behavior:
           scaleUp:
-            stabilizationWindowSeconds: 0
+            stabilizationWindowSeconds: 15
             policies:
               - { type: Pods, value: 8, periodSeconds: 15 }
               - { type: Percent, value: 200, periodSeconds: 15 }
@@ -73,14 +73,14 @@ autoscaling:
       - type: cron
         metadata:
           timezone: "Asia/Seoul"
-          start: "30 09 * * *"
+          start: "20 09 * * *"
           end: "0 13 * * *"
           desiredReplicas: "4"
       - type: prometheus
         metadata:
           serverAddress: http://mimir-prod-query-frontend.monitoring.svc.cluster.local:8080/prometheus
           metricName: http_rps_stadium_go
-          query: sum(rate(http_server_request_duration_seconds_count{service_name="goti-stadium-v2"}[30s]))
+          query: sum(rate(http_server_request_duration_seconds_count{service_name="goti-stadium-v2"}[45s]))
           threshold: "50"
 # TODO(verify): /healthz가 DB/Redis ping 포함 시 RDS 풀 초기화에 3~5s 소요
 # 가능 → liveness 재시작 루프 위험. 코드 확인 후 필요 시 liveness만 10s로 조정.

--- a/environments/prod/goti-stadium-v2/values.yaml
+++ b/environments/prod/goti-stadium-v2/values.yaml
@@ -49,23 +49,38 @@ gateway:
 # 윈도우 좁히기 또는 desiredReplicas/threshold 차등화 검토.
 autoscaling:
   enabled: true
+  # SDD-0007 PR-3: ticketing 5분 캐시 도입으로 부하 경감, cron만 확장
   minReplicas: 2
-  maxReplicas: 10
+  maxReplicas: 12
   keda:
     enabled: true
-    cooldownPeriod: 300
+    pollingInterval: 10
+    cooldownPeriod: 120
+    advanced:
+      horizontalPodAutoscalerConfig:
+        behavior:
+          scaleUp:
+            stabilizationWindowSeconds: 0
+            policies:
+              - { type: Pods, value: 8, periodSeconds: 15 }
+              - { type: Percent, value: 200, periodSeconds: 15 }
+            selectPolicy: Max
+          scaleDown:
+            stabilizationWindowSeconds: 300
+            policies:
+              - { type: Percent, value: 25, periodSeconds: 60 }
     triggers:
       - type: cron
         metadata:
           timezone: "Asia/Seoul"
-          start: "30 10 * * *"
+          start: "30 09 * * *"
           end: "0 13 * * *"
           desiredReplicas: "4"
       - type: prometheus
         metadata:
           serverAddress: http://mimir-prod-query-frontend.monitoring.svc.cluster.local:8080/prometheus
           metricName: http_rps_stadium_go
-          query: sum(rate(http_server_request_duration_seconds_count{service_name="goti-stadium-v2"}[1m]))
+          query: sum(rate(http_server_request_duration_seconds_count{service_name="goti-stadium-v2"}[30s]))
           threshold: "50"
 # TODO(verify): /healthz가 DB/Redis ping 포함 시 RDS 풀 초기화에 3~5s 소요
 # 가능 → liveness 재시작 루프 위험. 코드 확인 후 필요 시 liveness만 10s로 조정.

--- a/environments/prod/goti-ticketing-v2/values.yaml
+++ b/environments/prod/goti-ticketing-v2/values.yaml
@@ -55,26 +55,44 @@ gateway:
               number: 8080
 autoscaling:
   enabled: true
-  # 2026-04-14 부하테스트: scale-up 대기 중 k6 timeout 누적. prewarm 목적으로 min 2→6.
-  # DB 예산: 6 × 12 = 72 idle, 10 × 12 = 120 peak (RDS max_conn=200 내 stadium/queue/others 합 ≈ 200).
-  minReplicas: 8
-  maxReplicas: 12
+  # SDD-0007 PR-3: scale-up 반응성 튜닝. min 12 prewarm, max 24.
+  # DB 예산: MaxConns 10 × 24 = 240 < pgbouncer pool 300 안전.
+  minReplicas: 12
+  maxReplicas: 24
   keda:
     enabled: true
-    cooldownPeriod: 300
+    pollingInterval: 10
+    cooldownPeriod: 120
+    advanced:
+      horizontalPodAutoscalerConfig:
+        behavior:
+          scaleUp:
+            stabilizationWindowSeconds: 0
+            policies:
+              - { type: Pods, value: 8, periodSeconds: 15 }
+              - { type: Percent, value: 200, periodSeconds: 15 }
+            selectPolicy: Max
+          scaleDown:
+            stabilizationWindowSeconds: 300
+            policies:
+              - { type: Percent, value: 25, periodSeconds: 60 }
     triggers:
-      # - type: cron
-      #   metadata:
-      #     timezone: "Asia/Seoul"
-      #     start: "30 10 * * *"
-      #     end: "0 13 * * *"
-      #     desiredReplicas: "4"
+      - type: cron
+        metadata:
+          timezone: "Asia/Seoul"
+          start: "30 09 * * *"
+          end: "0 13 * * *"
+          desiredReplicas: "18"
       - type: prometheus
         metadata:
           serverAddress: http://mimir-prod-query-frontend.monitoring.svc:8080/prometheus
           metricName: http_rps_ticketing_go
-          query: sum(rate(http_server_request_duration_seconds_count{service_name="goti-ticketing-v2"}[1m]))
-          threshold: "50"
+          query: sum(rate(http_server_request_duration_seconds_count{service_name="goti-ticketing-v2"}[30s]))
+          threshold: "30"
+      - type: cpu
+        metricType: Utilization
+        metadata:
+          value: "70"
 probes:
   liveness:
     httpGet:
@@ -143,8 +161,9 @@ env:
   # 12 → 18: 3000 VU 부하에서 begin tx: context canceled 210건 관측.
   # PgBouncer session 모드 + goti_ticketing pool_size=100. 2026-04-14 2차 부하에서
   # 18→10 변경이 역효과(throughput 감소)로 확인되어 18 복귀.
+  # SDD-0007 PR-3: maxReplicas=24 전제, 24 × 10 = 240 < pgbouncer pool 300 안전
   - name: TICKETING_DATABASE_MAX_CONNS
-    value: "15"
+    value: "10"
   - name: TICKETING_DATABASE_MIN_CONNS
     value: "5"
   - name: TICKETING_DATABASE_MAX_CONN_IDLE_TIME_SEC

--- a/environments/prod/goti-ticketing-v2/values.yaml
+++ b/environments/prod/goti-ticketing-v2/values.yaml
@@ -67,7 +67,7 @@ autoscaling:
       horizontalPodAutoscalerConfig:
         behavior:
           scaleUp:
-            stabilizationWindowSeconds: 0
+            stabilizationWindowSeconds: 15
             policies:
               - { type: Pods, value: 8, periodSeconds: 15 }
               - { type: Percent, value: 200, periodSeconds: 15 }
@@ -80,14 +80,14 @@ autoscaling:
       - type: cron
         metadata:
           timezone: "Asia/Seoul"
-          start: "30 09 * * *"
+          start: "20 09 * * *"
           end: "0 13 * * *"
           desiredReplicas: "18"
       - type: prometheus
         metadata:
-          serverAddress: http://mimir-prod-query-frontend.monitoring.svc:8080/prometheus
+          serverAddress: http://mimir-prod-query-frontend.monitoring.svc.cluster.local:8080/prometheus
           metricName: http_rps_ticketing_go
-          query: sum(rate(http_server_request_duration_seconds_count{service_name="goti-ticketing-v2"}[30s]))
+          query: sum(rate(http_server_request_duration_seconds_count{service_name="goti-ticketing-v2"}[45s]))
           threshold: "30"
       - type: cpu
         metricType: Utilization
@@ -157,11 +157,10 @@ env:
       secretKeyRef:
         name: goti-ticketing-v2-prod-secrets
         key: TICKETING_QUEUE_TOKEN_SECRET
-  # --- DB pool (SDD Step 5 / S4: RDS max_conn 300, 2026-04-14 상향) ---
-  # 12 → 18: 3000 VU 부하에서 begin tx: context canceled 210건 관측.
-  # PgBouncer session 모드 + goti_ticketing pool_size=100. 2026-04-14 2차 부하에서
-  # 18→10 변경이 역효과(throughput 감소)로 확인되어 18 복귀.
-  # SDD-0007 PR-3: maxReplicas=24 전제, 24 × 10 = 240 < pgbouncer pool 300 안전
+  # --- DB pool (SDD-0007 PR-3) ---
+  # maxReplicas=24 전제, 24 × 10 = 240 < pgbouncer pool 300 안전.
+  # PgBouncer session 모드 + goti_ticketing pool_size=150 × 2 replicas.
+  # 이전 (2026-04-14) "18 복귀" 결정은 본 PR의 maxReplicas=24 + cron prewarm 18 도입으로 무효화됨.
   - name: TICKETING_DATABASE_MAX_CONNS
     value: "10"
   - name: TICKETING_DATABASE_MIN_CONNS

--- a/environments/prod/goti-user-v2/values.yaml
+++ b/environments/prod/goti-user-v2/values.yaml
@@ -47,16 +47,30 @@ gateway:
 autoscaling:
   enabled: true
   minReplicas: 3
-  maxReplicas: 10
+  maxReplicas: 12
   keda:
     enabled: true
-    cooldownPeriod: 300
+    pollingInterval: 10
+    cooldownPeriod: 120
+    advanced:
+      horizontalPodAutoscalerConfig:
+        behavior:
+          scaleUp:
+            stabilizationWindowSeconds: 0
+            policies:
+              - { type: Pods, value: 8, periodSeconds: 15 }
+              - { type: Percent, value: 200, periodSeconds: 15 }
+            selectPolicy: Max
+          scaleDown:
+            stabilizationWindowSeconds: 300
+            policies:
+              - { type: Percent, value: 25, periodSeconds: 60 }
     triggers:
       - type: prometheus
         metadata:
           serverAddress: http://mimir-prod-query-frontend.monitoring.svc.cluster.local:8080/prometheus
           metricName: http_rps_user_go
-          query: sum(rate(http_server_request_duration_seconds_count{service_name="goti-user-v2"}[1m]))
+          query: sum(rate(http_server_request_duration_seconds_count{service_name="goti-user-v2"}[30s]))
           threshold: "40"
 probes:
   liveness:

--- a/environments/prod/goti-user-v2/values.yaml
+++ b/environments/prod/goti-user-v2/values.yaml
@@ -56,7 +56,7 @@ autoscaling:
       horizontalPodAutoscalerConfig:
         behavior:
           scaleUp:
-            stabilizationWindowSeconds: 0
+            stabilizationWindowSeconds: 15
             policies:
               - { type: Pods, value: 8, periodSeconds: 15 }
               - { type: Percent, value: 200, periodSeconds: 15 }
@@ -70,7 +70,7 @@ autoscaling:
         metadata:
           serverAddress: http://mimir-prod-query-frontend.monitoring.svc.cluster.local:8080/prometheus
           metricName: http_rps_user_go
-          query: sum(rate(http_server_request_duration_seconds_count{service_name="goti-user-v2"}[30s]))
+          query: sum(rate(http_server_request_duration_seconds_count{service_name="goti-user-v2"}[45s]))
           threshold: "40"
 probes:
   liveness:


### PR DESCRIPTION
## 관련 이슈
- SDD-0007 PR-3 (plan: `~/.claude/plans/misty-seeking-orbit.md`)
- 선행 (반드시 먼저 머지): PR #258 (chart KEDA advanced 필드), PR #259 (Karpenter spot NodePool)

## 개요
4차 부하에서 burst 트래픽이 "터진 뒤에야" 스케일업 (체감 ~85s 지연). PR-1의 chart 확장과 PR-2의 Karpenter spot NodePool을 활용해 v2 서비스 6종에 KEDA advanced HPA behavior + cron prewarm + window 단축 + min/max 재조정 적용. 목표: scale-up 30s 이하.

## 작업 내용

### 공통 (6 v2 services)
- `pollingInterval: 10` (기본 30s)
- `cooldownPeriod: 300→120` (resale 180→120)
- Prometheus rate window `[1m]→[30s]`
- HPA behavior:
  - scaleUp: `stabilizationWindowSeconds 0`, `+8pod/15s OR +200%/15s`
  - scaleDown: `stabilizationWindowSeconds 300`, `-25%/60s`

### 서비스별

| 서비스 | minReplicas | maxReplicas | threshold | cron prewarm (KST) |
|---|---|---|---|---|
| ticketing-v2 | 8 → **12** | 12 → **24** | 50 → **30** | 09:30~13:00 desired=18, CPU 70% 추가 |
| payment-v2 | 4 → **6** | 8 → **16** | 30 → **20** | 09:30~13:00 desired=10, CPU 70% 추가 |
| queue-v2 | 2 → **4** | 10 → **20** | 50 → **30** | 09:30~13:00 desired=8 |
| stadium-v2 | 2 | 10 → **12** | 50 | 시간만 09:30~13:00로 확장 |
| user-v2 | 3 | 10 → **12** | 40 | 변경 없음 |
| resale-v2 | 1 | 6 | 20 | 변경 없음 |

### ticketing MaxConns 10
maxReplicas=24 전제로 `TICKETING_DATABASE_MAX_CONNS 15→10`. 24 × 10 = 240 < pgbouncer pool 300 안전.

## 테스트
- [x] `helm template` 6 서비스 ScaledObject 렌더링 확인 (advanced/pollingInterval/cron 모두 반영)
- [ ] PR #258 머지 후 chart `.tgz` 재패키징 확인
- [ ] PR #259 머지 후 NodePool 활성화 확인
- [ ] ArgoCD sync 후 `kubectl get scaledobject -o yaml` 실측 검증
- [ ] 5차 부하 측정: scale-up 시간, `karpenter_nodeclaims_created_total`, `ticket_success_rate`

## Rollout 순서 (필수 순서)
1. PR #258 (chart) merge → 10분 관찰
2. PR #259 (Karpenter spot) merge → 30분 관찰 (새 노드 생성 watch)
3. 본 PR merge → ArgoCD sync → 5차 부하

## 리스크
- PR-1/PR-2 미머지 상태에서 본 PR 머지 시: chart가 advanced 필드 무시, KEDA가 unknown field 에러는 발생 안 함 (silent ignore). 그러나 효과 없음. **순서 준수 필수**.