### PR TITLE
[CHORE] GCP prod Go 이미지 태그 업데이트: gcp-17-b1bc854

### DIFF
--- a/environments/prod-gcp/goti-outbox-worker/values.yaml
+++ b/environments/prod-gcp/goti-outbox-worker/values.yaml
@@ -4,7 +4,7 @@ nameOverride: goti-outbox-worker
 replicaCount: 1
 image:
   repository: "asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/goti-outbox-worker-go"
-  tag: "gcp-14-62295fd"
+  tag: "gcp-17-b1bc854"
   pullPolicy: IfNotPresent
 service:
   type: ClusterIP


### PR DESCRIPTION
## 변경 사항
- 이미지 태그: `gcp-17-b1bc854`
- 레지스트리: `asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/`
- 업데이트된 서비스: `{"include":[{"service":"outbox-worker"}]}`
- 대상 환경: GCP prod (`environments/prod-gcp/goti-*/`)

## 트리거
- 레포: `ressKim-io/Goti-go`
- 브랜치: `deploy/gcp`
- 커밋: b1bc8548e7592051a2e0765bee683f8712b02636
- 워크플로우: [#17](https://github.com/ressKim-io/Goti-go/actions/runs/24625828795)