### PR TITLE
[CHORE] GCP prod Go 이미지 태그 업데이트: gcp-8-e1bc2f3

### DIFF
--- a/environments/prod-gcp/goti-ticketing/values.yaml
+++ b/environments/prod-gcp/goti-ticketing/values.yaml
@@ -2,7 +2,7 @@ nameOverride: goti-ticketing
 replicaCount: 3
 image:
   repository: "asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/goti-ticketing-go"
-  tag: "gcp-6-977130c"
+  tag: "gcp-8-e1bc2f3"
   pullPolicy: IfNotPresent
 service: # GKE Workload Identity → Artifact Registry 자동 인증
   type: ClusterIP


### PR DESCRIPTION
## 변경 사항
- 이미지 태그: `gcp-8-e1bc2f3`
- 레지스트리: `asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/`
- 업데이트된 서비스: `{"include":[{"service":"ticketing"}]}`
- 대상 환경: GCP prod (`environments/prod-gcp/goti-*/`)

## 트리거
- 레포: `ressKim-io/Goti-go`
- 브랜치: `main`
- 커밋: e1bc2f3ff358be432c243e191d104c601184395e
- 워크플로우: [#8](https://github.com/ressKim-io/Goti-go/actions/runs/24564122330)