### PR TITLE
[FIX] CORS allowHeaders 에 X-GR-BS 추가

### DIFF
--- a/environments/prod-gcp/goti-payment/values.yaml
+++ b/environments/prod-gcp/goti-payment/values.yaml
@@ -117,6 +117,7 @@ gateway:
           - Authorization
           - Content-Type
           - X-Requested-With
+          - X-GR-BS
         allowCredentials: true
         maxAge: 24h
 autoscaling:

--- a/environments/prod-gcp/goti-queue-gate/values.yaml
+++ b/environments/prod-gcp/goti-queue-gate/values.yaml
@@ -83,6 +83,7 @@ gateway:
           - Authorization
           - Content-Type
           - X-Requested-With
+          - X-GR-BS
         allowCredentials: true
         maxAge: 24h
 podSecurityContext:

--- a/environments/prod-gcp/goti-queue/values.yaml
+++ b/environments/prod-gcp/goti-queue/values.yaml
@@ -65,6 +65,7 @@ gateway:
           - Authorization
           - Content-Type
           - X-Requested-With
+          - X-GR-BS
         allowCredentials: true
         maxAge: 24h
 autoscaling:

--- a/environments/prod-gcp/goti-resale/values.yaml
+++ b/environments/prod-gcp/goti-resale/values.yaml
@@ -117,6 +117,7 @@ gateway:
           - Authorization
           - Content-Type
           - X-Requested-With
+          - X-GR-BS
         allowCredentials: true
         maxAge: 24h
 autoscaling:

--- a/environments/prod-gcp/goti-stadium/values.yaml
+++ b/environments/prod-gcp/goti-stadium/values.yaml
@@ -114,6 +114,7 @@ gateway:
           - Authorization
           - Content-Type
           - X-Requested-With
+          - X-GR-BS
         allowCredentials: true
         maxAge: 24h
 externalSecret:

--- a/environments/prod-gcp/goti-ticketing/values.yaml
+++ b/environments/prod-gcp/goti-ticketing/values.yaml
@@ -152,6 +152,7 @@ gateway:
           - Authorization
           - Content-Type
           - X-Requested-With
+          - X-GR-BS
         allowCredentials: true
         maxAge: 24h
 autoscaling:

--- a/environments/prod-gcp/goti-user/values.yaml
+++ b/environments/prod-gcp/goti-user/values.yaml
@@ -203,6 +203,7 @@ gateway:
           - Authorization
           - Content-Type
           - X-Requested-With
+          - X-GR-BS
         allowCredentials: true
         maxAge: 24h
 autoscaling:


### PR DESCRIPTION
프론트 Guardrail Bot Score custom header 가 preflight 실패 원인. 7 개 서비스 VS allowHeaders 확장.