### PR TITLE
[FIX] v2 VS hosts 에 aws-api.go-ti.shop 추가 (Worker 라우팅 404 해결)

### DIFF
--- a/environments/prod/goti-payment-v2/values.yaml
+++ b/environments/prod/goti-payment-v2/values.yaml
@@ -30,6 +30,7 @@ gateway:
   hosts:
     - "go-ti.shop"
     - "api.go-ti.shop"
+    - aws-api.go-ti.shop
   gatewayRef: "istio-system/goti-shared-gateway"
   httpRoutes:
     - match:

--- a/environments/prod/goti-queue-v2/values.yaml
+++ b/environments/prod/goti-queue-v2/values.yaml
@@ -33,6 +33,7 @@ gateway:
   hosts:
     - "go-ti.shop"
     - "api.go-ti.shop"
+    - aws-api.go-ti.shop
   gatewayRef: "istio-system/goti-shared-gateway"
   httpRoutes:
     - match:

--- a/environments/prod/goti-resale-v2/values.yaml
+++ b/environments/prod/goti-resale-v2/values.yaml
@@ -30,6 +30,7 @@ gateway:
   hosts:
     - "go-ti.shop"
     - "api.go-ti.shop"
+    - aws-api.go-ti.shop
   gatewayRef: "istio-system/goti-shared-gateway"
   httpRoutes:
     - match:

--- a/environments/prod/goti-stadium-v2/values.yaml
+++ b/environments/prod/goti-stadium-v2/values.yaml
@@ -32,6 +32,7 @@ gateway:
   hosts:
     - "go-ti.shop"
     - "api.go-ti.shop"
+    - aws-api.go-ti.shop
   gatewayRef: "istio-system/goti-shared-gateway"
   httpRoutes:
     - match:

--- a/environments/prod/goti-ticketing-v2/values.yaml
+++ b/environments/prod/goti-ticketing-v2/values.yaml
@@ -32,6 +32,7 @@ gateway:
   hosts:
     - "go-ti.shop"
     - "api.go-ti.shop"
+    - aws-api.go-ti.shop
   gatewayRef: "istio-system/goti-shared-gateway"
   httpRoutes:
     - match:

--- a/environments/prod/goti-user-v2/values.yaml
+++ b/environments/prod/goti-user-v2/values.yaml
@@ -30,6 +30,7 @@ gateway:
   hosts:
     - "go-ti.shop"
     - "api.go-ti.shop"
+    - aws-api.go-ti.shop
   gatewayRef: "istio-system/goti-shared-gateway"
   httpRoutes:
     - match:


### PR DESCRIPTION
Worker 가 AWS 배정 요청을 aws-api.go-ti.shop 으로 보내는데 VS 는 go-ti.shop/api.go-ti.shop 만 수락 → 모든 AWS 라우팅 요청이 404. 6개 v2 서비스 VS hosts 에 aws-api.go-ti.shop 추가.