### PR TITLE
[CHORE] GCP prod Go 이미지 태그 업데이트: gcp-1-1bfe89e

### DIFF
--- a/environments/prod-gcp/goti-payment/values.yaml
+++ b/environments/prod-gcp/goti-payment/values.yaml
@@ -1,11 +1,9 @@
 nameOverride: goti-payment
 replicaCount: 0
 image:
-  repository: "harbor.go-ti.shop/prod/goti-payment-go"
-  tag: "prod-41-862c91c"
+  repository: "asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/goti-payment-go"
+  tag: "gcp-1-1bfe89e"
   pullPolicy: IfNotPresent
-imagePullSecrets:
-  - name: harbor-creds
 service: # GKE Workload Identity → Artifact Registry 자동 인증
   type: ClusterIP
   port: 8080

--- a/environments/prod-gcp/goti-queue/values.yaml
+++ b/environments/prod-gcp/goti-queue/values.yaml
@@ -5,11 +5,9 @@ replicaCount: 0
 # 메모리: project_jwks_automation_todo.md
 nameOverride: goti-queue
 image:
-  repository: "harbor.go-ti.shop/prod/goti-queue-go"
-  tag: "prod-41-862c91c" # linux/amd64 buildx 재빌드 (기존 bootstrap-20260413은 arm64로 잘못 푸시됨). CD 실행 시 gcp-N-SHA 로 auto-update
+  repository: "asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/goti-queue-go"
+  tag: "gcp-1-1bfe89e" # linux/amd64 buildx 재빌드 (기존 bootstrap-20260413은 arm64로 잘못 푸시됨). CD 실행 시 gcp-N-SHA 로 auto-update
   pullPolicy: IfNotPresent
-imagePullSecrets:
-  - name: harbor-creds
 service: # GKE Workload Identity → Artifact Registry 자동 인증
   type: ClusterIP
   port: 8080

--- a/environments/prod-gcp/goti-resale/values.yaml
+++ b/environments/prod-gcp/goti-resale/values.yaml
@@ -1,11 +1,9 @@
 nameOverride: goti-resale
 replicaCount: 0
 image:
-  repository: "harbor.go-ti.shop/prod/goti-resale-go"
-  tag: "prod-41-862c91c"
+  repository: "asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/goti-resale-go"
+  tag: "gcp-1-1bfe89e"
   pullPolicy: IfNotPresent
-imagePullSecrets:
-  - name: harbor-creds
 service: # GKE Workload Identity → Artifact Registry 자동 인증
   type: ClusterIP
   port: 8080

--- a/environments/prod-gcp/goti-stadium/values.yaml
+++ b/environments/prod-gcp/goti-stadium/values.yaml
@@ -1,11 +1,9 @@
 nameOverride: goti-stadium
 replicaCount: 0
 image:
-  repository: "harbor.go-ti.shop/prod/goti-stadium-go"
-  tag: "prod-41-862c91c"
+  repository: "asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/goti-stadium-go"
+  tag: "gcp-1-1bfe89e"
   pullPolicy: IfNotPresent
-imagePullSecrets:
-  - name: harbor-creds
 service: # GKE Workload Identity → Artifact Registry 자동 인증
   type: ClusterIP
   port: 8080

--- a/environments/prod-gcp/goti-ticketing/values.yaml
+++ b/environments/prod-gcp/goti-ticketing/values.yaml
@@ -1,11 +1,9 @@
 nameOverride: goti-ticketing
 replicaCount: 0
 image:
-  repository: "harbor.go-ti.shop/prod/goti-ticketing-go"
-  tag: "prod-46-eea4818"
+  repository: "asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/goti-ticketing-go"
+  tag: "gcp-1-1bfe89e"
   pullPolicy: IfNotPresent
-imagePullSecrets:
-  - name: harbor-creds
 service: # GKE Workload Identity → Artifact Registry 자동 인증
   type: ClusterIP
   port: 8080

--- a/environments/prod-gcp/goti-user/values.yaml
+++ b/environments/prod-gcp/goti-user/values.yaml
@@ -1,11 +1,9 @@
 nameOverride: goti-user
 replicaCount: 0
 image:
-  repository: "harbor.go-ti.shop/prod/goti-user-go"
-  tag: "prod-41-862c91c"
+  repository: "asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/goti-user-go"
+  tag: "gcp-1-1bfe89e"
   pullPolicy: IfNotPresent
-imagePullSecrets:
-  - name: harbor-creds
 service: # GKE Workload Identity → Artifact Registry 자동 인증
   type: ClusterIP
   port: 8080


### PR DESCRIPTION
## 변경 사항
- 이미지 태그: `gcp-1-1bfe89e`
- 레지스트리: `asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/`
- 업데이트된 서비스: `{"include":[{"service":"user"},{"service":"stadium"},{"service":"ticketing"},{"service":"payment"},{"service":"resale"},{"service":"queue"}]}`
- 대상 환경: GCP prod (`environments/prod-gcp/goti-*/`)

## 트리거
- 레포: `ressKim-io/Goti-go`
- 브랜치: `deploy/gcp`
- 커밋: 1bfe89e7963e630a3744aa4b994b9cdbd256c52f
- 워크플로우: [#1](https://github.com/ressKim-io/Goti-go/actions/runs/24431325458)