### PR TITLE
[CHORE] GCP prod Go 이미지 태그 업데이트: gcp-2-362b0e1

### DIFF
--- a/environments/prod-gcp/goti-user/values.yaml
+++ b/environments/prod-gcp/goti-user/values.yaml
@@ -2,7 +2,7 @@ nameOverride: goti-user
 replicaCount: 2
 image:
   repository: "asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/goti-user-go"
-  tag: "gcp-1-1bfe89e"
+  tag: "gcp-2-362b0e1"
   pullPolicy: IfNotPresent
 service: # GKE Workload Identity → Artifact Registry 자동 인증
   type: ClusterIP


### PR DESCRIPTION
## 변경 사항
- 이미지 태그: `gcp-2-362b0e1`
- 레지스트리: `asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/`
- 업데이트된 서비스: `{"include":[{"service":"user"}]}`
- 대상 환경: GCP prod (`environments/prod-gcp/goti-*/`)

## 트리거
- 레포: `ressKim-io/Goti-go`
- 브랜치: `main`
- 커밋: 362b0e1368c0e1da5832314bdeb26ee09ed256d3
- 워크플로우: [#2](https://github.com/ressKim-io/Goti-go/actions/runs/24544653529)