### PR TITLE
[FEAT] goti-security-dashboard GCP prod 배포 추가

### DIFF
--- a/environments/prod-gcp/goti-security-dashboard/values.yaml
+++ b/environments/prod-gcp/goti-security-dashboard/values.yaml
@@ -63,10 +63,8 @@ env:
     value: "/data"
   - name: PORT
     value: "8100"
-
-envFrom:
-  - secretRef:
-      name: goti-security-dashboard-prod-gcp-secrets
+# UPSTAGE_API_KEY는 유료 API라 주입 제외.
+# /api/v1/analysis/* 엔드포인트는 호출 시 500 반환 (다른 경로는 정상 작동).
 
 # Streamlit Cloud → gcp-api.go-ti.shop 경유 read 엔드포인트 호출
 # /api/v1/events/* 는 POST 호출자(guardrail/mouse-macro)가 GCP에 없어 현재 미노출.
@@ -117,17 +115,9 @@ gateway:
         allowCredentials: true
         maxAge: 24h
 
+# ExternalSecret 비활성화: UPSTAGE_API_KEY 유료 API 제외로 주입할 secret 없음.
 externalSecret:
-  enabled: true
-  refreshInterval: "1h"
-  secretStoreRef:
-    name: gcp-store
-    kind: ClusterSecretStore
-  remoteRef:
-    nameRegexp: "^goti-prod-server-"
-    nameRewriteSource: "^goti-prod-server-(.*)$"
-    overrideNameRegexp: "^goti-prod-security-dashboard-"
-    overrideNameRewriteSource: "^goti-prod-security-dashboard-(.*)$"
+  enabled: false
 
 # --- Istio 보안/네트워크 정책 ---
 # guardrail / mouse-macro 는 현재 GCP에 이관되지 않음 → POST 허용 블록 제거.

--- a/environments/prod-gcp/goti-security-dashboard/values.yaml
+++ b/environments/prod-gcp/goti-security-dashboard/values.yaml
@@ -1,0 +1,177 @@
+nameOverride: goti-security-dashboard
+
+# SQLite + RWO PVC는 동시 마운트 불가 → Recreate 전략 필수
+deploymentStrategy:
+  type: Recreate
+
+image:
+  repository: "asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/goti-security-dashboard-go"
+  tag: "gcp-0-init"
+  pullPolicy: IfNotPresent
+
+# GKE Workload Identity → Artifact Registry 자동 인증
+imagePullSecrets: []
+
+service:
+  type: ClusterIP
+  port: 8100
+  name: http
+
+podAnnotations:
+  sidecar.istio.io/inject: "true"
+
+probes:
+  liveness:
+    httpGet:
+      path: /health
+      port: http
+    initialDelaySeconds: 20
+    periodSeconds: 15
+    failureThreshold: 3
+  readiness:
+    httpGet:
+      path: /health
+      port: http
+    initialDelaySeconds: 15
+    periodSeconds: 10
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 256Mi
+
+# SQLite 영속 저장소 (GCP pd-balanced)
+persistence:
+  enabled: true
+  storageClassName: "gcp-pd-balanced"
+  size: "5Gi"
+
+extraVolumeMounts:
+  - name: data
+    mountPath: /data
+
+extraVolumes:
+  - name: data
+    persistentVolumeClaim:
+      claimName: goti-security-dashboard-prod-gcp-data
+
+env:
+  - name: DATABASE_DIR
+    value: "/data"
+  - name: PORT
+    value: "8100"
+
+envFrom:
+  - secretRef:
+      name: goti-security-dashboard-prod-gcp-secrets
+
+# Streamlit Cloud → gcp-api.go-ti.shop 경유 read 엔드포인트 호출
+# /api/v1/events/* 는 POST 호출자(guardrail/mouse-macro)가 GCP에 없어 현재 미노출.
+gateway:
+  enabled: true
+  hosts:
+    - "gcp-api.go-ti.shop"
+  gatewayRef: "istio-ingress/goti-shared-gateway"
+  httpRoutes:
+    - match:
+        - uri:
+            prefix: "/api/v1/dashboard"
+        - uri:
+            prefix: "/api/v1/detections"
+        - uri:
+            prefix: "/api/v1/stats"
+        - uri:
+            prefix: "/api/v1/mouse-macro"
+        - uri:
+            prefix: "/api/v1/interventions"
+        - uri:
+            prefix: "/api/v1/analysis"
+        - uri:
+            prefix: "/api/v1/analytics"
+        - uri:
+            prefix: "/api/v1/alerts"
+      route:
+        - destination:
+            host: goti-security-dashboard-prod-gcp
+            port:
+              number: 8100
+      corsPolicy:
+        allowOrigins:
+          - regex: "https://.*\\.streamlit\\.app"
+          - exact: https://go-ti.shop
+          - exact: https://www.go-ti.shop
+        allowMethods:
+          - GET
+          - POST
+          - PUT
+          - DELETE
+          - PATCH
+          - OPTIONS
+        allowHeaders:
+          - Authorization
+          - Content-Type
+          - X-Requested-With
+        allowCredentials: true
+        maxAge: 24h
+
+externalSecret:
+  enabled: true
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: gcp-store
+    kind: ClusterSecretStore
+  remoteRef:
+    nameRegexp: "^goti-prod-server-"
+    nameRewriteSource: "^goti-prod-server-(.*)$"
+    overrideNameRegexp: "^goti-prod-security-dashboard-"
+    overrideNameRewriteSource: "^goti-prod-security-dashboard-(.*)$"
+
+# --- Istio 보안/네트워크 정책 ---
+# guardrail / mouse-macro 는 현재 GCP에 이관되지 않음 → POST 허용 블록 제거.
+# ingress-gateway(브라우저) GET/OPTIONS만 허용.
+istioPolicy:
+  authorizationPolicy:
+    enabled: true
+    allowFrom:
+      - name: from-ingress-gateway
+        rules:
+          - from:
+              - source:
+                  namespaces: ["istio-ingress"]
+            to:
+              - operation:
+                  paths:
+                    - "/api/v1/dashboard/overview"
+                    - "/api/v1/detections"
+                    - "/api/v1/stats/summary"
+                    - "/api/v1/mouse-macro/sessions"
+                    - "/api/v1/mouse-macro/sessions/*"
+                    - "/api/v1/analytics/detection-types"
+                    - "/api/v1/analytics/hourly-trend"
+                    - "/api/v1/analytics/risk-distribution"
+                    - "/api/v1/alerts"
+                    - "/api/v1/interventions/*/action"
+                    - "/api/v1/analysis/guardrail/*"
+                    - "/api/v1/analysis/mouse-macro/*"
+                    - "/api/v1/analysis/ip/*"
+                    - "/api/v1/analysis/ip-summary"
+                    - "/health"
+                  methods: ["GET", "POST", "OPTIONS"]
+  requestAuthentication:
+    enabled: false
+  jwtAuthorizationPolicy:
+    enabled: false
+  destinationRule:
+    enabled: false
+  sidecar:
+    enabled: true
+    egress:
+      - hosts:
+          - "istio-system/*"
+          - "istio-ingress/*"
+          - "./*"
+          - "monitoring/*"
+          - "~/*.upstage.ai"

