### PR TITLE
[FIX] outbox-worker DATABASE_SCHEMA=ticketing_service 명시

### DIFF
--- a/environments/prod-gcp/goti-outbox-worker/values.yaml
+++ b/environments/prod-gcp/goti-outbox-worker/values.yaml
@@ -65,6 +65,10 @@ env:
       secretKeyRef:
         name: goti-outbox-worker-prod-gcp-secrets
         key: REDIS_URL
+  # viper 서비스별 기본값 (serviceName+"_service") 가 "outbox-worker_service" 로 잘못
+  # 잡혀 orders/order_items 를 찾지 못함. ticketing 과 동일 schema 로 명시.
+  - name: OUTBOX_WORKER_DATABASE_SCHEMA
+    value: "ticketing_service"
   # --- OTel ---
   - name: OUTBOX_WORKER_OTEL_ENABLED
     value: "true"


### PR DESCRIPTION
## 개요
k6 VUS=10 프로덕션 부하테스트 직후 outbox handler 가 전부 실패. 원인은 schema 설정.

## 증상
```
outbox handler error TICKET_ISSUED: enrich ticket: relation "order_items" does not exist
outbox handler error ORDER_PAID:   confirm order: relation "orders" does not exist
```
이벤트는 Redis Stream 에서 소비되지만 PG write 가 전부 실패 → RDS 반영 누락.

## 원인
`pkg/config`의 setDefaults 에서 `database.schema` 기본값이 `serviceName+"_service"` = `outbox-worker_service` 로 설정됨. 해당 schema 는 존재하지 않으므로 search_path 에 유효한 스키마 없음.

## 수정
`OUTBOX_WORKER_DATABASE_SCHEMA=ticketing_service` env 추가.

## 테스트
- [ ] merge 후 ArgoCD sync
- [ ] outbox 이벤트 10건 재처리 (Redis Stream 에 아직 pending)
- [ ] orders / tickets 테이블에 실제 row 생성 확인