### PR TITLE
[CHORE] prod istiod max 축소 + karpenter overprovisioner 비활성 — 부하테스트 중단

### DIFF
--- a/infrastructure/prod/istio/istiod/values-prod.yaml
+++ b/infrastructure/prod/istio/istiod/values-prod.yaml
@@ -3,7 +3,9 @@ istiod:
   replicaCount: 2
   autoscaleEnabled: true
   autoscaleMin: 2
-  autoscaleMax: 5
+  # 부하테스트 중단 임시 축소 (2026-04-18): 5 → 2. 부하 재개 시 5로 복구.
+  # 부하 없는 상태에서 HPA가 5까지 띄워 core 노드 CPU 압박 유발.
+  autoscaleMax: 2
   resources:
     requests:
       cpu: 100m

--- a/infrastructure/prod/karpenter/config/overprovision.yaml
+++ b/infrastructure/prod/karpenter/config/overprovision.yaml
@@ -19,7 +19,9 @@ metadata:
   labels:
     app: goti-overprovision
 spec:
-  replicas: 1
+  # 부하테스트 중단 임시 비활성화 (2026-04-18): 1 → 0. 부하 재개 시 1로 복구.
+  # Karpenter burst 흡수 목적인데 burst 자체가 없는 상태에서 1 vCPU/512Mi 상시 점유는 낭비.
+  replicas: 0
   selector:
     matchLabels:
       app: goti-overprovision


### PR DESCRIPTION
## 관련 이슈
- 없음 (운영 임시 조치)

## 개요
부하테스트를 진행하지 않는 기간 동안 prod 인프라의 자원 점유 축소.
각 변경에 \`부하테스트 중단 임시 축소 (2026-04-18): X → Y. 부하 재개 시 X로 복구.\` 주석 명시.

## 작업 내용
- [x] \`infrastructure/prod/istio/istiod/values-prod.yaml\`
  - \`autoscaleMax\` 5 → 2
  - 부하 없는 상태에서 HPA가 5까지 띄워 core 노드 CPU 압박 유발
  - 절감: -300m / -1.5GiB (5 pod → 2 pod)
- [x] \`infrastructure/prod/karpenter/config/overprovision.yaml\`
  - \`replicas\` 1 → 0
  - Karpenter burst 흡수 목적인데 burst 자체가 없어 1 vCPU 상시 점유 낭비
  - 절감: -1000m / -512Mi (1 pod → 0 pod)

## 합계
- 약 **-1.3 vCPU**, **-2 GiB** requests
- **-4 pod**

## 테스트
- [ ] \`helm lint\` 통과 (해당 없음 — 단순 values/manifest 수정)
- [ ] \`helm template\` 렌더링 검증 (해당 없음)
- [ ] Kind 로컬 클러스터 배포 검증 (prod 한정 변경)
- [x] ArgoCD sync 확인 — istiod-prod, karpenter-config Application

## ⚠️ 주의
- 부하테스트 재개 전 반드시 원복 필요. 주석으로 원래 값 표시되어 있음.