### PR TITLE
[FIX] GCP pod CPU limits 200m→1000m (CFS throttling 해소)

### DIFF
--- a/environments/prod-gcp/goti-payment/values.yaml
+++ b/environments/prod-gcp/goti-payment/values.yaml
@@ -31,11 +31,11 @@ probes:
     failureThreshold: 3
 resources:
   requests:
-    cpu: 50m
-    memory: 64Mi
-  limits:
-    cpu: 200m
+    cpu: 100m
     memory: 128Mi
+  limits:
+    cpu: 1000m
+    memory: 256Mi
 podAnnotations:
   sidecar.istio.io/inject: "true"
   # Memorystore Redis TLS+AUTH — Istio mTLS와 충돌하므로 sidecar 우회

--- a/environments/prod-gcp/goti-resale/values.yaml
+++ b/environments/prod-gcp/goti-resale/values.yaml
@@ -31,11 +31,11 @@ probes:
     failureThreshold: 3
 resources:
   requests:
-    cpu: 50m
-    memory: 64Mi
-  limits:
-    cpu: 200m
+    cpu: 100m
     memory: 128Mi
+  limits:
+    cpu: 1000m
+    memory: 256Mi
 podAnnotations:
   sidecar.istio.io/inject: "true"
   # Memorystore Redis TLS+AUTH — Istio mTLS와 충돌하므로 sidecar 우회

--- a/environments/prod-gcp/goti-stadium/values.yaml
+++ b/environments/prod-gcp/goti-stadium/values.yaml
@@ -31,11 +31,11 @@ probes:
     failureThreshold: 3
 resources:
   requests:
-    cpu: 50m
-    memory: 64Mi
-  limits:
-    cpu: 200m
+    cpu: 100m
     memory: 128Mi
+  limits:
+    cpu: 1000m
+    memory: 256Mi
 podAnnotations:
   sidecar.istio.io/inject: "true"
   # Memorystore Redis TLS+AUTH — Istio mTLS와 충돌하므로 sidecar 우회

--- a/environments/prod-gcp/goti-ticketing/values.yaml
+++ b/environments/prod-gcp/goti-ticketing/values.yaml
@@ -31,11 +31,11 @@ probes:
     failureThreshold: 3
 resources:
   requests:
-    cpu: 50m
-    memory: 64Mi
-  limits:
-    cpu: 200m
+    cpu: 100m
     memory: 128Mi
+  limits:
+    cpu: 1000m
+    memory: 256Mi
 podAnnotations:
   sidecar.istio.io/inject: "true"
   # Memorystore Redis TLS+AUTH — Istio mTLS와 충돌하므로 sidecar 우회

--- a/environments/prod-gcp/goti-user/values.yaml
+++ b/environments/prod-gcp/goti-user/values.yaml
@@ -31,11 +31,11 @@ probes:
     failureThreshold: 3
 resources:
   requests:
-    cpu: 50m
-    memory: 64Mi
-  limits:
-    cpu: 200m
+    cpu: 100m
     memory: 128Mi
+  limits:
+    cpu: 1000m
+    memory: 256Mi
 podAnnotations:
   sidecar.istio.io/inject: "true"
   # Memorystore Redis TLS+AUTH — Istio mTLS와 충돌하므로 sidecar 우회


### PR DESCRIPTION
5 개 서비스 리소스 상향. 병렬 요청 처리 개선 목적.