### PR TITLE
[FEAT] prod-gcp goti-outbox-worker 배포 매니페스트 추가

### DIFF
--- a/environments/prod-gcp/goti-outbox-worker/values.yaml
+++ b/environments/prod-gcp/goti-outbox-worker/values.yaml
@@ -4,7 +4,7 @@ nameOverride: goti-outbox-worker
 replicaCount: 1
 image:
   repository: "asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/goti-outbox-worker-go"
-  tag: "main"
+  tag: "gcp-9-bc2e881"
   pullPolicy: IfNotPresent
 service:
   type: ClusterIP

--- a/environments/prod-gcp/goti-outbox-worker/values.yaml
+++ b/environments/prod-gcp/goti-outbox-worker/values.yaml
@@ -1,0 +1,115 @@
+nameOverride: goti-outbox-worker
+# outbox consumer 는 단일 consumer group 이므로 HPA 대신 고정 replica.
+# lag 상승 시 수동으로 replicaCount 를 조정하거나 KEDA(outbox_lag_seconds) 도입 예정.
+replicaCount: 1
+image:
+  repository: "asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/goti-outbox-worker-go"
+  tag: "main"
+  pullPolicy: IfNotPresent
+service:
+  type: ClusterIP
+  port: 9090
+  name: http
+serviceMonitor:
+  enabled: true
+  port: http
+  path: /metrics
+  interval: 15s
+  release: kube-prometheus-stack-prod-gcp
+probes:
+  liveness:
+    httpGet:
+      path: /healthz
+      port: http
+    initialDelaySeconds: 3
+    periodSeconds: 10
+    failureThreshold: 3
+  readiness:
+    httpGet:
+      path: /readyz
+      port: http
+    initialDelaySeconds: 3
+    periodSeconds: 5
+    failureThreshold: 3
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 300m
+    memory: 128Mi
+podAnnotations:
+  sidecar.istio.io/inject: "true"
+  # Memorystore Redis TLS+AUTH — Istio mTLS와 충돌하므로 sidecar 우회
+  traffic.sidecar.istio.io/excludeOutboundPorts: "6379"
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  fsGroup: 65532
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop: ["ALL"]
+  seccompProfile:
+    type: RuntimeDefault
+env:
+  # --- 인프라 (Secret에서 주입) ---
+  - name: OUTBOX_WORKER_DATABASE_URL
+    valueFrom:
+      secretKeyRef:
+        name: goti-outbox-worker-prod-gcp-secrets
+        key: DATASOURCE_URL
+  - name: OUTBOX_WORKER_REDIS_URL
+    valueFrom:
+      secretKeyRef:
+        name: goti-outbox-worker-prod-gcp-secrets
+        key: REDIS_URL
+  # --- OTel ---
+  - name: OUTBOX_WORKER_OTEL_ENABLED
+    value: "true"
+  - name: OUTBOX_WORKER_OTEL_ENDPOINT
+    value: "http://otel-collector.monitoring.svc.cluster.local:4317"
+  - name: OUTBOX_WORKER_OTEL_SERVICE_NAME
+    value: "goti-outbox-worker"
+  - name: OTEL_SERVICE_NAME
+    value: "goti-outbox-worker"
+  - name: OTEL_EXPORTER_OTLP_ENDPOINT
+    value: "http://otel-collector.monitoring.svc.cluster.local:4317"
+configMap:
+  enabled: false
+# outbox worker 는 HTTP ingress 없음 — Gateway/HTTPRoute 미사용.
+gateway:
+  enabled: false
+# 수신 트래픽 없음 — 외부 호출 대상 아님.
+autoscaling:
+  enabled: false
+externalSecret:
+  enabled: true
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: gcp-store
+    kind: ClusterSecretStore
+  remoteRef:
+    # ticketing 서비스의 시크릿을 공유 (같은 PG, 같은 Redis).
+    nameRegexp: "^goti-prod-ticketing-"
+    nameRewriteSource: "^goti-prod-ticketing-(.*)$"
+# --- Istio 보안/네트워크 정책 ---
+istioPolicy:
+  # HTTP inbound 없음 — AuthorizationPolicy / RequestAuthentication / JWT 모두 불필요.
+  authorizationPolicy:
+    enabled: false
+  requestAuthentication:
+    enabled: false
+  jwtAuthorizationPolicy:
+    enabled: false
+  # outbound 만 필요 (Redis / PG / OTel collector)
+  destinationRule:
+    enabled: false
+  sidecar:
+    enabled: true
+    egress:
+      - hosts:
+          - "istio-system/*"
+          - "./*"
+          - "monitoring/*"

--- a/gitops/prod-gcp/applicationsets/goti-msa-appset.yaml
+++ b/gitops/prod-gcp/applicationsets/goti-msa-appset.yaml
@@ -26,6 +26,10 @@ spec:
           - service: queue
             namespace: goti
             valuesFile: environments/prod-gcp/goti-queue/values.yaml
+          # SDD-0005 D5b — Redis outbox stream → RDS 영속 consumer
+          - service: outbox-worker
+            namespace: goti
+            valuesFile: environments/prod-gcp/goti-outbox-worker/values.yaml
   template:
     metadata:
       name: "goti-{{service}}-prod-gcp"


### PR DESCRIPTION
## 관련 이슈
- Redis SoT rollout D8 (ADR-0017 / SDD-0005)

## 개요
Redis SoT 전환의 일부. payment_confirm.lua / order_cancel.lua 가 발행하는
outbox stream (`outbox:stream`) 을 소비해서 RDS 에 비동기 영속하는 consumer
(goti-outbox-worker) 를 prod-gcp 에 배포.

## 작업 내용
- [x] `environments/prod-gcp/goti-outbox-worker/values.yaml` 신규
  - goti-server Helm chart 재사용
  - replicaCount 1 (consumer group, 수평 확장은 KEDA 도입 시점에)
  - port 9090 (/healthz, /readyz, /metrics)
  - Gateway / AuthorizationPolicy / RequestAuthentication / JWT 모두 비활성 (HTTP 인바운드 없음)
  - ExternalSecret: \`goti-prod-ticketing-*\` 공유 (동일 PG/Redis)
  - Istio sidecar inject, Memorystore Redis (6379) 는 sidecar 우회
- [x] `gitops/prod-gcp/applicationsets/goti-msa-appset.yaml` 에 entry 추가

## 관련 커밋
- Goti-go: \`8ec2bbc\` / \`abb4318\` / \`bc2e881\` — ORDER_PAID / TICKET_ISSUED / ORDER_CANCELED / TICKET_CANCELED handlers
- Goti-monitoring: goti-outbox alert group (OutboxHighLag, OutboxHandlerErrorRate)

## 테스트
- [x] \`helm template goti-outbox-worker-prod-gcp charts/goti-server -f environments/prod-gcp/goti-outbox-worker/values.yaml\` 렌더링 확인
- [ ] ArgoCD sync 확인 (머지 후)
- [ ] GKE 에서 pod Running + /metrics 노출 확인
- [ ] 결제 1건 / 취소 1건 → RDS 반영 검증