### PR TITLE
refactor(jwt): issuer SoT to K8s values + GCP Go image bump

### DIFF
--- a/environments/prod-gcp/goti-payment/values.yaml
+++ b/environments/prod-gcp/goti-payment/values.yaml
@@ -2,7 +2,7 @@ nameOverride: goti-payment
 replicaCount: 2
 image:
   repository: "asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/goti-payment-go"
-  tag: "gcp-1-1bfe89e"
+  tag: "gcp-6-977130c"
   pullPolicy: IfNotPresent
 service: # GKE Workload Identity → Artifact Registry 자동 인증
   type: ClusterIP

--- a/environments/prod-gcp/goti-queue/values.yaml
+++ b/environments/prod-gcp/goti-queue/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 2
 nameOverride: goti-queue
 image:
   repository: "asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/goti-queue-go"
-  tag: "gcp-1-1bfe89e" # linux/amd64 buildx 재빌드 (기존 bootstrap-20260413은 arm64로 잘못 푸시됨). CD 실행 시 gcp-N-SHA 로 auto-update
+  tag: "gcp-6-977130c" # linux/amd64 buildx 재빌드 (기존 bootstrap-20260413은 arm64로 잘못 푸시됨). CD 실행 시 gcp-N-SHA 로 auto-update
   pullPolicy: IfNotPresent
 service: # GKE Workload Identity → Artifact Registry 자동 인증
   type: ClusterIP

--- a/environments/prod-gcp/goti-resale/values.yaml
+++ b/environments/prod-gcp/goti-resale/values.yaml
@@ -2,7 +2,7 @@ nameOverride: goti-resale
 replicaCount: 1
 image:
   repository: "asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/goti-resale-go"
-  tag: "gcp-1-1bfe89e"
+  tag: "gcp-6-977130c"
   pullPolicy: IfNotPresent
 service: # GKE Workload Identity → Artifact Registry 자동 인증
   type: ClusterIP

--- a/environments/prod-gcp/goti-stadium/values.yaml
+++ b/environments/prod-gcp/goti-stadium/values.yaml
@@ -2,7 +2,7 @@ nameOverride: goti-stadium
 replicaCount: 1
 image:
   repository: "asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/goti-stadium-go"
-  tag: "gcp-3-a47c425"
+  tag: "gcp-6-977130c"
   pullPolicy: IfNotPresent
 service: # GKE Workload Identity → Artifact Registry 자동 인증
   type: ClusterIP

--- a/environments/prod-gcp/goti-ticketing/values.yaml
+++ b/environments/prod-gcp/goti-ticketing/values.yaml
@@ -2,7 +2,7 @@ nameOverride: goti-ticketing
 replicaCount: 3
 image:
   repository: "asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/goti-ticketing-go"
-  tag: "gcp-1-1bfe89e"
+  tag: "gcp-6-977130c"
   pullPolicy: IfNotPresent
 service: # GKE Workload Identity → Artifact Registry 자동 인증
   type: ClusterIP

--- a/environments/prod-gcp/goti-user/values.yaml
+++ b/environments/prod-gcp/goti-user/values.yaml
@@ -75,6 +75,10 @@ env:
       secretKeyRef:
         name: goti-user-prod-gcp-secrets
         key: JWT_RSA_PRIVATE_KEY
+  # JWT iss claim. istioPolicy.requestAuthentication.issuer와 반드시 일치해야 한다.
+  # K8s values가 SoT → Goti-go configs/user.yaml은 issuer 필드 없음 (env만 신뢰).
+  - name: USER_JWT_ISSUER
+    value: "goti-user-service"
   # --- OAuth (Secret에서 주입) ---
   # Go 코드가 os.Getenv("OAUTH_..")로 직접 읽으므로 USER_ 접두사 없음.
   # Secret 키는 Terraform config 네이밍(KAKAO_CLIENT_ID / KAKAO_SECRET 등)을 그대로 사용.

--- a/environments/prod-gcp/goti-user/values.yaml
+++ b/environments/prod-gcp/goti-user/values.yaml
@@ -2,7 +2,7 @@ nameOverride: goti-user
 replicaCount: 2
 image:
   repository: "asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/goti-user-go"
-  tag: "gcp-5-be21c58"
+  tag: "gcp-6-977130c"
   pullPolicy: IfNotPresent
 service: # GKE Workload Identity → Artifact Registry 자동 인증
   type: ClusterIP


### PR DESCRIPTION
## 관련 이슈
- Closes #

## 개요
prod-gcp 환경에서 JWT iss claim 과 Istio RequestAuthentication.issuer 불일치로 발생한 401 ("Jwt issuer is not configured") 근본 해결.

## 작업 내용
- [x] GCP prod Go 이미지 태그 업데이트: `gcp-6-977130c` (6개 서비스 자동)
- [x] `environments/prod-gcp/goti-user/values.yaml` 에 `USER_JWT_ISSUER=goti-user-service` env 추가
  - 같은 파일 `istioPolicy.requestAuthentication.issuer` 와 값 일치
  - K8s values.yaml 이 issuer SoT
- [x] Goti-go 측 정리 (선행 commit `977130c`)
  - `pkg/config/config.go` default `"goti"` 제거
  - `internal/user/service/jwt_provider.go` issuer 빈 값 fail-fast
  - `configs/user.yaml`, `configs/payment.yaml`, `configs/stadium.yaml` 에서 `issuer` 필드 제거

## 근본 원인
viper 우선순위 (config file > env). `configs/user.yaml:issuer: "goti"` 하드코딩이 K8s env `USER_JWT_ISSUER=goti-user-service` 를 덮어써서 토큰의 iss 가 "goti" 로 발급 → Istio 검증 실패.

## 테스트
- [x] `go build ./...` 통과 (Goti-go)
- [x] `go vet ./...` 통과
- [x] CD workflow 성공 (gcp-6-977130c, 6 services)
- [ ] `helm lint` 통과
- [ ] ArgoCD sync 확인 (merge 후 auto-sync)
- [ ] 브라우저 /queue 재접속 검증

## 트리거
- Goti-go main: `977130c`
- CD workflow: [run #6](https://github.com/ressKim-io/Goti-go/actions/runs/24548695059)