### PR TITLE
[FIX] load-observer 태그 dev-9 → dev-12 (Worker ingest endpoint)

### DIFF
--- a/environments/prod-gcp/goti-load-observer/values.yaml
+++ b/environments/prod-gcp/goti-load-observer/values.yaml
@@ -2,7 +2,7 @@ nameOverride: goti-load-observer
 replicaCount: 1
 image:
   repository: "asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/goti-load-observer"
-  tag: "gcp-3-cc57b0f"
+  tag: "dev-12-cc57b0f"
   pullPolicy: IfNotPresent
 imagePullSecrets: []
 service:

--- a/environments/prod/goti-load-observer/values.yaml
+++ b/environments/prod/goti-load-observer/values.yaml
@@ -1,27 +1,21 @@
 nameOverride: goti-load-observer
-
 replicaCount: 1
-
 image:
   repository: "707925622666.dkr.ecr.ap-northeast-2.amazonaws.com/goti-load-observer"
-  tag: "dev-9-ee6198a"  # fix: DB poll active 경기 필터 추가
+  tag: "dev-12-cc57b0f" # fix: DB poll active 경기 필터 추가
   pullPolicy: Always
-
 imagePullSecrets:
   - name: ecr-creds
-
 service:
   type: ClusterIP
   port: 9090
   name: metrics
-
 serviceMonitor:
   enabled: true
   port: metrics
   interval: 30s
   path: /metrics
   release: kube-prometheus-stack-prod
-
 probes:
   liveness:
     httpGet:
@@ -37,7 +31,6 @@ probes:
     initialDelaySeconds: 10
     periodSeconds: 10
     failureThreshold: 3
-
 resources:
   requests:
     cpu: 20m
@@ -45,7 +38,6 @@ resources:
   limits:
     cpu: 100m
     memory: 64Mi
-
 env:
   - name: DB_DSN
     valueFrom:
@@ -70,12 +62,10 @@ env:
       secretKeyRef:
         name: goti-load-observer-prod-secrets
         key: WORKER_INGEST_TOKEN
-
 podAnnotations:
   sidecar.istio.io/inject: "true"
   # ElastiCache Redis는 TLS+AUTH 사용 — Istio mTLS와 충돌하므로 sidecar 우회
   traffic.sidecar.istio.io/excludeOutboundPorts: "6379"
-
 gateway:
   # Cloudflare Worker → /__worker-metrics/ingest 수신용 VirtualService.
   # aws-api.go-ti.shop 로 들어온 trraffic 중 이 prefix 만 load-observer 로 라우팅.
@@ -93,12 +83,10 @@ gateway:
             host: goti-load-observer-prod
             port:
               number: 9090
-
 podSecurityContext:
   runAsNonRoot: true
   runAsUser: 65532
   fsGroup: 65532
-
 securityContext:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
@@ -106,10 +94,8 @@ securityContext:
     drop: ["ALL"]
   seccompProfile:
     type: RuntimeDefault
-
 configMap:
   enabled: false
-
 externalSecret:
   enabled: true
   refreshInterval: "1h"
@@ -118,7 +104,6 @@ externalSecret:
     kind: ClusterSecretStore
   remoteRef:
     path: /prod/load-observer
-
 istioPolicy:
   authorizationPolicy:
     enabled: true


### PR DESCRIPTION
dev-9-ee6198a 에는 /__worker-metrics/ingest 가 없어 Multi-Cloud Failover 대시보드 데이터 부재. dev-12-cc57b0f 로 교체.