### PR TITLE
[FIX] istio shared-gateway selector 불일치 수정

### DIFF
--- a/infrastructure/prod/istio/gateway/templates/shared-gateway.yaml
+++ b/infrastructure/prod/istio/gateway/templates/shared-gateway.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   selector:
-    istio: gateway
+    istio: ingress
   servers:
     - port:
         number: 80


### PR DESCRIPTION
## 관련 이슈
- AWS bring-up 2026-04-19 follow-up (dev-log: \`2026-04-19-aws-bringup-harbor-to-ecr.md\`)

## 개요
\`goti-shared-gateway\` selector 가 \`istio: gateway\` 로 설정되어 있으나 실제 istio-ingress deployment pod label 은 \`istio: ingress\`. 매칭 실패로 전체 \`*.go-ti.shop\` 요청이 404.

## 증거
\`\`\`
$ kubectl get pod -n istio-ingress -o jsonpath='{.items[0].metadata.labels.istio}'
ingress
$ curl -o /dev/null -w "%{http_code}" https://aws-api.go-ti.shop/
404
\`\`\`

## 작업 내용
- [x] shared-gateway.yaml selector: \`istio: gateway\` → \`istio: ingress\`

## 테스트
- [ ] ArgoCD sync 후 \`curl https://aws-api.go-ti.shop/__worker-metrics/ingest\` → 401 (토큰 없이) 확인
- [ ] Multi-Cloud Failover 대시보드 \`goti_worker_requests_total\` 메트릭 수신 확인