### PR TITLE
[FEAT] prod-gcp goti-user USER_TEST_USER_ENABLED 추가

### DIFF
--- a/environments/prod-gcp/goti-user/values.yaml
+++ b/environments/prod-gcp/goti-user/values.yaml
@@ -152,6 +152,9 @@ env:
       secretKeyRef:
         name: goti-user-prod-gcp-secrets
         key: SMS_API_DOMAIN
+  # --- 부하테스트 전용 (OAuth/SMS 우회 회원가입 + 로그인). EKS prod 동일 설정. ---
+  - name: USER_TEST_USER_ENABLED
+    value: "true"
   # --- OTel ---
   - name: USER_OTEL_ENABLED
     value: "true"


### PR DESCRIPTION
## 관련 이슈
- GCP prod k6 부하테스트 setup

## 개요
Goti-go 의 \`/api/v1/test/users/*\` 3개 엔드포인트를 GCP prod 에 노출. k6 부하테스트가 OAuth/SMS 우회로 대량 유저 생성 + 로그인하기 위해 필요.

## 현 상태
- EKS prod: \`GOTI_TEST_USER_ENABLED=true\` 로 이미 노출됨
- GCP prod: 해당 env 누락 → k6 setup 단계에서 404 로 중단

## 작업 내용
- [x] \`environments/prod-gcp/goti-user/values.yaml\` 에 \`USER_TEST_USER_ENABLED=true\` 추가
  - Go viper prefix USER_ + test_user.enabled 매핑
  - cfg.TestUser.Enabled=true 일 때만 \`POST /api/v1/test/users\`, \`/bulk\`, \`/login\` 3개 handler 등록

## 보안
- OAuth/SMS 우회 회원가입 엔드포인트 — prod 노출은 리스크이지만 EKS 와 동일 상태
- 부하테스트 종료 후 필요 시 env 제거 + rollout 으로 다시 닫을 수 있음

## 테스트
- [ ] merge 후 ArgoCD sync → pod rollout
- [ ] \`curl -X POST https://gcp-api.go-ti.shop/api/v1/test/users ...\` 로 200 확인
- [ ] k6 queue-oneshot 재실행 (VUS=10)