### PR TITLE
[FEAT] prod-gcp goti-user에 JWT private key env 추가

### DIFF
--- a/environments/prod-gcp/goti-user/values.yaml
+++ b/environments/prod-gcp/goti-user/values.yaml
@@ -68,6 +68,13 @@ env:
       secretKeyRef:
         name: goti-user-prod-gcp-secrets
         key: JWT_PUBLIC_KEY_PEM
+  # goti-user는 로그인 시 JWT 서명 발급 → private key 필수.
+  # AWS SSM의 /prod/user/JWT_RSA_PRIVATE_KEY와 동일 값 (cross-cloud 세션 호환).
+  - name: USER_JWT_PRIVATE_KEY_PEM
+    valueFrom:
+      secretKeyRef:
+        name: goti-user-prod-gcp-secrets
+        key: JWT_RSA_PRIVATE_KEY
   # --- OAuth (Secret에서 주입) ---
   # Go 코드가 os.Getenv("OAUTH_..")로 직접 읽으므로 USER_ 접두사 없음.
   # Secret 키는 Terraform config 네이밍(KAKAO_CLIENT_ID / KAKAO_SECRET 등)을 그대로 사용.


### PR DESCRIPTION
## 관련 이슈
- 없음 (멀티클라우드 JWT 세션 호환성 작업의 일부)

## 개요
GCP 단독 운영 시 **로그인 불가** 이슈 해결.

현재 \`environments/prod-gcp/goti-user/values.yaml\`에 \`USER_JWT_PRIVATE_KEY_PEM\` env가 누락되어 있어, Go \`goti-user\`가 JWT 서명을 위한 RSA private key를 주입받지 못함.

→ \`/api/v1/auth/login\` 호출 시 \`CreateToken()\`이 \`"RSA private key not configured"\` 에러를 반환하여 500 응답.

## 작업 내용
- [x] \`USER_JWT_PRIVATE_KEY_PEM\` env 추가 (\`JWT_RSA_PRIVATE_KEY\` secret key 참조)
- [x] ExternalSecret은 이미 \`goti-prod-user-JWT_RSA_PRIVATE_KEY\`를 K8s Secret으로 동기화 중 (설정 변경 불필요)

## 병행 작업 (별도 PR — Goti-Terraform)
- GCP Secret Manager의 JWT RSA 키쌍을 AWS SSM 값과 동일하게 통일 완료
- \`tls_private_key.jwt_rsa\` 자동 생성 제거, \`.tfvars\`로 외부 주입
- 결과: AWS와 GCP가 동일 RSA 키 사용 → cross-cloud JWT 세션 호환

## 테스트
- [x] \`helm lint\` — 로컬 검증 필요
- [x] \`helm template\` — deployment에 env 추가 확인 필요
- [ ] ArgoCD sync 확인 (머지 후)
- [ ] goti-user pod 재기동 후 \`/api/v1/auth/test-user/login\` 호출 → 200 OK
- [ ] 발급된 JWT로 ticketing 서비스 호출 → Istio JWT 검증 통과