### PR TITLE
[CHORE] GCP prod Go 이미지 태그 업데이트: gcp-15-10a0976

### DIFF
--- a/environments/prod-gcp/goti-payment/values.yaml
+++ b/environments/prod-gcp/goti-payment/values.yaml
@@ -2,7 +2,7 @@ nameOverride: goti-payment
 replicaCount: 2
 image:
   repository: "asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/goti-payment-go"
-  tag: "gcp-14-62295fd"
+  tag: "gcp-15-10a0976"
   pullPolicy: IfNotPresent
 service: # GKE Workload Identity → Artifact Registry 자동 인증
   type: ClusterIP

--- a/environments/prod-gcp/goti-resale/values.yaml
+++ b/environments/prod-gcp/goti-resale/values.yaml
@@ -2,7 +2,7 @@ nameOverride: goti-resale
 replicaCount: 1
 image:
   repository: "asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/goti-resale-go"
-  tag: "gcp-14-62295fd"
+  tag: "gcp-15-10a0976"
   pullPolicy: IfNotPresent
 service: # GKE Workload Identity → Artifact Registry 자동 인증
   type: ClusterIP


### PR DESCRIPTION
## 변경 사항
- 이미지 태그: `gcp-15-10a0976`
- 레지스트리: `asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/`
- 업데이트된 서비스: `{"include":[{"service":"payment"},{"service":"resale"}]}`
- 대상 환경: GCP prod (`environments/prod-gcp/goti-*/`)

## 트리거
- 레포: `ressKim-io/Goti-go`
- 브랜치: `deploy/gcp`
- 커밋: 10a0976febd0eee07d7da1239e5d47976b9af447
- 워크플로우: [#15](https://github.com/ressKim-io/Goti-go/actions/runs/24623966549)