### PR TITLE
chore(prod-gcp): enable HPA on 6 Go services (multi-cloud failover absorb)

### DIFF
--- a/environments/prod-gcp/goti-payment/values.yaml
+++ b/environments/prod-gcp/goti-payment/values.yaml
@@ -103,25 +103,12 @@ gateway:
             port:
               number: 8080
 autoscaling:
-  enabled: false
+  enabled: true
   minReplicas: 2
-  maxReplicas: 8
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 60
   keda:
-    enabled: true
-    cooldownPeriod: 300
-    triggers:
-      - type: cron
-        metadata:
-          timezone: "Asia/Seoul"
-          start: "30 10 * * *"
-          end: "0 13 * * *"
-          desiredReplicas: "2" # Go는 cold start 빠름 (Java 4 → Go 2)
-      - type: prometheus
-        metadata:
-          serverAddress: http://mimir-prod-query-frontend.monitoring.svc:8080/prometheus
-          metricName: http_rps_payment_go
-          query: sum(rate(http_server_request_duration_seconds_count{service_name="goti-payment-go"}[1m]))
-          threshold: "30"
+    enabled: false
 externalSecret:
   enabled: true
   refreshInterval: "1h"

--- a/environments/prod-gcp/goti-queue/values.yaml
+++ b/environments/prod-gcp/goti-queue/values.yaml
@@ -51,26 +51,13 @@ gateway:
             port:
               number: 8080
 autoscaling:
-  enabled: false
+  enabled: true
   minReplicas: 2
-  maxReplicas: 10
+  maxReplicas: 12
+  # Multi-cloud failover 대비: AWS circuit open 시 전 트래픽 유입. 공격적 scale-up.
+  targetCPUUtilizationPercentage: 60
   keda:
-    enabled: true
-    cooldownPeriod: 300
-    triggers:
-      # 경기 시간대 사전 scale-up (CDN 대기열 특성상 시작 전 대량 진입)
-      - type: cron
-        metadata:
-          timezone: "Asia/Seoul"
-          start: "30 10 * * *"
-          end: "0 13 * * *"
-          desiredReplicas: "4"
-      - type: prometheus
-        metadata:
-          serverAddress: http://mimir-prod-query-frontend.monitoring.svc.cluster.local:8080/prometheus
-          metricName: http_rps_queue_go
-          query: sum(rate(http_server_request_duration_seconds_count{service_name="goti-queue-go"}[1m]))
-          threshold: "50"
+    enabled: false
 probes:
   liveness:
     httpGet:

--- a/environments/prod-gcp/goti-resale/values.yaml
+++ b/environments/prod-gcp/goti-resale/values.yaml
@@ -103,19 +103,12 @@ gateway:
             port:
               number: 8080
 autoscaling:
-  enabled: false
-  minReplicas: 1
-  maxReplicas: 6
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 8
+  targetCPUUtilizationPercentage: 60
   keda:
-    enabled: true
-    cooldownPeriod: 180
-    triggers:
-      - type: prometheus
-        metadata:
-          serverAddress: http://mimir-prod-query-frontend.monitoring.svc:8080/prometheus
-          metricName: http_rps_resale_go
-          query: sum(rate(http_server_request_duration_seconds_count{service_name="goti-resale-go"}[1m]))
-          threshold: "20"
+    enabled: false
 externalSecret:
   enabled: true
   refreshInterval: "1h"

--- a/environments/prod-gcp/goti-stadium/values.yaml
+++ b/environments/prod-gcp/goti-stadium/values.yaml
@@ -148,4 +148,9 @@ istioPolicy:
           - "./*"
           - "monitoring/*"
 autoscaling:
-  enabled: false
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 8
+  targetCPUUtilizationPercentage: 60
+  keda:
+    enabled: false

--- a/environments/prod-gcp/goti-ticketing/values.yaml
+++ b/environments/prod-gcp/goti-ticketing/values.yaml
@@ -138,25 +138,12 @@ gateway:
             port:
               number: 8080
 autoscaling:
-  enabled: false
+  enabled: true
   minReplicas: 2
-  maxReplicas: 10
+  maxReplicas: 12
+  targetCPUUtilizationPercentage: 60
   keda:
