### PR TITLE
[FIX] revert shared-gateway selector (PR #288 오진단)

### DIFF
--- a/infrastructure/prod/istio/gateway/templates/shared-gateway.yaml
+++ b/infrastructure/prod/istio/gateway/templates/shared-gateway.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   selector:
-    istio: ingress
+    istio: gateway
   servers:
     - port:
         number: 80


### PR DESCRIPTION
PR #288 은 istio-ingress ns 의 pod label 만 보고 selector 를 istio: ingress 로 변경했으나, 실제 ALB TargetGroupBinding 은 istio-system/istio-gateway (label istio: gateway) 를 가리킨다. 원래 설정으로 복원.