--- a/gitops/prod-gcp/applicationsets/goti-msa-appset.yaml
+++ b/gitops/prod-gcp/applicationsets/goti-msa-appset.yaml
@@ -30,6 +30,10 @@ spec:
           - service: outbox-worker
             namespace: goti
             valuesFile: environments/prod-gcp/goti-outbox-worker/values.yaml
+          # AI 매크로 탐지 대시보드 API (Streamlit Cloud → gcp-api.go-ti.shop 경유)
+          - service: security-dashboard
+            namespace: goti
+            valuesFile: environments/prod-gcp/goti-security-dashboard/values.yaml
   template:
     metadata:
       name: "goti-{{service}}-prod-gcp"


### PR DESCRIPTION
## 관련 이슈
- N/A (영상 촬영 긴급 대응)

## 개요
AWS 전량 destroy 상태에서 영상 추가 촬영을 위해 security dashboard API를 GCP prod-gcp 환경으로 이관. AWS 경로(`environments/prod/goti-security-dashboard/`)는 건드리지 않고 GCP 경로를 신설.

## 작업 내용
- [x] \`environments/prod-gcp/goti-security-dashboard/values.yaml\` 신규
  - GAR image: \`asia-northeast3-docker.pkg.dev/project-7b8317dd-9b4d-4f5f-ba2/goti-prod-registry/goti-security-dashboard-go\`
  - PVC: \`gcp-pd-balanced\` 5Gi, Recreate 전략 (SQLite RWO 제약)
  - Gateway: \`istio-ingress/goti-shared-gateway\`, host \`gcp-api.go-ti.shop\`
  - CORS: Streamlit Cloud (\`*.streamlit.app\`) + go-ti.shop allowOrigins
  - ExternalSecret: \`gcp-store\` + override regex (\`^goti-prod-security-dashboard-\`) → \`UPSTAGE_API_KEY\`
  - AuthorizationPolicy: ingress-gateway GET/POST/OPTIONS만 허용 (guardrail/mouse-macro는 GCP 미이관으로 POST 호출자 블록 제거)
- [x] \`gitops/prod-gcp/applicationsets/goti-msa-appset.yaml\`: \`security-dashboard\` 엔트리 추가

## 의존 PR
- Goti-Terraform #13 (UPSTAGE_API_KEY Secret Manager 추가) — 이 PR 이전에 apply 필요
- Go-ti-security-dashboard (CI 워크플로우) — 머지 후 CI가 이 레포로 image tag 업데이트 PR을 생성함

## 테스트
- [x] helm chart 기존 서비스(goti-stadium) 패턴 따름 (persistence/gateway/istioPolicy 템플릿 재사용)
- [ ] ArgoCD sync 후 pod Healthy (UPSTAGE_API_KEY Secret 주입 확인 필요)
- [ ] \`curl https://gcp-api.go-ti.shop/api/v1/dashboard/overview\` 200 응답

## 초기 상태
이미지 태그는 placeholder (\`gcp-0-init\`)로 세팅 — Go-ti-security-dashboard CI 첫 실행 시 자동으로 실제 태그로 PR 업데이트됨. 그 전까지는 pod ImagePullBackOff 예상.