### PR TITLE
[CHORE] v2 prod image registry: Harbor → ECR 전환

### DIFF
--- a/environments/prod/goti-payment-v2/values-aws.yaml
+++ b/environments/prod/goti-payment-v2/values-aws.yaml
@@ -1,9 +1,7 @@
 replicaCount: 2
 image:
-  repository: "harbor.go-ti.shop/prod/goti-payment-go"
+  repository: "707925622666.dkr.ecr.ap-northeast-2.amazonaws.com/goti-payment-go"
   pullPolicy: IfNotPresent
-imagePullSecrets:
-  - name: harbor-creds
 externalSecret:
   enabled: true
   refreshInterval: "1h"
@@ -21,7 +19,6 @@ istioPolicy:
           - "./*"
           - "monitoring/*"
           - "~/*.amazonaws.com"
-
 # Cutover: Go 활성화
 gateway:
   enabled: true

--- a/environments/prod/goti-queue-v2/values-aws.yaml
+++ b/environments/prod/goti-queue-v2/values-aws.yaml
@@ -1,10 +1,8 @@
 # SG1: 0% weight 첫 배포 — replicaCount: 0 (Java goti-queue-prod 무영향 보장)
 replicaCount: 2
 image:
-  repository: "harbor.go-ti.shop/prod/goti-queue-go"
+  repository: "707925622666.dkr.ecr.ap-northeast-2.amazonaws.com/goti-queue-go"
   pullPolicy: IfNotPresent
-imagePullSecrets:
-  - name: harbor-creds
 externalSecret:
   enabled: true
   refreshInterval: "1h"
@@ -22,7 +20,6 @@ istioPolicy:
           - "./*"
           - "monitoring/*"
           - "~/*.amazonaws.com"
-
 # Cutover: Go 활성화
 gateway:
   enabled: true

--- a/environments/prod/goti-resale-v2/values-aws.yaml
+++ b/environments/prod/goti-resale-v2/values-aws.yaml
@@ -1,9 +1,7 @@
 replicaCount: 1
 image:
-  repository: "harbor.go-ti.shop/prod/goti-resale-go"
+  repository: "707925622666.dkr.ecr.ap-northeast-2.amazonaws.com/goti-resale-go"
   pullPolicy: IfNotPresent
-imagePullSecrets:
-  - name: harbor-creds
 externalSecret:
   enabled: true
   refreshInterval: "1h"
@@ -21,7 +19,6 @@ istioPolicy:
           - "./*"
           - "monitoring/*"
           - "~/*.amazonaws.com"
-
 # Cutover: Go 활성화
 gateway:
   enabled: true

--- a/environments/prod/goti-stadium-v2/values-aws.yaml
+++ b/environments/prod/goti-stadium-v2/values-aws.yaml
@@ -1,10 +1,8 @@
 # SG1: 0% weight 첫 배포 — replicaCount: 0 (Java goti-stadium-prod 무영향 보장)
 replicaCount: 1
 image:
-  repository: "harbor.go-ti.shop/prod/goti-stadium-go"
+  repository: "707925622666.dkr.ecr.ap-northeast-2.amazonaws.com/goti-stadium-go"
   pullPolicy: IfNotPresent
-imagePullSecrets:
-  - name: harbor-creds
 externalSecret:
   enabled: true
   refreshInterval: "1h"
@@ -25,7 +23,6 @@ istioPolicy:
           - "./*"
           - "monitoring/*"
           - "~/*.amazonaws.com"
-
 # Cutover: Go 활성화
 gateway:
   enabled: true

--- a/environments/prod/goti-ticketing-v2/values-aws.yaml
+++ b/environments/prod/goti-ticketing-v2/values-aws.yaml
@@ -1,9 +1,7 @@
 replicaCount: 2
 image:
-  repository: "harbor.go-ti.shop/prod/goti-ticketing-go"
+  repository: "707925622666.dkr.ecr.ap-northeast-2.amazonaws.com/goti-ticketing-go"
   pullPolicy: IfNotPresent
-imagePullSecrets:
-  - name: harbor-creds
 externalSecret:
   enabled: true
   refreshInterval: "1h"
@@ -21,7 +19,6 @@ istioPolicy:
           - "./*"
           - "monitoring/*"
           - "~/*.amazonaws.com"
-
 # Cutover: Go 활성화
 gateway:
   enabled: true

--- a/environments/prod/goti-user-v2/values-aws.yaml
+++ b/environments/prod/goti-user-v2/values-aws.yaml
@@ -1,9 +1,7 @@
 replicaCount: 4
 image:
-  repository: "harbor.go-ti.shop/prod/goti-user-go"
+  repository: "707925622666.dkr.ecr.ap-northeast-2.amazonaws.com/goti-user-go"
   pullPolicy: IfNotPresent
-imagePullSecrets:
-  - name: harbor-creds
 externalSecret:
   enabled: true
   refreshInterval: "1h"
@@ -21,7 +19,6 @@ istioPolicy:
           - "./*"
           - "monitoring/*"
           - "~/*.amazonaws.com"
-
 # Cutover: Go 활성화
 gateway:
   enabled: true


### PR DESCRIPTION
## 관련 이슈
- Closes #TBD (AWS bring-up 2026-04-19)

## 개요
AWS Harbor DB/image가 재기동 과정에서 초기화됨. 이미지 재push 대신 ECR로 전환하는 것이 빠름.

## 작업 내용
- [x] 6개 v2 values-aws.yaml repository Harbor → ECR
  - \`harbor.go-ti.shop/prod/goti-X-go\` → \`707925622666.dkr.ecr.ap-northeast-2.amazonaws.com/goti-X-go\`
- [x] imagePullSecrets 제거 (ECR은 EKS node IAM role로 인증)
- [x] image.tag는 Goti-go CD가 자동 갱신 (별도 PR 예상)

## 대상 서비스
- goti-user-v2
- goti-ticketing-v2
- goti-payment-v2
- goti-resale-v2
- goti-stadium-v2
- goti-queue-v2

## 사전 세팅 (완료됨)
- ECR 6개 repo: \`aws ecr describe-repositories\` 확인
- EKS node role: \`AmazonEC2ContainerRegistryReadOnly\` attached
- Goti-go CI: [PR #8](https://github.com/ressKim-io/Goti-go/pull/8) merge 완료 → 빌드 진행 중

## 테스트
- [x] \`yq\` 수정 결과 육안 확인
- [ ] helm template 렌더링 검증 (선택)
- [ ] ArgoCD sync 확인 — merge 후 자동 sync 예정
- [ ] v2 pod Running 확인 (이미지 태그 자동 PR 머지 후)

## 연관 작업
- Goti-go PR: https://github.com/ressKim-io/Goti-go/pull/8 (merged)
- Goti-go 빌드 run: https://github.com/ressKim-io/Goti-go/actions/runs/24617537033