### PR TITLE
[CHORE] prod Go 이미지 태그 업데이트: prod-47-942b299

### DIFF
--- a/environments/prod-gcp/goti-payment/values.yaml
+++ b/environments/prod-gcp/goti-payment/values.yaml
@@ -2,7 +2,7 @@ nameOverride: goti-payment
 replicaCount: 0
 image:
   repository: "harbor.go-ti.shop/prod/goti-payment-go"
-  tag: "prod-41-862c91c"
+  tag: "prod-47-942b299"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod-gcp/goti-queue/values.yaml
+++ b/environments/prod-gcp/goti-queue/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 0
 nameOverride: goti-queue
 image:
   repository: "harbor.go-ti.shop/prod/goti-queue-go"
-  tag: "prod-41-862c91c" # linux/amd64 buildx 재빌드 (기존 bootstrap-20260413은 arm64로 잘못 푸시됨). CD 실행 시 gcp-N-SHA 로 auto-update
+  tag: "prod-47-942b299" # linux/amd64 buildx 재빌드 (기존 bootstrap-20260413은 arm64로 잘못 푸시됨). CD 실행 시 gcp-N-SHA 로 auto-update
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod-gcp/goti-resale/values.yaml
+++ b/environments/prod-gcp/goti-resale/values.yaml
@@ -2,7 +2,7 @@ nameOverride: goti-resale
 replicaCount: 0
 image:
   repository: "harbor.go-ti.shop/prod/goti-resale-go"
-  tag: "prod-41-862c91c"
+  tag: "prod-47-942b299"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod-gcp/goti-stadium/values.yaml
+++ b/environments/prod-gcp/goti-stadium/values.yaml
@@ -2,7 +2,7 @@ nameOverride: goti-stadium
 replicaCount: 0
 image:
   repository: "harbor.go-ti.shop/prod/goti-stadium-go"
-  tag: "prod-41-862c91c"
+  tag: "prod-47-942b299"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod-gcp/goti-ticketing/values.yaml
+++ b/environments/prod-gcp/goti-ticketing/values.yaml
@@ -2,7 +2,7 @@ nameOverride: goti-ticketing
 replicaCount: 0
 image:
   repository: "harbor.go-ti.shop/prod/goti-ticketing-go"
-  tag: "prod-46-eea4818"
+  tag: "prod-47-942b299"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod-gcp/goti-user/values.yaml
+++ b/environments/prod-gcp/goti-user/values.yaml
@@ -2,7 +2,7 @@ nameOverride: goti-user
 replicaCount: 0
 image:
   repository: "harbor.go-ti.shop/prod/goti-user-go"
-  tag: "prod-41-862c91c"
+  tag: "prod-47-942b299"
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-payment-v2/values.yaml
+++ b/environments/prod/goti-payment-v2/values.yaml
@@ -56,13 +56,13 @@ autoscaling:
           scaleUp:
             stabilizationWindowSeconds: 15
             policies:
-              - { type: Pods, value: 8, periodSeconds: 15 }
-              - { type: Percent, value: 200, periodSeconds: 15 }
+              - {type: Pods, value: 8, periodSeconds: 15}
+              - {type: Percent, value: 200, periodSeconds: 15}
             selectPolicy: Max
           scaleDown:
             stabilizationWindowSeconds: 300
             policies:
-              - { type: Percent, value: 25, periodSeconds: 60 }
+              - {type: Percent, value: 25, periodSeconds: 60}
     triggers:
       - type: cron
         metadata:
@@ -193,7 +193,7 @@ istioPolicy:
     enabled: true
 image:
   repository: harbor.go-ti.shop/prod/goti-payment-go
-  tag: prod-41-862c91c
+  tag: prod-47-942b299
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-queue-v2/values.yaml
+++ b/environments/prod/goti-queue-v2/values.yaml
@@ -64,13 +64,13 @@ autoscaling:
           scaleUp:
             stabilizationWindowSeconds: 15
             policies:
-              - { type: Pods, value: 8, periodSeconds: 15 }
-              - { type: Percent, value: 200, periodSeconds: 15 }
+              - {type: Pods, value: 8, periodSeconds: 15}
+              - {type: Percent, value: 200, periodSeconds: 15}
             selectPolicy: Max
           scaleDown:
             stabilizationWindowSeconds: 300
             policies:
-              - { type: Percent, value: 25, periodSeconds: 60 }
+              - {type: Percent, value: 25, periodSeconds: 60}
     triggers:
       - type: cron
         metadata:
@@ -183,7 +183,7 @@ istioPolicy:
     enabled: true
 image:
   repository: harbor.go-ti.shop/prod/goti-queue-go
-  tag: prod-41-862c91c
+  tag: prod-47-942b299
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-resale-v2/values.yaml
+++ b/environments/prod/goti-resale-v2/values.yaml
@@ -54,13 +54,13 @@ autoscaling:
           scaleUp:
             stabilizationWindowSeconds: 15
             policies:
