### PR TITLE
[FEAT] prod-gcp goti-user에 SMS env 추가

### DIFF
--- a/environments/prod-gcp/goti-user/values.yaml
+++ b/environments/prod-gcp/goti-user/values.yaml
@@ -123,6 +123,31 @@ env:
       secretKeyRef:
         name: goti-user-prod-gcp-secrets
         key: GOOGLE_REDIRECT_URI
+  # --- SMS (CoolSMS/Nurigo) ---
+  # Go 코드가 os.Getenv("SMS_*")로 직접 읽으므로 USER_ 접두사 없음.
+  # AWS는 envFrom으로 bulk load되지만 GCP는 개별 명시 필요.
+  - name: SMS_ENABLED
+    value: "true"
+  - name: SMS_API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: goti-user-prod-gcp-secrets
+        key: SMS_API_KEY
+  - name: SMS_API_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: goti-user-prod-gcp-secrets
+        key: SMS_API_SECRET
+  - name: SMS_API_SENDER
+    valueFrom:
+      secretKeyRef:
+        name: goti-user-prod-gcp-secrets
+        key: SMS_API_SENDER
+  - name: SMS_API_DOMAIN
+    valueFrom:
+      secretKeyRef:
+        name: goti-user-prod-gcp-secrets
+        key: SMS_API_DOMAIN
   # --- OTel ---
   - name: USER_OTEL_ENABLED
     value: "true"

--- a/environments/prod-gcp/goti-user/values.yaml
+++ b/environments/prod-gcp/goti-user/values.yaml
@@ -68,6 +68,13 @@ env:
       secretKeyRef:
         name: goti-user-prod-gcp-secrets
         key: JWT_PUBLIC_KEY_PEM
+  # goti-user는 로그인 시 JWT 서명 발급 → private key 필수.
+  # AWS SSM의 /prod/user/JWT_RSA_PRIVATE_KEY와 동일 값 (cross-cloud 세션 호환).
+  - name: USER_JWT_PRIVATE_KEY_PEM
+    valueFrom:
+      secretKeyRef:
+        name: goti-user-prod-gcp-secrets
+        key: JWT_RSA_PRIVATE_KEY
   # --- OAuth (Secret에서 주입) ---
   # Go 코드가 os.Getenv("OAUTH_..")로 직접 읽으므로 USER_ 접두사 없음.
   # Secret 키는 Terraform config 네이밍(KAKAO_CLIENT_ID / KAKAO_SECRET 등)을 그대로 사용.


### PR DESCRIPTION
## 관련 이슈
- 없음 (팀원 리포트: GCP 신규 회원가입 시 휴대폰 인증번호 미도착)

## 개요
GCP 환경에서 \`/api/v1/auth/signup/sms/send\` 호출 시 **API는 200 응답하지만 실제 SMS 발송 안 됨** (silent failure).

**원인**: Go \`goti-user\`가 \`os.Getenv("SMS_*")\`로 SMS 설정을 직접 읽는데, prod-gcp values.yaml에 SMS env가 전혀 정의되지 않아 \`SmsProvider.Enabled=false\`로 초기화됨 → \`Send()\`는 no-op.

### 재현 로그
\`\`\`
{"msg":"sms provider disabled, skipping send","to":"010****3182"}
{"msg":"sms auth code generated","mobile":"010****3182"}
{"msg":"request","method":"POST","path":"/api/v1/auth/signup/sms/send","status":200}
\`\`\`

### AWS vs GCP 차이
- AWS(Java): \`envFrom: secretRef\`로 K8s Secret의 모든 키가 자동으로 env 주입
- GCP(Go): 각 env를 \`valueFrom: secretKeyRef\`로 개별 명시 필수 — \`envFrom\` 사용 불가 (Go \`os.Getenv\`는 명시된 env만 인식)

### 검증 완료
- GCP Secret Manager의 SMS 4개 값이 AWS SSM과 **완전 일치** (SHA256 해시 비교, trailing newline 제외)
- GCP K8s Secret \`goti-user-prod-gcp-secrets\`에 SMS 4개 키 모두 동기화됨
- → Secret 값은 정상, pod에 env 주입만 누락

## 작업 내용
- [x] \`SMS_ENABLED=true\` 하드코딩 추가 (Go \`loadSmsConfig\`가 default false로 초기화하므로 필수)
- [x] \`SMS_API_KEY\`, \`SMS_API_SECRET\`, \`SMS_API_SENDER\`, \`SMS_API_DOMAIN\` 4개 env 추가 (secretKeyRef)

## 테스트
- [ ] ArgoCD sync 확인 (머지 후)
- [ ] pod 재기동 후 \`SMS_*\` env 주입 확인
- [ ] 실제 회원가입 flow로 SMS 수신 확인