### PR TITLE
[CHORE] GCP prod Go 이미지 태그 업데이트: gcp-11-9f2431b

### DIFF
--- a/environments/prod-gcp/goti-outbox-worker/values.yaml
+++ b/environments/prod-gcp/goti-outbox-worker/values.yaml
@@ -4,7 +4,7 @@ nameOverride: goti-outbox-worker
 replicaCount: 1
 image:
   repository: "asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/goti-outbox-worker-go"
-  tag: "gcp-9-bc2e881"
+  tag: "gcp-11-9f2431b"
   pullPolicy: IfNotPresent
 service:
   type: ClusterIP


### PR DESCRIPTION
## 변경 사항
- 이미지 태그: `gcp-11-9f2431b`
- 레지스트리: `asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/`
- 업데이트된 서비스: `{"include":[{"service":"outbox-worker"}]}`
- 대상 환경: GCP prod (`environments/prod-gcp/goti-*/`)

## 트리거
- 레포: `ressKim-io/Goti-go`
- 브랜치: `deploy/gcp`
- 커밋: 9f2431bb363e0db5de584794f47594904b4478af
- 워크플로우: [#11](https://github.com/ressKim-io/Goti-go/actions/runs/24593847240)