-              - { type: Pods, value: 8, periodSeconds: 15 }
-              - { type: Percent, value: 200, periodSeconds: 15 }
+              - {type: Pods, value: 8, periodSeconds: 15}
+              - {type: Percent, value: 200, periodSeconds: 15}
             selectPolicy: Max
           scaleDown:
             stabilizationWindowSeconds: 300
             policies:
-              - { type: Percent, value: 25, periodSeconds: 60 }
+              - {type: Percent, value: 25, periodSeconds: 60}
     triggers:
       - type: prometheus
         metadata:
@@ -195,7 +195,7 @@ istioPolicy:
     enabled: true
 image:
   repository: harbor.go-ti.shop/prod/goti-resale-go
-  tag: prod-41-862c91c
+  tag: prod-47-942b299
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-stadium-v2/values.yaml
+++ b/environments/prod/goti-stadium-v2/values.yaml
@@ -63,13 +63,13 @@ autoscaling:
           scaleUp:
             stabilizationWindowSeconds: 15
             policies:
-              - { type: Pods, value: 8, periodSeconds: 15 }
-              - { type: Percent, value: 200, periodSeconds: 15 }
+              - {type: Pods, value: 8, periodSeconds: 15}
+              - {type: Percent, value: 200, periodSeconds: 15}
             selectPolicy: Max
           scaleDown:
             stabilizationWindowSeconds: 300
             policies:
-              - { type: Percent, value: 25, periodSeconds: 60 }
+              - {type: Percent, value: 25, periodSeconds: 60}
     triggers:
       - type: cron
         metadata:
@@ -214,7 +214,7 @@ istioPolicy:
     enabled: true
 image:
   repository: harbor.go-ti.shop/prod/goti-stadium-go
-  tag: prod-41-862c91c
+  tag: prod-47-942b299
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-ticketing-v2/values.yaml
+++ b/environments/prod/goti-ticketing-v2/values.yaml
@@ -76,13 +76,13 @@ autoscaling:
           scaleUp:
             stabilizationWindowSeconds: 15
             policies:
-              - { type: Pods, value: 8, periodSeconds: 15 }
-              - { type: Percent, value: 200, periodSeconds: 15 }
+              - {type: Pods, value: 8, periodSeconds: 15}
+              - {type: Percent, value: 200, periodSeconds: 15}
             selectPolicy: Max
           scaleDown:
             stabilizationWindowSeconds: 300
             policies:
-              - { type: Percent, value: 25, periodSeconds: 60 }
+              - {type: Percent, value: 25, periodSeconds: 60}
     triggers:
       - type: cron
         metadata:
@@ -264,7 +264,7 @@ istioPolicy:
     enabled: true
 image:
   repository: harbor.go-ti.shop/prod/goti-ticketing-go
-  tag: prod-46-eea4818
+  tag: prod-47-942b299
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds

--- a/environments/prod/goti-user-v2/values.yaml
+++ b/environments/prod/goti-user-v2/values.yaml
@@ -59,13 +59,13 @@ autoscaling:
           scaleUp:
             stabilizationWindowSeconds: 15
             policies:
-              - { type: Pods, value: 8, periodSeconds: 15 }
-              - { type: Percent, value: 200, periodSeconds: 15 }
+              - {type: Pods, value: 8, periodSeconds: 15}
+              - {type: Percent, value: 200, periodSeconds: 15}
             selectPolicy: Max
           scaleDown:
             stabilizationWindowSeconds: 300
             policies:
-              - { type: Percent, value: 25, periodSeconds: 60 }
+              - {type: Percent, value: 25, periodSeconds: 60}
     triggers:
       - type: prometheus
         metadata:
@@ -255,7 +255,7 @@ istioPolicy:
     enabled: true
 image:
   repository: harbor.go-ti.shop/prod/goti-user-go
-  tag: prod-41-862c91c
+  tag: prod-47-942b299
   pullPolicy: IfNotPresent
 imagePullSecrets:
   - name: harbor-creds


### PR DESCRIPTION
## 변경 사항
- 이미지 태그: `prod-47-942b299`
- 레지스트리: `harbor.go-ti.shop/prod/`
- 업데이트된 서비스: `{"include":[{"service":"user"},{"service":"stadium"},{"service":"ticketing"},{"service":"payment"},{"service":"resale"},{"service":"queue"}]}`
- 대상 환경: AWS prod (`environments/prod/goti-*-go/`) + GCP prod (`environments/prod-gcp/goti-*/`)

## 트리거
- 레포: `ressKim-io/Goti-go`
- 브랜치: `deploy/prod`
- 커밋: 942b2999c998f9563ac93ec725250b319396e851
- 워크플로우: [#47](https://github.com/ressKim-io/Goti-go/actions/runs/24418399915)