### PR TITLE
[FIX] outbox-worker ExternalSecret base goti-prod-server-* 추가

### DIFF
--- a/environments/prod-gcp/goti-outbox-worker/values.yaml
+++ b/environments/prod-gcp/goti-outbox-worker/values.yaml
@@ -91,9 +91,13 @@ externalSecret:
     name: gcp-store
     kind: ClusterSecretStore
   remoteRef:
-    # ticketing 서비스의 시크릿을 공유 (같은 PG, 같은 Redis).
-    nameRegexp: "^goti-prod-ticketing-"
-    nameRewriteSource: "^goti-prod-ticketing-(.*)$"
+    # base 로 공통 goti-prod-server-* (REDIS_URL 등) 수집 후
+    # override 로 ticketing 전용 goti-prod-ticketing-* (DATASOURCE_URL 등) 덮어씀.
+    # ticketing 서비스와 동일한 PG + Redis 사용.
+    nameRegexp: "^goti-prod-server-"
+    nameRewriteSource: "^goti-prod-server-(.*)$"
+    overrideNameRegexp: "^goti-prod-ticketing-"
+    overrideNameRewriteSource: "^goti-prod-ticketing-(.*)$"
 # --- Istio 보안/네트워크 정책 ---
 istioPolicy:
   # HTTP inbound 없음 — AuthorizationPolicy / RequestAuthentication / JWT 모두 불필요.


### PR DESCRIPTION
## 관련 이슈
- Redis SoT D8 follow-up (PR #275 버그 수정)

## 개요
#275 에서 outbox-worker ExternalSecret 이 \`^goti-prod-ticketing-\` regex 만 사용해서 REDIS_URL 이 secret 에 주입되지 않음. pod 가 \`CreateContainerConfigError: couldn't find key REDIS_URL\` 로 기동 실패.

## 원인
\`goti-prod-ticketing-*\` GSM secret 은 DATASOURCE_URL / DATASOURCE_USERNAME / DATASOURCE_PASSWORD 3개 뿐. REDIS_URL 은 공통 \`goti-prod-server-*\` 에 있음. ticketing 서비스는 base + override 2개 regex 로 설정되어 있었음.

## 작업 내용
- [x] \`remoteRef.nameRegexp\` = \`^goti-prod-server-\` (base)
- [x] \`remoteRef.overrideNameRegexp\` = \`^goti-prod-ticketing-\` (override — ticketing 전용 DATASOURCE_URL 덮어씀)

## 테스트
- [x] ticketing values.yaml 동일 패턴 비교 확인
- [ ] merge 후 secret 에 REDIS_URL 주입 확인
- [ ] pod Running + /readyz 확인