### PR TITLE
[CHORE] goti-load-observer prod-gcp 이미지 태그 업데이트: gcp-3-cc57b0f

### DIFF
--- a/environments/prod-gcp/goti-load-observer/values.yaml
+++ b/environments/prod-gcp/goti-load-observer/values.yaml
@@ -1,26 +1,20 @@
 nameOverride: goti-load-observer
-
 replicaCount: 1
-
 image:
   repository: "asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/goti-load-observer"
-  tag: "dev-9-ee6198a"
-  pullPolicy: Always
-
+  tag: "gcp-3-cc57b0f"
+  pullPolicy: IfNotPresent
 imagePullSecrets: []
-
 service:
   type: ClusterIP
   port: 9090
   name: metrics
-
 serviceMonitor:
   enabled: true
   port: metrics
   interval: 30s
   path: /metrics
   release: kube-prometheus-stack-prod-gcp
-
 probes:
   liveness:
     httpGet:
@@ -36,7 +30,6 @@ probes:
     initialDelaySeconds: 10
     periodSeconds: 10
     failureThreshold: 3
-
 resources:
   requests:
     cpu: 20m
@@ -44,7 +37,6 @@ resources:
   limits:
     cpu: 100m
     memory: 64Mi
-
 env:
   - name: DB_DSN
     valueFrom:
@@ -70,12 +62,10 @@ env:
       secretKeyRef:
         name: goti-load-observer-prod-gcp-secrets
         key: WORKER_INGEST_TOKEN
-
 podAnnotations:
   sidecar.istio.io/inject: "true"
   # Memorystore Redis TLS+AUTH — Istio mTLS와 충돌하므로 sidecar 우회
   traffic.sidecar.istio.io/excludeOutboundPorts: "6379"
-
 gateway:
   # Cloudflare Worker → /__worker-metrics/ingest 수신용 VirtualService.
   # gcp-api.go-ti.shop 로 들어온 traffic 중 이 prefix 만 load-observer 로 라우팅.
@@ -93,12 +83,10 @@ gateway:
             host: goti-load-observer-prod-gcp
             port:
               number: 9090
-
 podSecurityContext:
   runAsNonRoot: true
   runAsUser: 65532
   fsGroup: 65532
-
 securityContext:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
@@ -106,7 +94,6 @@ securityContext:
     drop: ["ALL"]
   seccompProfile:
     type: RuntimeDefault
-
 externalSecret:
   enabled: true
   refreshInterval: "1h"
@@ -116,7 +103,6 @@ externalSecret:
   remoteRef:
     nameRegexp: "^goti-prod-load-observer-"
     nameRewriteSource: "^goti-prod-load-observer-(.*)$"
-
 istioPolicy:
   authorizationPolicy:
     enabled: true


### PR DESCRIPTION
## 변경 사항
- 이미지 태그: `gcp-3-cc57b0f`
- 레지스트리: `asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/goti-load-observer`
- 대상 환경: GCP prod (`environments/prod-gcp/goti-load-observer/values.yaml`)

## 트리거
- 레포: `ressKim-io/goti-load-observer`
- 브랜치: `main`
- 커밋: cc57b0f5b36af76f7d87cde5996c4ac52d989e2c
- 워크플로우: [#3](https://github.com/ressKim-io/goti-load-observer/actions/runs/24553641066)