### PR TITLE
[CHORE] GCP prod Go 이미지 태그 업데이트: gcp-19-9a57d5e

### DIFF
--- a/environments/prod-gcp/goti-resale/values.yaml
+++ b/environments/prod-gcp/goti-resale/values.yaml
@@ -2,7 +2,7 @@ nameOverride: goti-resale
 replicaCount: 1
 image:
   repository: "asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/goti-resale-go"
-  tag: "gcp-18-7a08fe8"
+  tag: "gcp-19-9a57d5e"
   pullPolicy: IfNotPresent
 service: # GKE Workload Identity → Artifact Registry 자동 인증
   type: ClusterIP


### PR DESCRIPTION
## 변경 사항
- 이미지 태그: `gcp-19-9a57d5e`
- 레지스트리: `asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/`
- 업데이트된 서비스: `{"include":[{"service":"resale"}]}`
- 대상 환경: GCP prod (`environments/prod-gcp/goti-*/`)

## 트리거
- 레포: `ressKim-io/Goti-go`
- 브랜치: `deploy/gcp`
- 커밋: 9a57d5e016c4b45bd40a895a0ecba4a831e87cb8
- 워크플로우: [#19](https://github.com/ressKim-io/Goti-go/actions/runs/24626524125)