### PR TITLE
[FEAT] Redis Cluster 활성화 (SDD-0005 D0)

### DIFF
--- a/infrastructure/prod/redis-cluster/application.yaml
+++ b/infrastructure/prod/redis-cluster/application.yaml
@@ -1,46 +1,38 @@
-# Redis Cluster ArgoCD Application — SDD-0005 D0 scaffolding
+# Redis Cluster ArgoCD Application — SDD-0005 D0 활성화
 #
-# 활성화 전 체크리스트 (CR-001~016):
-#  [ ] CR-003 ExternalSecret `goti-redis-cluster-auth` 배포 (ESO sync-wave -2 선행)
-#  [ ] CR-005 chart targetRevision 고정 버전 확정 (현재 "11.*"는 예시)
-#  [ ] CR-007 NetworkPolicy podSelector 서비스 라벨 실제 배포 환경과 일치하는지 확인
-#  [ ] CR-008 `helm template` 로 StatefulSet replicas 수 검증 (6M+6R=12 pod 여부)
-#  [ ] CR-011 D7 완료 후 `infrastructure/prod/redis/` (standalone) 디렉토리 삭제 PR 동반
-#  [ ] CR-014 auth 활성화 시 sync-wave -5 → -1 로 조정 (ExternalSecret 이후)
+# 머지 후 반드시 SSM 파라미터 사전 준비:
+#   aws ssm put-parameter --name /prod/redis-cluster/AUTH_TOKEN --type SecureString --value "<32자 random>"
 #
-# 금지 사항 (rules/user-approval.md):
-#  - ServerSideApply=true Application에 Force Sync 금지 (2026-03-28 사고)
-#  - prune/selfHeal 초기엔 off, 수동 sync로 검증 우선
-#
-# 현재 파일은 전체 주석 처리되어 ArgoCD에서 인식되지 않음 (CR-012).
-# 활성화 시점에 주석 해제 + chart 버전 pin.
-#
-# apiVersion: argoproj.io/v1alpha1
-# kind: Application
-# metadata:
-#   name: goti-redis-cluster
-#   namespace: argocd
-#   annotations:
-#     argocd.argoproj.io/sync-wave: "-1"   # auth 활성화 시 ESO(-2) 이후
-# spec:
-#   project: default
-#   sources:
-#     - repoURL: https://charts.bitnami.com/bitnami
-#       chart: redis-cluster
-#       targetRevision: 11.3.5   # TODO: 활성화 시점 최신 stable 버전으로 pin (Renovate 관리)
-#       helm:
-#         valueFiles:
-#           - $values/infrastructure/prod/redis-cluster/values.yaml
-#     - repoURL: https://github.com/Team-Ikujo/Goti-k8s.git
-#       targetRevision: main
-#       ref: values
-#   destination:
-#     server: https://kubernetes.default.svc
-#     namespace: goti
-#   syncPolicy:
-#     automated:
-#       selfHeal: false   # 초기엔 수동 sync로 검증 우선
-#       prune: false
-#     syncOptions:
-#       - CreateNamespace=true
-#       - ServerSideApply=true
+# Bitnami chart 11.3.5 pin (Renovate 관리). values.yaml 의 auth.existingSecret 사용.
+# sync-wave -1: ExternalSecret(-2) 이후, MSA 서비스(0) 이전.
+# selfHeal/prune false: 초기엔 수동 sync로 cluster init 검증 우선.
+# ServerSideApply=true: Force Sync 금지 (2026-03-28 사고 학습).
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: goti-redis-cluster
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  project: default
+  sources:
+    - repoURL: https://charts.bitnami.com/bitnami
+      chart: redis-cluster
+      targetRevision: 11.3.5
+      helm:
+        valueFiles:
+          - $values/infrastructure/prod/redis-cluster/values.yaml
+    - repoURL: https://github.com/Team-Ikujo/Goti-k8s.git
+      targetRevision: main
+      ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: goti
+  syncPolicy:
+    automated:
+      selfHeal: false
+      prune: false
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/infrastructure/prod/redis-cluster/externalsecret.yaml
+++ b/infrastructure/prod/redis-cluster/externalsecret.yaml
@@ -1,0 +1,23 @@
+# Redis Cluster auth — SSM /prod/redis-cluster/AUTH_TOKEN
+# SDD-0005 D0. Bitnami redis-cluster chart의 auth.existingSecret 으로 마운트됨.
+# Application sync-wave -5 보다 먼저 sync 되도록 ExternalSecret -2.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: goti-redis-cluster-auth
+  namespace: goti
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aws-ssm
+    kind: ClusterSecretStore
+  target:
+    name: goti-redis-cluster-auth
+    creationPolicy: Owner
+  data:
+    # Bitnami redis-cluster: existingSecretPasswordKey 값과 일치 (values.yaml)
+    - secretKey: redis-password
+      remoteRef:
+        key: /prod/redis-cluster/AUTH_TOKEN


### PR DESCRIPTION
## 관련 이슈
- SDD-0005 D0 (plan: \`~/.claude/plans/misty-seeking-orbit.md\`)
- 선행 PR #257 (scaffolding) — 이미 머지됨

## 개요
Redis Cluster를 prod에 실제 배포 활성화. Goti-go의 dual-write Redis SoT 전환은 별도 PR (Goti-go main).

## 작업 내용
- \`externalsecret.yaml\` (NEW) — SSM \`/prod/redis-cluster/AUTH_TOKEN\` → secret \`goti-redis-cluster-auth\` (key: \`redis-password\`)
- \`application.yaml\` 주석 해제 — Bitnami chart 11.3.5 pin, sync-wave -1, selfHeal/prune false

## 사전 작업 (manual, 머지 전 또는 직후)
\`\`\`bash
aws ssm put-parameter \\
  --name /prod/redis-cluster/AUTH_TOKEN \\
  --type SecureString \\
  --value \"\$(openssl rand -base64 32 | tr -d '/+=' | head -c 32)\"
\`\`\`

## 머지 후 검증
- [ ] ArgoCD에서 \`goti-redis-cluster\` Application 수동 sync
- [ ] \`kubectl get pod -n goti -l app.kubernetes.io/name=redis-cluster\` 12 pod ready 확인
- [ ] \`kubectl exec -n goti goti-redis-cluster-0 -- redis-cli --cluster check 127.0.0.1:6379 -a \$(redis-password)\` 검증
- [ ] NetworkPolicy: ticketing-v2 → redis-cluster 6379 접근 OK
- [ ] cluster_state=ok, master 6 + slave 6, slot 16384 모두 할당

## 리스크
- spot 노드 12대 동시 프로비저닝 → Karpenter 부담 (PR #259 활성화 후 안정성 확인 후 sync)
- bind/unbind 중 stuck 시 \`prune: false\`라 수동 \`kubectl delete\` 필요

## 후속
- Goti-go PR (D0b~D6): ClusterClient + EventBus + Lua + dual-write