### PR TITLE
[CHORE] prod Go 이미지 태그 업데이트: prod-48-0a4e690

### DIFF
--- a/environments/prod/goti-payment-v2/values-aws.yaml
+++ b/environments/prod/goti-payment-v2/values-aws.yaml
@@ -2,6 +2,7 @@ replicaCount: 2
 image:
   repository: "707925622666.dkr.ecr.ap-northeast-2.amazonaws.com/goti-payment-go"
   pullPolicy: IfNotPresent
+  tag: prod-48-0a4e690
 externalSecret:
   enabled: true
   refreshInterval: "1h"

--- a/environments/prod/goti-queue-v2/values-aws.yaml
+++ b/environments/prod/goti-queue-v2/values-aws.yaml
@@ -3,6 +3,7 @@ replicaCount: 2
 image:
   repository: "707925622666.dkr.ecr.ap-northeast-2.amazonaws.com/goti-queue-go"
   pullPolicy: IfNotPresent
+  tag: prod-48-0a4e690
 externalSecret:
   enabled: true
   refreshInterval: "1h"

--- a/environments/prod/goti-resale-v2/values-aws.yaml
+++ b/environments/prod/goti-resale-v2/values-aws.yaml
@@ -2,6 +2,7 @@ replicaCount: 1
 image:
   repository: "707925622666.dkr.ecr.ap-northeast-2.amazonaws.com/goti-resale-go"
   pullPolicy: IfNotPresent
+  tag: prod-48-0a4e690
 externalSecret:
   enabled: true
   refreshInterval: "1h"

--- a/environments/prod/goti-stadium-v2/values-aws.yaml
+++ b/environments/prod/goti-stadium-v2/values-aws.yaml
@@ -3,6 +3,7 @@ replicaCount: 1
 image:
   repository: "707925622666.dkr.ecr.ap-northeast-2.amazonaws.com/goti-stadium-go"
   pullPolicy: IfNotPresent
+  tag: prod-48-0a4e690
 externalSecret:
   enabled: true
   refreshInterval: "1h"

--- a/environments/prod/goti-ticketing-v2/values-aws.yaml
+++ b/environments/prod/goti-ticketing-v2/values-aws.yaml
@@ -2,6 +2,7 @@ replicaCount: 2
 image:
   repository: "707925622666.dkr.ecr.ap-northeast-2.amazonaws.com/goti-ticketing-go"
   pullPolicy: IfNotPresent
+  tag: prod-48-0a4e690
 externalSecret:
   enabled: true
   refreshInterval: "1h"

--- a/environments/prod/goti-user-v2/values-aws.yaml
+++ b/environments/prod/goti-user-v2/values-aws.yaml
@@ -2,6 +2,7 @@ replicaCount: 4
 image:
   repository: "707925622666.dkr.ecr.ap-northeast-2.amazonaws.com/goti-user-go"
   pullPolicy: IfNotPresent
+  tag: prod-48-0a4e690
 externalSecret:
   enabled: true
   refreshInterval: "1h"


### PR DESCRIPTION
## 변경 사항
- 이미지 태그: `prod-48-0a4e690`
- 레지스트리: `707925622666.dkr.ecr.ap-northeast-2.amazonaws.com`
- 업데이트된 서비스: `{"include":[{"service":"user"},{"service":"stadium"},{"service":"ticketing"},{"service":"payment"},{"service":"resale"},{"service":"queue"}]}`
- 대상 환경: AWS prod (`environments/prod/goti-*-v2/values-aws.yaml`)

## 트리거
- 레포: `ressKim-io/Goti-go`
- 브랜치: `deploy/prod`
- 커밋: 0a4e6909678c8659eb71b40db6e01281a0210096
- 워크플로우: [#48](https://github.com/ressKim-io/Goti-go/actions/runs/24617537033)