### PR TITLE
[CHORE] GCP prod Go 이미지 태그 업데이트: gcp-14-62295fd

### DIFF
--- a/environments/prod-gcp/goti-outbox-worker/values.yaml
+++ b/environments/prod-gcp/goti-outbox-worker/values.yaml
@@ -4,7 +4,7 @@ nameOverride: goti-outbox-worker
 replicaCount: 1
 image:
   repository: "asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/goti-outbox-worker-go"
-  tag: "gcp-13-bcf3720"
+  tag: "gcp-14-62295fd"
   pullPolicy: IfNotPresent
 service:
   type: ClusterIP

--- a/environments/prod-gcp/goti-payment/values.yaml
+++ b/environments/prod-gcp/goti-payment/values.yaml
@@ -2,7 +2,7 @@ nameOverride: goti-payment
 replicaCount: 2
 image:
   repository: "asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/goti-payment-go"
-  tag: "gcp-9-bc2e881"
+  tag: "gcp-14-62295fd"
   pullPolicy: IfNotPresent
 service: # GKE Workload Identity → Artifact Registry 자동 인증
   type: ClusterIP

--- a/environments/prod-gcp/goti-queue/values.yaml
+++ b/environments/prod-gcp/goti-queue/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 2
 nameOverride: goti-queue
 image:
   repository: "asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/goti-queue-go"
-  tag: "gcp-9-bc2e881" # linux/amd64 buildx 재빌드 (기존 bootstrap-20260413은 arm64로 잘못 푸시됨). CD 실행 시 gcp-N-SHA 로 auto-update
+  tag: "gcp-14-62295fd" # linux/amd64 buildx 재빌드 (기존 bootstrap-20260413은 arm64로 잘못 푸시됨). CD 실행 시 gcp-N-SHA 로 auto-update
   pullPolicy: IfNotPresent
 service: # GKE Workload Identity → Artifact Registry 자동 인증
   type: ClusterIP

--- a/environments/prod-gcp/goti-resale/values.yaml
+++ b/environments/prod-gcp/goti-resale/values.yaml
@@ -2,7 +2,7 @@ nameOverride: goti-resale
 replicaCount: 1
 image:
   repository: "asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/goti-resale-go"
-  tag: "gcp-9-bc2e881"
+  tag: "gcp-14-62295fd"
   pullPolicy: IfNotPresent
 service: # GKE Workload Identity → Artifact Registry 자동 인증
   type: ClusterIP

--- a/environments/prod-gcp/goti-stadium/values.yaml
+++ b/environments/prod-gcp/goti-stadium/values.yaml
@@ -2,7 +2,7 @@ nameOverride: goti-stadium
 replicaCount: 1
 image:
   repository: "asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/goti-stadium-go"
-  tag: "gcp-9-bc2e881"
+  tag: "gcp-14-62295fd"
   pullPolicy: IfNotPresent
 service: # GKE Workload Identity → Artifact Registry 자동 인증
   type: ClusterIP

--- a/environments/prod-gcp/goti-ticketing/values.yaml
+++ b/environments/prod-gcp/goti-ticketing/values.yaml
@@ -2,7 +2,7 @@ nameOverride: goti-ticketing
 replicaCount: 3
 image:
   repository: "asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/goti-ticketing-go"
-  tag: "gcp-12-bcf3720"
+  tag: "gcp-14-62295fd"
   pullPolicy: IfNotPresent
 service: # GKE Workload Identity → Artifact Registry 자동 인증
   type: ClusterIP

--- a/environments/prod-gcp/goti-user/values.yaml
+++ b/environments/prod-gcp/goti-user/values.yaml
@@ -2,7 +2,7 @@ nameOverride: goti-user
 replicaCount: 2
 image:
   repository: "asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/goti-user-go"
-  tag: "gcp-9-bc2e881"
+  tag: "gcp-14-62295fd"
   pullPolicy: IfNotPresent
 service: # GKE Workload Identity → Artifact Registry 자동 인증
   type: ClusterIP


### PR DESCRIPTION
## 변경 사항
- 이미지 태그: `gcp-14-62295fd`
- 레지스트리: `asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/`
- 업데이트된 서비스: `{"include":[{"service":"user"},{"service":"stadium"},{"service":"ticketing"},{"service":"payment"},{"service":"resale"},{"service":"queue"},{"service":"outbox-worker"}]}`
- 대상 환경: GCP prod (`environments/prod-gcp/goti-*/`)

## 트리거
- 레포: `ressKim-io/Goti-go`
- 브랜치: `deploy/gcp`
- 커밋: 62295fdbb39b115c32e0cfee648799214d25c4fb
- 워크플로우: [#14](https://github.com/ressKim-io/Goti-go/actions/runs/24621948084)