-    enabled: true
-    cooldownPeriod: 300
-    triggers:
-      - type: cron
-        metadata:
-          timezone: "Asia/Seoul"
-          start: "30 10 * * *"
-          end: "0 13 * * *"
-          desiredReplicas: "3" # Go는 cold start 빠름 (Java 6 → Go 3)
-      - type: prometheus
-        metadata:
-          serverAddress: http://mimir-prod-query-frontend.monitoring.svc:8080/prometheus
-          metricName: http_rps_ticketing_go
-          query: sum(rate(http_server_request_duration_seconds_count{service_name="goti-ticketing-go"}[1m]))
-          threshold: "50"
+    enabled: false
 externalSecret:
   enabled: true
   refreshInterval: "1h"

--- a/environments/prod-gcp/goti-user/values.yaml
+++ b/environments/prod-gcp/goti-user/values.yaml
@@ -186,25 +186,16 @@ gateway:
             port:
               number: 8080
 autoscaling:
-  enabled: false
+  enabled: true
   minReplicas: 3
-  maxReplicas: 10
+  maxReplicas: 12
+  # Multi-cloud failover 대비: AWS circuit open 시 GCP 로 전 트래픽 유입됨.
+  # CPU 60% 로 공격적 기준 잡아 빠르게 scale up.
+  targetCPUUtilizationPercentage: 60
+  # KEDA prometheus trigger 는 GMP(Google Managed Prometheus) adapter 구축 후 재도입.
+  # 그 때까지는 HPA CPU 기반 단순화.
   keda:
-    enabled: true
-    cooldownPeriod: 300
-    triggers:
-      - type: cron
-        metadata:
-          timezone: "Asia/Seoul"
-          start: "50 10 * * *"
-          end: "0 13 * * *"
-          desiredReplicas: "3" # Go는 cold start 빠름 (Java 5 → Go 3)
-      - type: prometheus
-        metadata:
-          serverAddress: http://mimir-prod-query-frontend.monitoring.svc:8080/prometheus
-          metricName: http_rps_user_go
-          query: sum(rate(http_server_request_duration_seconds_count{service_name="goti-user-go"}[1m]))
-          threshold: "40"
+    enabled: false
 externalSecret:
   enabled: true
   refreshInterval: "1h"


### PR DESCRIPTION
## 관련 이슈
- Closes #

## 개요
Cloudflare Worker 의 AWS circuit breaker 가 열렸을 때 GCP 가 흡수해야 할 트래픽을 pod 자동 확장으로 감당하기 위해, prod-gcp 6개 Go 서비스에 HPA 를 활성화한다.

## 작업 내용
- [x] goti-user, goti-queue, goti-ticketing, goti-resale, goti-stadium, goti-payment 의 autoscaling 블록 수정
  - enabled: false → true
  - targetCPUUtilizationPercentage: 60 (공격적 scale-up)
  - minReplicas / maxReplicas 재정의 (stadium/resale 최소 2 보장)
- [x] 기존 KEDA prometheus trigger 제거
  - 모든 trigger 가 `mimir-prod-query-frontend.monitoring.svc` 를 참조했는데 prod-gcp 는 Google Managed Prometheus 사용 → unreachable 설정
- [x] KEDA 블록 (`keda.enabled: false`) 유지 — GMP adapter 구축 후 재도입 예정

## 근본 배경
- Cloudflare Worker 는 AWS origin 에 1.5s primary timeout + 60s circuit open 으로 동작 예정 (별도 반영 필요)
- circuit open 시 AWS 매핑 5팀 트래픽이 GCP 로 몰림 → ~2x 부하
- 현재 GCP pod 수 (1~3) 로는 대응 불가 → HPA 필수

## Before / After

| service | before (replicaCount) | after (HPA min~max) |
|---|---|---|
| user | 2 | 3 ~ 12 |
| queue | 2 | 2 ~ 12 |
| ticketing | 3 | 2 ~ 12 |
| resale | 1 | 2 ~ 8 |
| stadium | 1 | 2 ~ 8 |
| payment | 2 | 2 ~ 10 |

## 테스트
- [x] helm template 렌더링 검증 (HorizontalPodAutoscaler kind, minReplicas/maxReplicas 정상)
- [x] helm lint (모두 통과)
- [ ] ArgoCD auto-sync → HPA 생성 확인 (merge 후)
- [ ] 부하 테스트로 scale-up 트리거 검증 (후속)

## 후속 작업
- Cloudflare Worker Circuit Breaker 배포 (controller 레포 `infra/cloudflare/multicloud-router.worker.js`)
- KEDA + GMP adapter 구축 후 prometheus 기반 scale 재도입