### PR TITLE
[FIX] ticketing-v2 AWS 리소스 축소 (Pending 해소)

### DIFF
--- a/environments/prod/goti-ticketing-v2/values-aws.yaml
+++ b/environments/prod/goti-ticketing-v2/values-aws.yaml
@@ -1,4 +1,4 @@
-replicaCount: 2
+replicaCount: 1
 image:
   repository: "707925622666.dkr.ecr.ap-northeast-2.amazonaws.com/goti-ticketing-go"
   pullPolicy: IfNotPresent
@@ -23,3 +23,6 @@ istioPolicy:
 # Cutover: Go 활성화
 gateway:
   enabled: true
+resources:
+  requests:
+    cpu: 300m


### PR DESCRIPTION
## 개요
10개 노드 전부 CPU allocatable 부족으로 ticketing-v2 pod Pending.

## 변경
- replicaCount: 2 → 1
- resources.requests.cpu: 1000m → 300m

AWS는 CDN 캐싱으로 ticketing 부하 분산 → 1 replica 충분.