### PR TITLE
[FIX] CORS preflight OPTIONS 를 require-jwt DENY 에서 예외

### DIFF
--- a/charts/goti-common/templates/_authorizationpolicy-jwt.tpl
+++ b/charts/goti-common/templates/_authorizationpolicy-jwt.tpl
@@ -44,6 +44,9 @@ spec:
             notRequestPrincipals: ["*"]
       to:
         - operation:
+            # CORS preflight 는 브라우저가 JWT 없이 보내므로 OPTIONS 는 DENY 제외.
+            # 실제 GET/POST 요청은 jwtAuthorizationPolicy 또는 애플리케이션 단에서 권한 검증.
+            notMethods: ["OPTIONS"]
             notPaths:
               {{- range $excludePaths }}
               - {{ . | quote }}


### PR DESCRIPTION
gcp-api.go-ti.shop 직통 시 브라우저 CORS error 원인.

- 브라우저 OPTIONS preflight → JWT 없음 → Istio DENY → CORS 차단
- 해결: notMethods: [OPTIONS] 추가